### PR TITLE
Stabilize TCP tunnels through  Kubernetes

### DIFF
--- a/pkg/kubernetes/client-port-dial.go
+++ b/pkg/kubernetes/client-port-dial.go
@@ -199,18 +199,20 @@ func (this *httpstreamConn) RemoteAddr() gonet.Addr {
 }
 
 func (this *httpstreamConn) SetDeadline(t time.Time) error {
-	this.delegate.SetIdleTimeout(time.Until(t))
+	if !t.IsZero() {
+		this.delegate.SetIdleTimeout(time.Until(t))
+	} else {
+		this.delegate.SetIdleTimeout(0)
+	}
 	return nil
 }
 
 func (this *httpstreamConn) SetReadDeadline(t time.Time) error {
-	this.delegate.SetIdleTimeout(time.Until(t))
-	return nil
+	return this.SetDeadline(t)
 }
 
 func (this *httpstreamConn) SetWriteDeadline(t time.Time) error {
-	this.delegate.SetIdleTimeout(time.Until(t))
-	return nil
+	return this.SetDeadline(t)
 }
 
 type httpstreamAddr string


### PR DESCRIPTION
## Motivation
In some cases the connections via the TCP Tunnels of Kubernetes are get closed unexpectedly. The reason is, that `httpstreamConn.SetDeadline(time.Time)` will be set to an empty `time.Time` object. As this is translated via `time.Until(time.Time)` to a `time.Duration` in these cases the result will be a negative instance of `time.Duration` which means the connection will be closed instantly.

## Changes
In case `time.Time` interpret `time.Duration` also as `0` which means: No timeout.
