### PR TITLE
Improve Kubernetes POD Handshake

### DIFF
--- a/pkg/common/context.go
+++ b/pkg/common/context.go
@@ -1,0 +1,21 @@
+package common
+
+import (
+	"context"
+	"time"
+)
+
+func Sleep(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func SleepSilently(ctx context.Context, duration time.Duration) {
+	_ = Sleep(ctx, duration)
+}

--- a/pkg/environment/docker.go
+++ b/pkg/environment/docker.go
@@ -80,6 +80,10 @@ func (this *DockerRepository) new(ctx context.Context, container *types.Containe
 	}
 
 	for try := 1; try <= 200; try++ {
+		if err := ctx.Err(); err != nil {
+			return fail(err)
+		}
+
 		if err := result.impSession.Ping(ctx, connId); err == nil {
 			break
 		} else if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
@@ -93,7 +97,10 @@ func (this *DockerRepository) new(ctx context.Context, container *types.Containe
 		} else {
 			l.Info("still waiting for container's imp getting ready...")
 		}
-		time.Sleep(500 * time.Millisecond)
+
+		if err := common.Sleep(ctx, 500*time.Millisecond); err != nil {
+			return fail(err)
+		}
 	}
 
 	result.owners.Add(1)

--- a/pkg/environment/kubernetes.go
+++ b/pkg/environment/kubernetes.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	log "github.com/echocat/slf4g"
+	"github.com/moby/spdystream"
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/engity-com/bifroest/pkg/common"
@@ -66,31 +67,40 @@ func (this *KubernetesRepository) new(ctx context.Context, pod *v1.Pod, logger l
 	fail := func(err error) (*kubernetes, error) {
 		return nil, errors.System.Newf("cannot create environment from pod %v/%v of flow %v: %w", pod.Namespace, pod.Name, this.flow, err)
 	}
+	failf := func(msg string, args ...any) (*kubernetes, error) {
+		return fail(errors.System.Newf(msg, args...))
+	}
 
 	result := &kubernetes{
 		repository: this,
 	}
 	if err := result.parsePod(pod); err != nil {
-		return fail(err)
+		return failf("cannot parse pod: %w", err)
 	}
 	var err error
 	if result.impSession, err = this.imp.Open(ctx, result); err != nil {
-		return fail(err)
+		return failf("cannot open IMP session: %w", err)
 	}
 
 	connId, err := connection.NewId()
 	if err != nil {
-		return fail(err)
+		return failf("cannot create new connection ID: %w", err)
 	}
 
 	for try := 1; try <= 200; try++ {
 		if environ, err := result.impSession.GetEnvironment(ctx, connId); err == nil {
 			result.environ = environ
 			break
-		} else if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, bkube.ErrEndpointNotFound) {
+		} else if errors.Is(err, io.EOF) ||
+			errors.Is(err, io.ErrUnexpectedEOF) ||
+			errors.Is(err, bkube.ErrEndpointNotFound) ||
+			errors.Is(err, spdystream.ErrWriteClosedStream) ||
+			errors.Is(err, spdystream.ErrReset) ||
+			errors.Is(err, spdystream.ErrTimeout) ||
+			errors.Is(err, spdystream.ErrInvalidStreamId) {
 			// try waiting...
 		} else {
-			return fail(err)
+			return failf("cannot get environment of created pod: %w", err)
 		}
 		l := logger.With("try", try)
 		if try <= 2 {

--- a/pkg/environment/kubernetes.go
+++ b/pkg/environment/kubernetes.go
@@ -88,6 +88,10 @@ func (this *KubernetesRepository) new(ctx context.Context, pod *v1.Pod, logger l
 	}
 
 	for try := 1; try <= 200; try++ {
+		if err := ctx.Err(); err != nil {
+			return fail(err)
+		}
+
 		if environ, err := result.impSession.GetEnvironment(ctx, connId); err == nil {
 			result.environ = environ
 			break
@@ -108,7 +112,10 @@ func (this *KubernetesRepository) new(ctx context.Context, pod *v1.Pod, logger l
 		} else if try%30 == 0 {
 			l.Info("still waiting for container's imp getting ready...")
 		}
-		time.Sleep(50 * time.Millisecond)
+
+		if err := common.Sleep(ctx, 50*time.Millisecond); err != nil {
+			return fail(err)
+		}
 	}
 
 	result.owners.Add(1)

--- a/pkg/imp/roundtrip_test.go
+++ b/pkg/imp/roundtrip_test.go
@@ -136,14 +136,14 @@ func runRoundtripMaster(t *testing.T, impPreparation func(crypto.PublicKey, sess
 		dummyCmd := prepareRoundtripDummyCmd(t, dummyCmdConnectionId)
 		wg.Add(1)
 		go runCmd(ctx, t, dummyCmd, wg.Done, &dummyCmdPid)
-		time.Sleep(100 * time.Millisecond)
+		common.SleepSilently(ctx, 100*time.Millisecond)
 	}
 
 	defer wg.Wait()
 	defer cancelFn()
 
 	for i := 0; i < 10000; i++ {
-		time.Sleep(1 * time.Millisecond)
+		common.SleepSilently(ctx, 1*time.Millisecond)
 		conn, err := gonet.DialTimeout("tcp", roundtripTestImpAddress.String(), time.Millisecond*10)
 		if err != nil {
 			continue
@@ -172,7 +172,7 @@ func runRoundtripMaster(t *testing.T, impPreparation func(crypto.PublicKey, sess
 		err = sess.Ping(ctx, connId)
 		require.NoError(t, err)
 
-		time.Sleep(time.Millisecond * 100)
+		common.SleepSilently(ctx, time.Millisecond*100)
 	})
 
 	if *roundtripTestWithKill {
@@ -194,7 +194,7 @@ func runRoundtripMaster(t *testing.T, impPreparation func(crypto.PublicKey, sess
 			}, 1*time.Minute, 100*time.Millisecond)
 		})
 
-		time.Sleep(time.Millisecond * 100)
+		common.SleepSilently(ctx, time.Millisecond*100)
 	}
 
 	t.Run("tcp-forward", func(t *testing.T) {
@@ -226,7 +226,7 @@ func runRoundtripMaster(t *testing.T, impPreparation func(crypto.PublicKey, sess
 		require.NoError(t, err)
 		assert.Equal(t, "OK!", string(b))
 
-		time.Sleep(time.Millisecond * 100)
+		common.SleepSilently(ctx, time.Millisecond*100)
 	})
 
 	t.Run("named-pipe", func(t *testing.T) {
@@ -258,10 +258,10 @@ func runRoundtripMaster(t *testing.T, impPreparation func(crypto.PublicKey, sess
 
 			assert.Equal(t, "foobar", string(buf))
 
-			time.Sleep(time.Millisecond * 100)
+			common.SleepSilently(ctx, time.Millisecond*100)
 		}()
 
-		time.Sleep(time.Millisecond * 200)
+		common.SleepSilently(ctx, time.Millisecond*200)
 
 		assert.NotEmpty(t, local.Path())
 		remote, err := net.ConnectToNamedPipe(ctx, local.Path())
@@ -271,13 +271,13 @@ func runRoundtripMaster(t *testing.T, impPreparation func(crypto.PublicKey, sess
 		_, err = remote.Write([]byte("foobar"))
 		require.NoError(t, err)
 
-		time.Sleep(time.Millisecond * 200)
+		common.SleepSilently(ctx, time.Millisecond*200)
 
 		require.NoError(t, remote.Close())
 		require.NoError(t, local.Close())
 		iwg.Wait()
 
-		time.Sleep(time.Millisecond * 100)
+		common.SleepSilently(ctx, time.Millisecond*100)
 	})
 
 	t.Run("named-pipe-noop", func(t *testing.T) {
@@ -290,11 +290,11 @@ func runRoundtripMaster(t *testing.T, impPreparation func(crypto.PublicKey, sess
 		require.NotNil(t, local)
 		defer common.IgnoreCloseError(local)
 
-		time.Sleep(time.Millisecond * 100)
+		common.SleepSilently(ctx, time.Millisecond*100)
 
 		require.NoError(t, local.Close())
 
-		time.Sleep(time.Millisecond * 100)
+		common.SleepSilently(ctx, time.Millisecond*100)
 	})
 
 	t.Run("get-environment", func(t *testing.T) {
@@ -310,7 +310,7 @@ func runRoundtripMaster(t *testing.T, impPreparation func(crypto.PublicKey, sess
 		require.Equal(t, expected, env)
 	})
 
-	time.Sleep(time.Millisecond * 100)
+	common.SleepSilently(ctx, time.Millisecond*100)
 
 }
 


### PR DESCRIPTION
## Motivation
In some cases the initial handshake with the IMP process inside the POD fails because of timing issues.

## Changes
We will ignore more of these issues for now and keep continue retry for a moment. This will stabilize the initial handshake procedure.

Additionally we replace all direct `time.Sleep` call now with a custom sleep (`common.Sleep`) which also takes `context.Context` into consideration to respect faster to cancellations.
