### PR TITLE
Current best practices for used ciphers, key exchanges and message authentication

### DIFF
--- a/docs/reference/connection/ssh.md
+++ b/docs/reference/connection/ssh.md
@@ -65,7 +65,7 @@ Default Locations:
 * Linux: `/etc/engity/bifroest/key`
 * Windows: `C:\ProgramData\Engity\Bifroest\key`
 
-<<property("exchanges", "Exchanges", "../data-type.md#ssh-key-exchange", default=["curve25519-sha256@libssh.org", "curve25519-sha256", "diffie-hellman-group16-sha512", "diffie-hellman-group14-sha256"], heading=4, id_prefix="keys-")>>
+<<property("exchanges", "Exchanges", "../data-type.md#ssh-key-exchange", default=["curve25519-sha256@libssh.org", "curve25519-sha256", "diffie-hellman-group16-sha512"], heading=4, id_prefix="keys-")>>
 Restrict which key exchanges are allowed to be used.
 
 <<property("rsaRestriction", "RSA Restriction", "../data-type.md#rsa-restriction", default="at-least-4096-bits", heading=4, id_prefix="keys-")>>
@@ -92,7 +92,6 @@ exchanges:
   - curve25519-sha256@libssh.org
   - curve25519-sha256
   - diffie-hellman-group16-sha512
-  - diffie-hellman-group14-sha256
 rsaRestriction: at-least-4096-bits
 dsaRestriction: none
 ecdsaRestriction: at-least-384-bits

--- a/docs/reference/connection/ssh.md
+++ b/docs/reference/connection/ssh.md
@@ -13,6 +13,9 @@ To which address the service will bind and listen to.
 <<property("keys", "Keys", "#keys")>>
 See [below](#keys).
 
+<<property("messages", "Messages", "#messages")>>
+See [below](#messages).
+
 <<property("idleTimeout", "Duration", "../data-type.md#duration", default="10m")>>
 For how long a connection can be idle before it will forcibly be closed. The client can send keep alive packages to extend the idle time. `0` means that the connection will never time out.
 
@@ -38,6 +41,8 @@ addresses: [ ":22" ]
 keys:
   hostKeys: [ /etc/engity/bifroest/key ]
   # ...
+messages:
+  # ...
 idleTimeout: 10m
 maxTimeout: 0
 maxAuthTries: 6
@@ -60,6 +65,9 @@ Default Locations:
 * Linux: `/etc/engity/bifroest/key`
 * Windows: `C:\ProgramData\Engity\Bifroest\key`
 
+<<property("exchanges", "Exchanges", "../data-type.md#ssh-key-exchange", default=["curve25519-sha256@libssh.org", "curve25519-sha256", "diffie-hellman-group16-sha512", "diffie-hellman-group14-sha256"], heading=4, id_prefix="keys-")>>
+Restrict which key exchanges are allowed to be used.
+
 <<property("rsaRestriction", "RSA Restriction", "../data-type.md#rsa-restriction", default="at-least-4096-bits", heading=4, id_prefix="keys-")>>
 Restrict which RSA keys are allowed to be used.
 
@@ -80,11 +88,40 @@ Banner which will be shown if the connection was based on an authentication meth
 
 ```yaml
 hostKeys: [ /etc/engity/bifroest/key ]
+exchanges:
+  - curve25519-sha256@libssh.org
+  - curve25519-sha256
+  - diffie-hellman-group16-sha512
+  - diffie-hellman-group14-sha256
 rsaRestriction: at-least-4096-bits
 dsaRestriction: none
 ecdsaRestriction: at-least-384-bits
 ed25519Restriction: all
 rememberMeNotification: "If you return until {{.session.validUntil | format `dateTimeT`}} with the same public key {{.key | fingerprint}}), you can seamlessly login again.\n\n"
+```
+
+## Messages
+
+### Configuration {: #messages-configuration }
+
+<<property("authentications", "Authentications", "../data-type.md#ssh-message-authentication", default=["hmac-sha2-512-etm@openssh.com", "hmac-sha2-512", "hmac-sha2-256-etm@openssh.com", "hmac-sha2-256"], heading=4, id_prefix="messages-")>>
+Restrict which message authentications are allowed to be used.
+
+<<property("ciphers", "Ciphers", "../data-type.md#ssh-ciphers", default=["aes256-gcm@openssh.com", "aes256-ctr", "aes192-ctr"], heading=4, id_prefix="messages-")>>
+Restrict which ciphers are allowed to be used.
+
+### Examples {: #messages-examples }
+
+```yaml
+authentications:
+  - hmac-sha2-512-etm@openssh.com
+  - hmac-sha2-512
+  - hmac-sha2-256-etm@openssh.com
+  - hmac-sha2-256
+ciphers:
+  - aes256-gcm@openssh.com
+  - aes256-ctr
+  - aes192-ctr
 ```
 
 ## Preparation Messages {: #preparationMessages }
@@ -140,8 +177,6 @@ preparationMessages:
     end: ""
     error: ""
 ```
-
-
 
 ## Compatibility
 

--- a/docs/reference/connection/ssh.md
+++ b/docs/reference/connection/ssh.md
@@ -103,7 +103,7 @@ rememberMeNotification: "If you return until {{.session.validUntil | format `dat
 
 ### Configuration {: #messages-configuration }
 
-<<property("authentications", "Authentications", "../data-type.md#ssh-message-authentication", default=["hmac-sha2-512-etm@openssh.com", "hmac-sha2-512", "hmac-sha2-256-etm@openssh.com", "hmac-sha2-256"], heading=4, id_prefix="messages-")>>
+<<property("authentications", "Authentications", "../data-type.md#ssh-message-authentication", default=["hmac-sha2-512-etm@openssh.com", "hmac-sha2-256-etm@openssh.com"], heading=4, id_prefix="messages-")>>
 Restrict which message authentications are allowed to be used.
 
 <<property("ciphers", "Ciphers", "../data-type.md#ssh-ciphers", default=["aes256-gcm@openssh.com", "aes256-ctr", "aes192-ctr"], heading=4, id_prefix="messages-")>>
@@ -114,9 +114,7 @@ Restrict which ciphers are allowed to be used.
 ```yaml
 authentications:
   - hmac-sha2-512-etm@openssh.com
-  - hmac-sha2-512
   - hmac-sha2-256-etm@openssh.com
-  - hmac-sha2-256
 ciphers:
   - aes256-gcm@openssh.com
   - aes256-ctr

--- a/docs/reference/data-type.md
+++ b/docs/reference/data-type.md
@@ -140,6 +140,46 @@ Can be one of:
 * `at-least-3072-bits`
 * `at-least-4096-bits`
 
+## SSH Ciphers
+Can be one of:
+
+* `aes128-cbc`
+* `3des-cbc`
+* `arcfour`
+* `arcfour128`
+* `arcfour256`
+* `chacha20-poly1305@openssh.com`
+* `aes128-ctr`
+* `aes192-ctr`
+* `aes256-ctr`
+* `aes128-gcm@openssh.com`
+* `aes256-gcm@openssh.com`
+
+## SSH Key Exchange
+Can be one of:
+
+* `diffie-hellman-group1-sha1`
+* `diffie-hellman-group14-sha1`
+* `diffie-hellman-group14-sha256`
+* `diffie-hellman-group16-sha512`
+* `ecdh-sha2-nistp256`
+* `ecdh-sha2-nistp384`
+* `ecdh-sha2-nistp521`
+* `curve25519-sha256@libssh.org`
+* `curve25519-sha256`
+* `diffie-hellman-group-exchange-sha1`
+* `"diffie-hellman-group-exchange-sha256`
+
+## SSH Message Authentication
+Can be one of:
+
+* `hmac-sha1`
+* `hmac-sha1-96`
+* `hmac-sha2-256`
+* `hmac-sha2-512`
+* `hmac-sha2-256-etm@openssh.com`
+* `hmac-sha2-512-etm@openssh.com`
+
 ## SSH Public Key
 The public variant of an [SSH keypair](https://wiki.archlinux.org/title/SSH_keys) of a user.
 

--- a/pkg/configuration/configuration_unix_test.go
+++ b/pkg/configuration/configuration_unix_test.go
@@ -48,11 +48,16 @@ func TestConfiguration_UnmarshalYAML(t *testing.T) {
 					Addresses: DefaultSshAddresses,
 					Keys: Keys{
 						HostKeys:               DefaultHostKeyLocations,
+						Exchanges:              DefaultKeyExchanges,
 						RsaRestriction:         crypto.DefaultRsaRestriction,
 						DsaRestriction:         crypto.DefaultDsaRestriction,
 						EcdsaRestriction:       crypto.DefaultEcdsaRestriction,
 						Ed25519Restriction:     crypto.DefaultEd25519Restriction,
 						RememberMeNotification: DefaultRememberMeNotification,
+					},
+					Messages: Messages{
+						Authentications: DefaultMessagesAuthentications,
+						Ciphers:         DefaultMessagesCiphers,
 					},
 					IdleTimeout:    DefaultSshIdleTimeout,
 					MaxTimeout:     DefaultSshMaxTimeout,

--- a/pkg/configuration/configuration_windows_test.go
+++ b/pkg/configuration/configuration_windows_test.go
@@ -47,11 +47,16 @@ func TestConfiguration_UnmarshalYAML(t *testing.T) {
 					Addresses: DefaultSshAddresses,
 					Keys: Keys{
 						HostKeys:               DefaultHostKeyLocations,
+						Exchanges:              DefaultKeyExchanges,
 						RsaRestriction:         crypto.DefaultRsaRestriction,
 						DsaRestriction:         crypto.DefaultDsaRestriction,
 						EcdsaRestriction:       crypto.DefaultEcdsaRestriction,
 						Ed25519Restriction:     crypto.DefaultEd25519Restriction,
 						RememberMeNotification: DefaultRememberMeNotification,
+					},
+					Messages: Messages{
+						Authentications: DefaultMessagesAuthentications,
+						Ciphers:         DefaultMessagesCiphers,
 					},
 					IdleTimeout:    DefaultSshIdleTimeout,
 					MaxTimeout:     DefaultSshMaxTimeout,

--- a/pkg/configuration/keys.go
+++ b/pkg/configuration/keys.go
@@ -4,16 +4,19 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/engity-com/bifroest/pkg/crypto"
+	"github.com/engity-com/bifroest/pkg/ssh"
 	"github.com/engity-com/bifroest/pkg/template"
 )
 
 var (
 	DefaultHostKeyLocations       = template.MustNewStrings(DefaultHostKeyLocation)
+	DefaultKeyExchanges           = ssh.DefaultKeyExchanges
 	DefaultRememberMeNotification = template.MustNewString("\nIf you return until {{.session.validUntil | format `dateTimeT`}} with the same public key ({{.key | fingerprint}}), you can seamlessly login again.\n\n")
 )
 
 type Keys struct {
 	HostKeys               template.Strings          `yaml:"hostKeys"`
+	Exchanges              ssh.KeyExchanges          `yaml:"exchanges"`
 	RsaRestriction         crypto.RsaRestriction     `yaml:"rsaRestriction"`
 	DsaRestriction         crypto.DsaRestriction     `yaml:"dsaRestriction"`
 	EcdsaRestriction       crypto.EcdsaRestriction   `yaml:"ecdsaRestriction"`
@@ -24,6 +27,7 @@ type Keys struct {
 func (this *Keys) SetDefaults() error {
 	return setDefaults(this,
 		fixedDefault("hostKeys", func(v *Keys) *template.Strings { return &v.HostKeys }, DefaultHostKeyLocations),
+		fixedDefault("exchanges", func(v *Keys) *ssh.KeyExchanges { return &v.Exchanges }, DefaultKeyExchanges),
 		fixedDefault("rsaRestriction", func(v *Keys) *crypto.RsaRestriction { return &v.RsaRestriction }, crypto.DefaultRsaRestriction),
 		fixedDefault("dsaRestriction", func(v *Keys) *crypto.DsaRestriction { return &v.DsaRestriction }, crypto.DefaultDsaRestriction),
 		fixedDefault("ecdsaRestriction", func(v *Keys) *crypto.EcdsaRestriction { return &v.EcdsaRestriction }, crypto.DefaultEcdsaRestriction),
@@ -35,6 +39,7 @@ func (this *Keys) SetDefaults() error {
 func (this *Keys) Trim() error {
 	return trim(this,
 		noopTrim[Keys]("hostKeys"),
+		noopTrim[Keys]("exchanges"),
 		noopTrim[Keys]("rsaRestriction"),
 		noopTrim[Keys]("dsaRestriction"),
 		noopTrim[Keys]("ecdsaRestriction"),
@@ -47,6 +52,8 @@ func (this *Keys) Validate() error {
 	return validate(this,
 		func(v *Keys) (string, validator) { return "hostKeys", &v.HostKeys },
 		notZeroValidate("hostKeys", func(v *Keys) *template.Strings { return &v.HostKeys }),
+		func(v *Keys) (string, validator) { return "exchanges", &v.Exchanges },
+		notZeroValidate("exchanges", func(v *Keys) *ssh.KeyExchanges { return &v.Exchanges }),
 		func(v *Keys) (string, validator) { return "rsaRestriction", &v.RsaRestriction },
 		func(v *Keys) (string, validator) { return "dsaRestriction", &v.DsaRestriction },
 		func(v *Keys) (string, validator) { return "ecdsaRestriction", &v.EcdsaRestriction },
@@ -78,6 +85,7 @@ func (this Keys) IsEqualTo(other any) bool {
 
 func (this Keys) isEqualTo(other *Keys) bool {
 	return isEqual(&this.HostKeys, &other.HostKeys) &&
+		isEqual(&this.Exchanges, &other.Exchanges) &&
 		isEqual(&this.RsaRestriction, &other.RsaRestriction) &&
 		isEqual(&this.DsaRestriction, &other.DsaRestriction) &&
 		isEqual(&this.EcdsaRestriction, &other.EcdsaRestriction) &&

--- a/pkg/configuration/messages.go
+++ b/pkg/configuration/messages.go
@@ -1,0 +1,66 @@
+package configuration
+
+import (
+	"gopkg.in/yaml.v3"
+
+	"github.com/engity-com/bifroest/pkg/ssh"
+)
+
+var (
+	DefaultMessagesAuthentications = ssh.DefaultMessageAuthentications
+	DefaultMessagesCiphers         = ssh.DefaultCiphers
+)
+
+type Messages struct {
+	Authentications ssh.MessageAuthentications `yaml:"authentications"`
+	Ciphers         ssh.Ciphers                `yaml:"ciphers"`
+}
+
+func (this *Messages) SetDefaults() error {
+	return setDefaults(this,
+		fixedDefault("authentications", func(v *Messages) *ssh.MessageAuthentications { return &v.Authentications }, DefaultMessagesAuthentications),
+		fixedDefault("ciphers", func(v *Messages) *ssh.Ciphers { return &v.Ciphers }, DefaultMessagesCiphers),
+	)
+}
+
+func (this *Messages) Trim() error {
+	return trim(this,
+		noopTrim[Messages]("authentications"),
+		noopTrim[Messages]("ciphers"),
+	)
+}
+
+func (this *Messages) Validate() error {
+	return validate(this,
+		func(v *Messages) (string, validator) { return "authentications", &v.Authentications },
+		notZeroValidate("authentications", func(v *Messages) *ssh.MessageAuthentications { return &v.Authentications }),
+		func(v *Messages) (string, validator) { return "ciphers", &v.Ciphers },
+		notZeroValidate("ciphers", func(v *Messages) *ssh.Ciphers { return &v.Ciphers }),
+	)
+}
+
+func (this *Messages) UnmarshalYAML(node *yaml.Node) error {
+	return unmarshalYAML(this, node, func(target *Messages, node *yaml.Node) error {
+		type raw Messages
+		return node.Decode((*raw)(target))
+	})
+}
+
+func (this Messages) IsEqualTo(other any) bool {
+	if other == nil {
+		return false
+	}
+	switch v := other.(type) {
+	case Messages:
+		return this.isEqualTo(&v)
+	case *Messages:
+		return this.isEqualTo(v)
+	default:
+		return false
+	}
+}
+
+func (this Messages) isEqualTo(other *Messages) bool {
+	return isEqual(&this.Authentications, &other.Authentications) &&
+		isEqual(&this.Ciphers, &other.Ciphers)
+}

--- a/pkg/configuration/ssh.go
+++ b/pkg/configuration/ssh.go
@@ -41,6 +41,9 @@ type Ssh struct {
 	// Keys represents all key related settings of the service.
 	Keys Keys `yaml:"keys"`
 
+	// Messages represents all message related settings of the service.
+	Messages Messages `yaml:"messages"`
+
 	// IdleTimeout represents the duration a connection can be idle until it will be forcibly closed.
 	// 0 means no limitation at all. Defaults to DefaultSshIdleTimeout.
 	IdleTimeout common.Duration `yaml:"idleTimeout"`
@@ -74,6 +77,7 @@ func (this *Ssh) SetDefaults() error {
 	return setDefaults(this,
 		fixedDefault("addresses", func(v *Ssh) *net.NetAddresses { return &v.Addresses }, DefaultSshAddresses),
 		func(v *Ssh) (string, defaulter) { return "keys", &v.Keys },
+		func(v *Ssh) (string, defaulter) { return "messages", &v.Messages },
 		fixedDefault("idleTimeout", func(v *Ssh) *common.Duration { return &v.IdleTimeout }, DefaultSshIdleTimeout),
 		fixedDefault("maxTimeout", func(v *Ssh) *common.Duration { return &v.MaxTimeout }, DefaultSshMaxTimeout),
 		fixedDefault("maxAuthTries", func(v *Ssh) *uint8 { return &v.MaxAuthTries }, DefaultSshMaxAuthTries),
@@ -88,6 +92,7 @@ func (this *Ssh) Trim() error {
 	return trim(this,
 		func(v *Ssh) (string, trimmer) { return "addresses", &v.Addresses },
 		func(v *Ssh) (string, trimmer) { return "keys", &v.Keys },
+		func(v *Ssh) (string, trimmer) { return "messages", &v.Messages },
 		noopTrim[Ssh]("idleTimeout"),
 		noopTrim[Ssh]("maxTimeout"),
 		noopTrim[Ssh]("maxAuthTries"),
@@ -102,6 +107,7 @@ func (this *Ssh) Validate() error {
 	return validate(this,
 		func(v *Ssh) (string, validator) { return "addresses", &v.Addresses },
 		func(v *Ssh) (string, validator) { return "keys", &v.Keys },
+		func(v *Ssh) (string, validator) { return "messages", &v.Messages },
 		func(v *Ssh) (string, validator) { return "idleTimeout", &v.IdleTimeout },
 		func(v *Ssh) (string, validator) { return "maxTimeout", &v.MaxTimeout },
 		noopValidate[Ssh]("maxAuthTries"),
@@ -136,6 +142,7 @@ func (this Ssh) IsEqualTo(other any) bool {
 func (this Ssh) isEqualTo(other *Ssh) bool {
 	return isEqual(&this.Addresses, &other.Addresses) &&
 		isEqual(&this.Keys, &other.Keys) &&
+		isEqual(&this.Messages, &other.Messages) &&
 		isEqual(&this.IdleTimeout, &other.IdleTimeout) &&
 		isEqual(&this.MaxTimeout, &other.MaxTimeout) &&
 		this.MaxAuthTries == other.MaxAuthTries &&

--- a/pkg/ssh/cipher.go
+++ b/pkg/ssh/cipher.go
@@ -1,0 +1,197 @@
+package ssh
+
+import (
+	"bytes"
+	"fmt"
+	"slices"
+)
+
+type Cipher uint8
+
+const (
+	CipherAes128Cbc Cipher = iota
+	Cipher3desCbc
+	CipherArcfour
+	CipherArcfour128
+	CipherArcfour256
+	CipherChacha20Poly1305
+	CipherAes128Ctr
+	CipherAes192Ctr
+	CipherAes256Ctr
+	CipherAes128Gcm
+	CipherAes256Gcm
+)
+
+var (
+	cipher2Name = map[Cipher]string{
+		CipherAes128Cbc:        "aes128-cbc",
+		Cipher3desCbc:          "3des-cbc",
+		CipherArcfour:          "arcfour",
+		CipherArcfour128:       "arcfour128",
+		CipherArcfour256:       "arcfour256",
+		CipherChacha20Poly1305: "chacha20-poly1305@openssh.com",
+		CipherAes128Ctr:        "aes128-ctr",
+		CipherAes192Ctr:        "aes192-ctr",
+		CipherAes256Ctr:        "aes256-ctr",
+		CipherAes128Gcm:        "aes128-gcm@openssh.com",
+		CipherAes256Gcm:        "aes256-gcm@openssh.com",
+	}
+	name2Cipher = func(in map[Cipher]string) map[string]Cipher {
+		result := make(map[string]Cipher, len(in))
+		for k, v := range in {
+			result[v] = k
+		}
+		return result
+	}(cipher2Name)
+
+	DefaultCiphers = []Cipher{
+		CipherAes256Gcm,
+		CipherAes256Ctr,
+		CipherAes192Ctr,
+	}
+)
+
+func (this Cipher) Validate() error {
+	_, err := this.MarshalText()
+	return err
+}
+
+func (this Cipher) MarshalText() (text []byte, err error) {
+	if v, ok := cipher2Name[this]; ok {
+		return []byte(v), nil
+	}
+	return nil, fmt.Errorf("illegal ssh cipher: %d", this)
+}
+
+func (this Cipher) String() string {
+	if v, err := this.MarshalText(); err == nil {
+		return string(v)
+	}
+	return fmt.Sprintf("illegal-ssh-cipher-%d", this)
+}
+
+func (this *Cipher) UnmarshalText(text []byte) error {
+	if v, ok := name2Cipher[string(text)]; ok {
+		*this = v
+		return nil
+	}
+	return fmt.Errorf("illegal ssh cipher: %q", string(text))
+}
+
+func (this *Cipher) Set(text string) error {
+	return this.UnmarshalText([]byte(text))
+}
+
+func (this Cipher) IsZero() bool {
+	return false
+}
+
+func (this Cipher) IsEqualTo(other any) bool {
+	if other == nil {
+		return false
+	}
+	switch v := other.(type) {
+	case Cipher:
+		return this.isEqualTo(&v)
+	case *Cipher:
+		return this.isEqualTo(v)
+	default:
+		return false
+	}
+}
+
+func (this Cipher) isEqualTo(other *Cipher) bool {
+	return this == *other
+}
+
+type Ciphers []Cipher
+
+func (this Ciphers) IsEmpty() bool {
+	return len(this) == 0
+}
+
+func (this Ciphers) IsCumulative() bool {
+	return true
+}
+
+func (this Ciphers) Validate() error {
+	_, err := this.MarshalText()
+	return err
+}
+
+func (this Ciphers) MarshalTexts() (texts [][]byte, err error) {
+	texts = make([][]byte, len(this))
+	for i, v := range this {
+		texts[i], err = v.MarshalText()
+		if err != nil {
+			return nil, fmt.Errorf("[%d] %w", i, err)
+		}
+	}
+	return texts, nil
+}
+func (this Ciphers) MarshalText() (text []byte, err error) {
+	texts, err := this.MarshalTexts()
+	if err != nil {
+		return nil, err
+	}
+	return bytes.Join(texts, []byte(",")), nil
+}
+
+func (this Ciphers) String() string {
+	v, err := this.MarshalText()
+	if err != nil {
+		return fmt.Sprintf("illegal-ssh-ciphers: %s", err.Error())
+	}
+	return string(v)
+}
+
+func (this *Ciphers) UnmarshalText(text []byte) error {
+	texts := bytes.Split(text, []byte(","))
+	for _, v := range texts {
+		var buf Cipher
+		if err := buf.UnmarshalText(v); err != nil {
+			return err
+		}
+		*this = append(*this, buf)
+	}
+	return nil
+}
+
+func (this *Ciphers) Set(text string) error {
+	return this.UnmarshalText([]byte(text))
+}
+
+func (this Ciphers) IsZero() bool {
+	return false
+}
+
+func (this Ciphers) IsEqualTo(other any) bool {
+	if other == nil {
+		return false
+	}
+	switch v := other.(type) {
+	case Ciphers:
+		return this.isEqualTo(&v)
+	case *Ciphers:
+		return this.isEqualTo(v)
+	default:
+		return false
+	}
+}
+
+func (this Ciphers) isEqualTo(other *Ciphers) bool {
+	if len(this) != len(*other) {
+		return false
+	}
+	for i, tv := range this {
+		ov := (*other)[i]
+		if !tv.isEqualTo(&ov) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this Ciphers) Contains(v Cipher) bool {
+	return slices.Contains(this, v)
+}

--- a/pkg/ssh/cipher_test.go
+++ b/pkg/ssh/cipher_test.go
@@ -1,0 +1,30 @@
+package ssh
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestCipher_supportedBySdk(t *testing.T) {
+	for c := range cipher2Name {
+		t.Run(c.String(), func(t *testing.T) {
+			var sc ssh.Config
+			sc.Ciphers = []string{c.String()}
+			sc.SetDefaults()
+			require.Containsf(t, sc.Ciphers, c.String(), "%v should be supported by SDK, but isn't", c)
+		})
+	}
+}
+
+func TestCipher_implementedByUs(t *testing.T) {
+	var sc ssh.Config
+	sc.SetDefaults()
+
+	for _, c := range sc.Ciphers {
+		t.Run(c, func(t *testing.T) {
+			require.Containsf(t, name2Cipher, c, "%v should be implemented, but isn't", c)
+		})
+	}
+}

--- a/pkg/ssh/key-exchange.go
+++ b/pkg/ssh/key-exchange.go
@@ -48,7 +48,6 @@ var (
 		KeyExchangeCurve25519Sha256LibSsh,
 		KeyExchangeCurve25519Sha256,
 		KeyExchangeDh16Sha512,
-		KeyExchangeDh14Sha256,
 	}
 )
 

--- a/pkg/ssh/key-exchange.go
+++ b/pkg/ssh/key-exchange.go
@@ -1,0 +1,198 @@
+package ssh
+
+import (
+	"bytes"
+	"fmt"
+	"slices"
+)
+
+type KeyExchange uint8
+
+const (
+	KeyExchangeDh1Sha1 KeyExchange = iota
+	KeyExchangeDh14Sha1
+	KeyExchangeDh14Sha256
+	KeyExchangeDh16Sha512
+	KeyExchangeEcdh256
+	KeyExchangeEcdh384
+	KeyExchangeEcdh521
+	KeyExchangeCurve25519Sha256LibSsh
+	KeyExchangeCurve25519Sha256
+	KeyExchangeDhgexSha1
+	KeyExchangeDhgexSha256
+)
+
+var (
+	keyExchange2Name = map[KeyExchange]string{
+		KeyExchangeDh1Sha1:                "diffie-hellman-group1-sha1",
+		KeyExchangeDh14Sha1:               "diffie-hellman-group14-sha1",
+		KeyExchangeDh14Sha256:             "diffie-hellman-group14-sha256",
+		KeyExchangeDh16Sha512:             "diffie-hellman-group16-sha512",
+		KeyExchangeEcdh256:                "ecdh-sha2-nistp256",
+		KeyExchangeEcdh384:                "ecdh-sha2-nistp384",
+		KeyExchangeEcdh521:                "ecdh-sha2-nistp521",
+		KeyExchangeCurve25519Sha256LibSsh: "curve25519-sha256@libssh.org",
+		KeyExchangeCurve25519Sha256:       "curve25519-sha256",
+		KeyExchangeDhgexSha1:              "diffie-hellman-group-exchange-sha1",
+		KeyExchangeDhgexSha256:            "diffie-hellman-group-exchange-sha256",
+	}
+	name2KeyExchange = func(in map[KeyExchange]string) map[string]KeyExchange {
+		result := make(map[string]KeyExchange, len(in))
+		for k, v := range in {
+			result[v] = k
+		}
+		return result
+	}(keyExchange2Name)
+
+	DefaultKeyExchanges = []KeyExchange{
+		KeyExchangeCurve25519Sha256LibSsh,
+		KeyExchangeCurve25519Sha256,
+		KeyExchangeDh16Sha512,
+		KeyExchangeDh14Sha256,
+	}
+)
+
+func (this KeyExchange) Validate() error {
+	_, err := this.MarshalText()
+	return err
+}
+
+func (this KeyExchange) MarshalText() (text []byte, err error) {
+	if v, ok := keyExchange2Name[this]; ok {
+		return []byte(v), nil
+	}
+	return nil, fmt.Errorf("illegal ssh key exchange: %d", this)
+}
+
+func (this KeyExchange) String() string {
+	if v, err := this.MarshalText(); err == nil {
+		return string(v)
+	}
+	return fmt.Sprintf("illegal-ssh-key-exchange-%d", this)
+}
+
+func (this *KeyExchange) UnmarshalText(text []byte) error {
+	if v, ok := name2KeyExchange[string(text)]; ok {
+		*this = v
+		return nil
+	}
+	return fmt.Errorf("illegal ssh key exchange: %q", string(text))
+}
+
+func (this *KeyExchange) Set(text string) error {
+	return this.UnmarshalText([]byte(text))
+}
+
+func (this KeyExchange) IsZero() bool {
+	return false
+}
+
+func (this KeyExchange) IsEqualTo(other any) bool {
+	if other == nil {
+		return false
+	}
+	switch v := other.(type) {
+	case KeyExchange:
+		return this.isEqualTo(&v)
+	case *KeyExchange:
+		return this.isEqualTo(v)
+	default:
+		return false
+	}
+}
+
+func (this KeyExchange) isEqualTo(other *KeyExchange) bool {
+	return this == *other
+}
+
+type KeyExchanges []KeyExchange
+
+func (this KeyExchanges) IsEmpty() bool {
+	return len(this) == 0
+}
+
+func (this KeyExchanges) IsCumulative() bool {
+	return true
+}
+
+func (this KeyExchanges) Validate() error {
+	_, err := this.MarshalText()
+	return err
+}
+
+func (this KeyExchanges) MarshalTexts() (texts [][]byte, err error) {
+	texts = make([][]byte, len(this))
+	for i, v := range this {
+		texts[i], err = v.MarshalText()
+		if err != nil {
+			return nil, fmt.Errorf("[%d] %w", i, err)
+		}
+	}
+	return texts, nil
+}
+func (this KeyExchanges) MarshalText() (text []byte, err error) {
+	texts, err := this.MarshalTexts()
+	if err != nil {
+		return nil, err
+	}
+	return bytes.Join(texts, []byte(",")), nil
+}
+
+func (this KeyExchanges) String() string {
+	v, err := this.MarshalText()
+	if err != nil {
+		return fmt.Sprintf("illegal-ssh-key-exchanges: %s", err.Error())
+	}
+	return string(v)
+}
+
+func (this *KeyExchanges) UnmarshalText(text []byte) error {
+	texts := bytes.Split(text, []byte(","))
+	for _, v := range texts {
+		var buf KeyExchange
+		if err := buf.UnmarshalText(v); err != nil {
+			return err
+		}
+		*this = append(*this, buf)
+	}
+	return nil
+}
+
+func (this *KeyExchanges) Set(text string) error {
+	return this.UnmarshalText([]byte(text))
+}
+
+func (this KeyExchanges) IsZero() bool {
+	return false
+}
+
+func (this KeyExchanges) IsEqualTo(other any) bool {
+	if other == nil {
+		return false
+	}
+	switch v := other.(type) {
+	case KeyExchanges:
+		return this.isEqualTo(&v)
+	case *KeyExchanges:
+		return this.isEqualTo(v)
+	default:
+		return false
+	}
+}
+
+func (this KeyExchanges) isEqualTo(other *KeyExchanges) bool {
+	if len(this) != len(*other) {
+		return false
+	}
+	for i, tv := range this {
+		ov := (*other)[i]
+		if !tv.isEqualTo(&ov) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this KeyExchanges) Contains(v KeyExchange) bool {
+	return slices.Contains(this, v)
+}

--- a/pkg/ssh/key-exchange_test.go
+++ b/pkg/ssh/key-exchange_test.go
@@ -1,0 +1,30 @@
+package ssh
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestKeyExchange_supportedBySdk(t *testing.T) {
+	for c := range keyExchange2Name {
+		t.Run(c.String(), func(t *testing.T) {
+			var sc ssh.Config
+			sc.KeyExchanges = []string{c.String()}
+			sc.SetDefaults()
+			require.Containsf(t, sc.KeyExchanges, c.String(), "%v should be supported by SDK, but isn't", c)
+		})
+	}
+}
+
+func TestKeyExchange_implementedByUs(t *testing.T) {
+	var sc ssh.Config
+	sc.SetDefaults()
+
+	for _, c := range sc.KeyExchanges {
+		t.Run(c, func(t *testing.T) {
+			require.Containsf(t, name2KeyExchange, c, "%v should be implemented, but isn't", c)
+		})
+	}
+}

--- a/pkg/ssh/message-authentication.go
+++ b/pkg/ssh/message-authentication.go
@@ -1,0 +1,188 @@
+package ssh
+
+import (
+	"bytes"
+	"fmt"
+	"slices"
+)
+
+type MessageAuthentication uint8
+
+const (
+	MessageAuthenticationHmacSha1 MessageAuthentication = iota
+	MessageAuthenticationHmacSha1B96
+	MessageAuthenticationHmacSha2B256
+	MessageAuthenticationHmacSha2B512
+	MessageAuthenticationHmacSha2B256Etm
+	MessageAuthenticationHmacSha2B512Etm
+)
+
+var (
+	messageAuthentication2Name = map[MessageAuthentication]string{
+		MessageAuthenticationHmacSha1:        "hmac-sha1",
+		MessageAuthenticationHmacSha1B96:     "hmac-sha1-96",
+		MessageAuthenticationHmacSha2B256:    "hmac-sha2-256",
+		MessageAuthenticationHmacSha2B512:    "hmac-sha2-512",
+		MessageAuthenticationHmacSha2B256Etm: "hmac-sha2-256-etm@openssh.com",
+		MessageAuthenticationHmacSha2B512Etm: "hmac-sha2-512-etm@openssh.com",
+	}
+	name2MessageAuthentication = func(in map[MessageAuthentication]string) map[string]MessageAuthentication {
+		result := make(map[string]MessageAuthentication, len(in))
+		for k, v := range in {
+			result[v] = k
+		}
+		return result
+	}(messageAuthentication2Name)
+
+	DefaultMessageAuthentications = []MessageAuthentication{
+		MessageAuthenticationHmacSha2B512Etm,
+		MessageAuthenticationHmacSha2B512,
+		MessageAuthenticationHmacSha2B256Etm,
+		MessageAuthenticationHmacSha2B256,
+	}
+)
+
+func (this MessageAuthentication) Validate() error {
+	_, err := this.MarshalText()
+	return err
+}
+
+func (this MessageAuthentication) MarshalText() (text []byte, err error) {
+	if v, ok := messageAuthentication2Name[this]; ok {
+		return []byte(v), nil
+	}
+	return nil, fmt.Errorf("illegal ssh message authentication: %d", this)
+}
+
+func (this MessageAuthentication) String() string {
+	if v, err := this.MarshalText(); err == nil {
+		return string(v)
+	}
+	return fmt.Sprintf("illegal-ssh-message-authentication-%d", this)
+}
+
+func (this *MessageAuthentication) UnmarshalText(text []byte) error {
+	if v, ok := name2MessageAuthentication[string(text)]; ok {
+		*this = v
+		return nil
+	}
+	return fmt.Errorf("illegal ssh message authentication: %q", string(text))
+}
+
+func (this *MessageAuthentication) Set(text string) error {
+	return this.UnmarshalText([]byte(text))
+}
+
+func (this MessageAuthentication) IsZero() bool {
+	return false
+}
+
+func (this MessageAuthentication) IsEqualTo(other any) bool {
+	if other == nil {
+		return false
+	}
+	switch v := other.(type) {
+	case MessageAuthentication:
+		return this.isEqualTo(&v)
+	case *MessageAuthentication:
+		return this.isEqualTo(v)
+	default:
+		return false
+	}
+}
+
+func (this MessageAuthentication) isEqualTo(other *MessageAuthentication) bool {
+	return this == *other
+}
+
+type MessageAuthentications []MessageAuthentication
+
+func (this MessageAuthentications) IsEmpty() bool {
+	return len(this) == 0
+}
+
+func (this MessageAuthentications) IsCumulative() bool {
+	return true
+}
+
+func (this MessageAuthentications) Validate() error {
+	_, err := this.MarshalText()
+	return err
+}
+
+func (this MessageAuthentications) MarshalTexts() (texts [][]byte, err error) {
+	texts = make([][]byte, len(this))
+	for i, v := range this {
+		texts[i], err = v.MarshalText()
+		if err != nil {
+			return nil, fmt.Errorf("[%d] %w", i, err)
+		}
+	}
+	return texts, nil
+}
+func (this MessageAuthentications) MarshalText() (text []byte, err error) {
+	texts, err := this.MarshalTexts()
+	if err != nil {
+		return nil, err
+	}
+	return bytes.Join(texts, []byte(",")), nil
+}
+
+func (this MessageAuthentications) String() string {
+	v, err := this.MarshalText()
+	if err != nil {
+		return fmt.Sprintf("illegal-ssh-message-authentications: %s", err.Error())
+	}
+	return string(v)
+}
+
+func (this *MessageAuthentications) UnmarshalText(text []byte) error {
+	texts := bytes.Split(text, []byte(","))
+	for _, v := range texts {
+		var buf MessageAuthentication
+		if err := buf.UnmarshalText(v); err != nil {
+			return err
+		}
+		*this = append(*this, buf)
+	}
+	return nil
+}
+
+func (this *MessageAuthentications) Set(text string) error {
+	return this.UnmarshalText([]byte(text))
+}
+
+func (this MessageAuthentications) IsZero() bool {
+	return false
+}
+
+func (this MessageAuthentications) IsEqualTo(other any) bool {
+	if other == nil {
+		return false
+	}
+	switch v := other.(type) {
+	case MessageAuthentications:
+		return this.isEqualTo(&v)
+	case *MessageAuthentications:
+		return this.isEqualTo(v)
+	default:
+		return false
+	}
+}
+
+func (this MessageAuthentications) isEqualTo(other *MessageAuthentications) bool {
+	if len(this) != len(*other) {
+		return false
+	}
+	for i, tv := range this {
+		ov := (*other)[i]
+		if !tv.isEqualTo(&ov) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this MessageAuthentications) Contains(v MessageAuthentication) bool {
+	return slices.Contains(this, v)
+}

--- a/pkg/ssh/message-authentication.go
+++ b/pkg/ssh/message-authentication.go
@@ -36,9 +36,7 @@ var (
 
 	DefaultMessageAuthentications = []MessageAuthentication{
 		MessageAuthenticationHmacSha2B512Etm,
-		MessageAuthenticationHmacSha2B512,
 		MessageAuthenticationHmacSha2B256Etm,
-		MessageAuthenticationHmacSha2B256,
 	}
 )
 

--- a/pkg/ssh/message-authentication_test.go
+++ b/pkg/ssh/message-authentication_test.go
@@ -1,0 +1,30 @@
+package ssh
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestMessageAuthentication_supportedBySdk(t *testing.T) {
+	for c := range messageAuthentication2Name {
+		t.Run(c.String(), func(t *testing.T) {
+			var sc ssh.Config
+			sc.MACs = []string{c.String()}
+			sc.SetDefaults()
+			require.Containsf(t, sc.MACs, c.String(), "%v should be supported by SDK, but isn't", c)
+		})
+	}
+}
+
+func TestMessageAuthentication_implementedByUs(t *testing.T) {
+	var sc ssh.Config
+	sc.SetDefaults()
+
+	for _, c := range sc.MACs {
+		t.Run(c, func(t *testing.T) {
+			require.Containsf(t, name2MessageAuthentication, c, "%v should be implemented, but isn't", c)
+		})
+	}
+}


### PR DESCRIPTION
## Motivation
Default settings for ciphers, key exchanges and message authentication as taken from OpenSSH are not longer recommend. To prevent users of Bifröst to go with those settings set the current best practices as default.

## Changes
1. Make those values anyhow configurable (before it wasn't the case, we just used the defaults).
2. Set the defaults to the current recommend ones.
3. Update the documentation accordingly.
