### PR TITLE
Link security documentation directly to repository.

### DIFF
--- a/docs/setup/security.md
+++ b/docs/setup/security.md
@@ -1,5 +1,0 @@
----
-description: Which security policies are in place for Bifröst and how to deal with potential security issues?
----
-
---8<-- "SECURITY.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,7 +130,7 @@ nav:
           - On Host: setup/on-host.md
           - In Docker: setup/in-docker.md
       - setup/distribution.md
-      - Security: setup/security.md
+      - Security: https://github.com/engity-com/bifroest/blob/main/SECURITY.md
       - License: legal/license.md
   - Reference:
       - reference/index.md


### PR DESCRIPTION
## Motivation
Because the security information can change between the versions, we should link to the repository instead have a dedicated document per release.
