### PR TITLE
Ensure, we always also send SIGTERM on end of a session to the underlying process.

### DIFF
--- a/internal/imp/protocol/method-kill.go
+++ b/internal/imp/protocol/method-kill.go
@@ -105,6 +105,9 @@ func (this *imp) handleMethodKill(ctx context.Context, header *Header, _ log.Log
 				}
 			}
 		}
+		if pid == 0 {
+			return methodKillResponse{ErrNoSuchProcess}
+		}
 
 		if err := this.kill(ctx, pid, req.signal); err != nil {
 			return fail(err)

--- a/pkg/service/service-session.go
+++ b/pkg/service/service-session.go
@@ -37,7 +37,7 @@ func (this *service) uncheckedExecuteSshSession(sshSess glssh.Session, taskType 
 
 	l.With("type", taskType).
 		With("env", sshSess.Environ()).
-		With("command", sshSess.Command()).
+		With("command", sshSess.RawCommand()).
 		Info("new remote session")
 
 	if exitCode, err := this.executeSession(sshSess, conn, taskType); err != nil {


### PR DESCRIPTION
## Motivation
Not all processes (like a sleep) will end if the SSH sessions ends.

## Changes
Now we send always (if still alive) at the underlying process also a `SIGTERM` on disconnect (if still alive).
