### PR TITLE
Improve session timeout handling

### DIFF
--- a/pkg/service/housekeeper.go
+++ b/pkg/service/housekeeper.go
@@ -111,7 +111,7 @@ func (this *houseKeeper) inspectSession(ctx context.Context, sess session.Sessio
 	logger := this.logger().With("session", sess)
 	started := time.Now()
 
-	reportAndContiue := func(err error) (bool, error) {
+	reportAndContinue := func(err error) (bool, error) {
 		logger.WithError(err).
 			With("duration", time.Since(started).Truncate(time.Microsecond)).
 			Warn("cannot inspect session; skipping...")
@@ -121,23 +121,23 @@ func (this *houseKeeper) inspectSession(ctx context.Context, sess session.Sessio
 	logger.Debug("inspecting session...")
 
 	if shouldBeDeleted, err := session.IsExpiredWithThreshold(this.service.Configuration.HouseKeeping.KeepExpiredFor.Native())(ctx, sess); err != nil {
-		return reportAndContiue(err)
+		return reportAndContinue(err)
 	} else if shouldBeDeleted {
 		if _, err := this.dispose(ctx, logger, sess); err != nil {
-			return reportAndContiue(err)
+			return reportAndContinue(err)
 		}
 
 		if err := this.service.sessions.Delete(ctx, sess); err != nil {
-			return reportAndContiue(err)
+			return reportAndContinue(err)
 		}
 		logger.Info("session reached maximum age to be kept after being expired and was therefore deleted")
 
 	} else if expired, err := session.IsExpired(ctx, sess); err != nil {
-		return reportAndContiue(err)
+		return reportAndContinue(err)
 	} else if expired {
 		disposed, err := this.dispose(ctx, logger, sess)
 		if err != nil {
-			return reportAndContiue(err)
+			return reportAndContinue(err)
 		}
 		if disposed {
 			logger.Info("session is expired and was therefore disposed")

--- a/pkg/session/fs-info.go
+++ b/pkg/session/fs-info.go
@@ -77,8 +77,8 @@ func (this *fsInfo) Created(context.Context) (InfoCreated, error) {
 	return &this.created, nil
 }
 
-func (this *fsInfo) ValidUntil(ctx context.Context) (result time.Time, _ error) {
-	lastAccessed, err := this.LastAccessed(ctx)
+func (this *fsInfo) ValidUntil(context.Context) (result time.Time, _ error) {
+	lastAccessed, err := this.lastAccessed()
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -95,7 +95,7 @@ func (this *fsInfo) ValidUntil(ctx context.Context) (result time.Time, _ error) 
 	return result, nil
 }
 
-func (this *fsInfo) lastAccessed(_ context.Context) (*fsLastAccessed, error) {
+func (this *fsInfo) lastAccessed() (*fsLastAccessed, error) {
 	this.session.repository.mutex.RLock()
 	defer this.session.repository.mutex.RUnlock()
 
@@ -123,11 +123,11 @@ func (this *fsInfo) stat() (os.FileInfo, error) {
 	return this.session.repository.stat(this.session.flow, this.session.id, FsFileSession)
 }
 
-func (this *fsInfo) LastAccessed(ctx context.Context) (InfoLastAccessed, error) {
-	return this.lastAccessed(ctx)
+func (this *fsInfo) LastAccessed(context.Context) (InfoLastAccessed, error) {
+	return this.lastAccessed()
 }
 
-func (this *fsInfo) save(_ context.Context) error {
+func (this *fsInfo) save() error {
 	f, _, err := this.session.repository.openWrite(this.session.flow, this.session.id, FsFileSession, false)
 	if err != nil {
 		return err
@@ -138,7 +138,8 @@ func (this *fsInfo) save(_ context.Context) error {
 		return fmt.Errorf("cannot encode session %v: %w", this, err)
 	}
 
-	if err := os.Chtimes(f.Name(), time.Now(), this.createdAt); err != nil {
+	now := time.Now()
+	if err := os.Chtimes(f.Name(), now, now); err != nil {
 		return fmt.Errorf("cannot change time of session %v: %w", this, err)
 	}
 

--- a/pkg/session/fs-lastaccessed.go
+++ b/pkg/session/fs-lastaccessed.go
@@ -1,7 +1,6 @@
 package session
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -46,7 +45,7 @@ func (this *fsLastAccessed) Remote() net.Remote {
 	return &this.remote
 }
 
-func (this *fsLastAccessed) save(_ context.Context) error {
+func (this *fsLastAccessed) save() error {
 	if _, err := this.info.stat(); err != nil {
 		return fmt.Errorf("cannot session's %v last access because cannot stat info: %w", this, err)
 	}
@@ -60,7 +59,8 @@ func (this *fsLastAccessed) save(_ context.Context) error {
 	if err := json.NewEncoder(f).Encode(this); err != nil {
 		return fmt.Errorf("cannot encode session %v: %w", this.info.session, err)
 	}
-	if err := os.Chtimes(f.Name(), time.Now(), this.at); err != nil {
+	now := time.Now()
+	if err := os.Chtimes(f.Name(), now, now); err != nil {
 		return fmt.Errorf("cannot change time of session's last access %v: %w", this, err)
 	}
 

--- a/pkg/session/fs.go
+++ b/pkg/session/fs.go
@@ -155,23 +155,23 @@ func (this *fs) DeletePublicKey(ctx context.Context, pub ssh.PublicKey) error {
 	return this.repository.deletePublicKey(ctx, this.flow, this.id, pub)
 }
 
-func (this *fs) NotifyLastAccess(ctx context.Context, remote net.Remote, newState State) (State, error) {
-	return this.notifyLastAccess(ctx, remote, newState)
+func (this *fs) NotifyLastAccess(_ context.Context, remote net.Remote, newState State) (State, error) {
+	return this.notifyLastAccess(remote, newState)
 }
 
-func (this *fs) notifyLastAccess(ctx context.Context, remote net.Remote, newState State) (State, error) {
+func (this *fs) notifyLastAccess(remote net.Remote, newState State) (State, error) {
 	var buf fsLastAccessed
 	buf.at = time.Now().Truncate(time.Millisecond)
 	buf.VRemoteUser = remote.User()
 	buf.VRemoteHost = remote.Host()
 	buf.init(&this.info)
-	if err := buf.save(ctx); err != nil {
+	if err := buf.save(); err != nil {
 		return 0, err
 	}
 	oldState := this.info.VState
 	if newState != 0 && newState != this.info.VState {
 		this.info.VState = newState
-		if err := this.info.save(ctx); err != nil {
+		if err := this.info.save(); err != nil {
 			return 0, err
 		}
 	}


### PR DESCRIPTION
## Motivation
Currently the detection when a session times out does not always works as expected. Sometimes the sessions are timing out too early.

## Changes
Generally we're touching now the `FsFileLastAccessed` files by default every minute.
