### PR TITLE
Kubernetes: Ensure environment variables also inherited by the actual connection sessions

### DIFF
--- a/internal/imp/protocol/imp.go
+++ b/internal/imp/protocol/imp.go
@@ -129,6 +129,8 @@ func (this *imp) serveConn(ctx context.Context, plainConn gonet.Conn) (rErr erro
 		return done(this.handleMethodNamedPipe(ctx, &header, l, conn))
 	case MethodGetConnectionExitCode:
 		return done(this.handleMethodGetConnectionExitCode(ctx, &header, l, conn))
+	case MethodGetEnvironment:
+		return done(this.handleMethodGetEnvironment(ctx, &header, l, conn))
 	default:
 		return fail(errors.Network.Newf("unsupported method %v", header.Method))
 	}

--- a/internal/imp/protocol/master-session.go
+++ b/internal/imp/protocol/master-session.go
@@ -65,6 +65,10 @@ func (this *MasterSession) GetConnectionExitCode(ctx context.Context, connection
 	return result, nil
 }
 
+func (this *MasterSession) GetEnvironment(ctx context.Context, connectionId connection.Id) (sys.EnvVars, error) {
+	return this.parent.methodGetEnvironment(ctx, this.ref, connectionId)
+}
+
 func (this *MasterSession) Kill(ctx context.Context, connectionId connection.Id, pid int, signal sys.Signal) error {
 	return this.parent.methodKill(ctx, this.ref, connectionId, pid, signal)
 }

--- a/internal/imp/protocol/method-get-environment.go
+++ b/internal/imp/protocol/method-get-environment.go
@@ -1,0 +1,108 @@
+package protocol
+
+import (
+	"context"
+	"os"
+
+	log "github.com/echocat/slf4g"
+	"github.com/vmihailenco/msgpack/v5"
+
+	"github.com/engity-com/bifroest/pkg/codec"
+	"github.com/engity-com/bifroest/pkg/connection"
+	"github.com/engity-com/bifroest/pkg/errors"
+	"github.com/engity-com/bifroest/pkg/sys"
+)
+
+type methodGetEnvironmentRequest struct{}
+
+func (this methodGetEnvironmentRequest) EncodeMsgpack(enc *msgpack.Encoder) error {
+	return this.EncodeMsgPack(enc)
+}
+
+func (this *methodGetEnvironmentRequest) DecodeMsgpack(dec *msgpack.Decoder) (err error) {
+	return this.DecodeMsgPack(dec)
+}
+
+func (this methodGetEnvironmentRequest) EncodeMsgPack(codec.MsgPackEncoder) error {
+	return nil
+}
+
+func (this *methodGetEnvironmentRequest) DecodeMsgPack(codec.MsgPackDecoder) (err error) {
+	return nil
+}
+
+type methodGetEnvironmentResponse struct {
+	variables sys.EnvVars
+	error     error
+}
+
+func (this methodGetEnvironmentResponse) EncodeMsgpack(enc *msgpack.Encoder) error {
+	return this.EncodeMsgPack(enc)
+}
+
+func (this *methodGetEnvironmentResponse) DecodeMsgpack(dec *msgpack.Decoder) (err error) {
+	return this.DecodeMsgPack(dec)
+}
+
+func (this methodGetEnvironmentResponse) EncodeMsgPack(enc codec.MsgPackEncoder) error {
+	if err := enc.EncodeInt(int64(len(this.variables))); err != nil {
+		return err
+	}
+	for k, v := range this.variables {
+		if err := enc.EncodeString(k); err != nil {
+			return err
+		}
+		if err := enc.EncodeString(v); err != nil {
+			return err
+		}
+	}
+
+	if err := errors.EncodeMsgPack(this.error, enc); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (this *methodGetEnvironmentResponse) DecodeMsgPack(dec codec.MsgPackDecoder) (err error) {
+	numberOfVariables, err := dec.DecodeInt()
+	if err != nil {
+		return err
+	}
+	this.variables = make(map[string]string, numberOfVariables)
+	for i := 0; i < numberOfVariables; i++ {
+		k, err := dec.DecodeString()
+		if err != nil {
+			return err
+		}
+		v, err := dec.DecodeString()
+		if err != nil {
+			return err
+		}
+		this.variables[k] = v
+	}
+
+	if this.error, err = errors.DecodeMsgPack(dec); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (this *imp) handleMethodGetEnvironment(ctx context.Context, header *Header, _ log.Logger, conn codec.MsgPackConn) error {
+	return handleFromServerSide(ctx, header, conn, func(req *methodGetEnvironmentRequest) methodGetEnvironmentResponse {
+		var result methodGetEnvironmentResponse
+		result.variables.Add(os.Environ()...)
+		return result
+	})
+}
+
+func (this *Master) methodGetEnvironment(ctx context.Context, ref Ref, connectionId connection.Id) (result sys.EnvVars, _ error) {
+	if err := this.do(ctx, ref, connectionId, MethodGetEnvironment, func(header *Header, conn codec.MsgPackConn) error {
+		return handleFromClientSide(ctx, header, conn, methodGetEnvironmentRequest{}, func(v *methodGetEnvironmentResponse) error {
+			result = v.variables
+			return v.error
+		})
+	}); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/internal/imp/protocol/method.go
+++ b/internal/imp/protocol/method.go
@@ -18,6 +18,7 @@ const (
 	MethodTcpForward
 	MethodNamedPipe
 	MethodGetConnectionExitCode
+	MethodGetEnvironment
 )
 
 var (
@@ -80,6 +81,7 @@ var (
 		"tcpForward":            MethodTcpForward,
 		"namedPipe":             MethodNamedPipe,
 		"getConnectionExitCode": MethodGetConnectionExitCode,
+		"getEnvironment":        MethodGetEnvironment,
 	}
 	protocolMethodToString = func(in map[string]Method) map[Method]string {
 		result := make(map[Method]string, len(in))

--- a/pkg/environment/kubernetes-usage-specific.go
+++ b/pkg/environment/kubernetes-usage-specific.go
@@ -75,6 +75,7 @@ func (this *kubernetes) Run(t Task) (exitCode int, rErr error) {
 	}
 
 	ev := sys.EnvVars{}
+	ev.AddAllOf(this.environ)
 	if v, ok := os.LookupEnv("TZ"); ok {
 		ev.Set("TZ", v)
 	}

--- a/pkg/environment/kubernetes.go
+++ b/pkg/environment/kubernetes.go
@@ -45,6 +45,7 @@ type kubernetes struct {
 	portForwardingAllowed bool
 
 	impSession imp.Session
+	environ    sys.EnvVars
 
 	owners atomic.Int32
 }
@@ -83,7 +84,8 @@ func (this *KubernetesRepository) new(ctx context.Context, pod *v1.Pod, logger l
 	}
 
 	for try := 1; try <= 200; try++ {
-		if err := result.impSession.Ping(ctx, connId); err == nil {
+		if environ, err := result.impSession.GetEnvironment(ctx, connId); err == nil {
+			result.environ = environ
 			break
 		} else if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, bkube.ErrEndpointNotFound) {
 			// try waiting...

--- a/pkg/imp/roundtrip_test.go
+++ b/pkg/imp/roundtrip_test.go
@@ -296,6 +296,22 @@ func runRoundtripMaster(t *testing.T, impPreparation func(crypto.PublicKey, sess
 
 		time.Sleep(time.Millisecond * 100)
 	})
+
+	t.Run("get-environment", func(t *testing.T) {
+		testlog.Hook(t)
+		connId, err := connection.NewId()
+		require.NoError(t, err)
+
+		env, err := sess.GetEnvironment(ctx, connId)
+		require.NoError(t, err)
+
+		var expected sys.EnvVars
+		expected.Add(os.Environ()...)
+		require.Equal(t, expected, env)
+	})
+
+	time.Sleep(time.Millisecond * 100)
+
 }
 
 func runRoundtripImpProcess(t *testing.T) {

--- a/pkg/imp/session.go
+++ b/pkg/imp/session.go
@@ -20,6 +20,8 @@ type Session interface {
 	// or [connection.ErrNotFound] if the corresponding connection can't be found.
 	GetConnectionExitCode(ctx context.Context, connectionId connection.Id) (int, error)
 
+	GetEnvironment(ctx context.Context, connectionId connection.Id) (sys.EnvVars, error)
+
 	// Kill will try to kill the process with the given signal.
 	// If pid is 0, the process will be resolved by its connection.EnvVar that is matching the provided
 	// connectionId.


### PR DESCRIPTION
## Motivation
Inside of an actual connection on a Kubernetes cluster, we should be able to have the same environment variables, also the root process has. For example `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` are not present, currently.

## Changes
Migrate the environment variables of the IMP process over to the actual connections.
