### PR TITLE
Fix idle detection

### DIFF
--- a/pkg/environment/docker-repository.go
+++ b/pkg/environment/docker-repository.go
@@ -219,6 +219,9 @@ func (this *DockerRepository) createContainerBy(req Request, sess session.Sessio
 	if err != nil {
 		return fail(err)
 	}
+	if c == nil {
+		return failf(errors.System, "container %v died instant after initial start", containerId)
+	}
 
 	success = true
 	return c, nil


### PR DESCRIPTION
## Motivation
Currently the idle detection does not work properly. Regardless which action is taken via an existing connection, if `ssh.idleTimeout` is configured it works currently like `ssh.maxTimeout`.

## Changes
We've fixed this. Now `lastAction` at the connections are recorded properly. Additionally, we also log deadline exceeding, too.
