### PR TITLE
Add SSH environments, user certificates, and Bifroest delegation

### DIFF
--- a/cmd/bifroest/bootstrap-io.go
+++ b/cmd/bifroest/bootstrap-io.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	goos "os"
+	"path/filepath"
+
+	bfcrypto "github.com/engity-com/bifroest/pkg/crypto"
+)
+
+func readBootstrapInput(path string, stdin io.Reader) ([]byte, error) {
+	var reader io.Reader
+	var closeInput io.Closer
+	if path == "-" {
+		reader = stdin
+	} else {
+		file, err := goos.Open(path)
+		if err != nil {
+			return nil, fmt.Errorf("cannot open input file %q: %w", path, err)
+		}
+		reader, closeInput = file, file
+	}
+	if closeInput != nil {
+		defer closeInput.Close()
+	}
+	raw, err := io.ReadAll(io.LimitReader(reader, bfcrypto.MaxBootstrapInputSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("cannot read input: %w", err)
+	}
+	if len(raw) > bfcrypto.MaxBootstrapInputSize {
+		return nil, fmt.Errorf("input exceeds %d bytes", bfcrypto.MaxBootstrapInputSize)
+	}
+	return raw, nil
+}
+
+func writeBootstrapOutput(path string, raw []byte, force bool, stdout io.Writer) error {
+	if path == "-" {
+		_, err := stdout.Write(raw)
+		return err
+	}
+	return bfcrypto.WriteBootstrapFile(path, raw, force)
+}
+
+func ensureBootstrapOutputIsNotPrivateKey(output string, privateKeys ...string) error {
+	if output == "-" {
+		return nil
+	}
+	outputPath, err := filepath.Abs(output)
+	if err != nil {
+		return fmt.Errorf("cannot resolve output path %q: %w", output, err)
+	}
+	outputInfo, outputInfoErr := goos.Stat(outputPath)
+	for _, privateKey := range privateKeys {
+		if privateKey == "" {
+			continue
+		}
+		privateKeyPath, err := filepath.Abs(privateKey)
+		if err != nil {
+			return fmt.Errorf("cannot resolve private key path %q: %w", privateKey, err)
+		}
+		if outputPath == privateKeyPath {
+			return fmt.Errorf("output %q must not replace private key %q", output, privateKey)
+		}
+		if outputInfoErr == nil {
+			if privateKeyInfo, err := goos.Stat(privateKeyPath); err == nil && goos.SameFile(outputInfo, privateKeyInfo) {
+				return fmt.Errorf("output %q must not replace private key %q", output, privateKey)
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/bifroest/configuration-flag.go
+++ b/cmd/bifroest/configuration-flag.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"github.com/alecthomas/kingpin/v2"
+
+	"github.com/engity-com/bifroest/pkg/configuration"
+)
+
+func registerConfigurationFlag(cmd *kingpin.CmdClause, target *configuration.Ref) {
+	cmd.Flag("configuration", "Configuration which should be used. Default: "+defaultConfigurationRef).
+		Short('c').
+		Default(defaultConfigurationRef).
+		PlaceHolder("<path>").
+		SetValue(target)
+}

--- a/cmd/bifroest/key-export-ca.go
+++ b/cmd/bifroest/key-export-ca.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	goos "os"
+
+	"github.com/alecthomas/kingpin/v2"
+
+	"github.com/engity-com/bifroest/pkg/configuration"
+	bfcrypto "github.com/engity-com/bifroest/pkg/crypto"
+	"github.com/engity-com/bifroest/pkg/environment"
+)
+
+type keyExportCaOpts struct {
+	configuration configuration.Ref
+	flow          configuration.FlowName
+	output        string
+	force         bool
+}
+
+func registerKeyExportCaCmd(parent *kingpin.CmdClause) {
+	opts := keyExportCaOpts{output: "-"}
+
+	cmd := parent.Command("ca", "Export the public key of a flow's SSH certificate authority.").
+		Action(func(*kingpin.ParseContext) error {
+			return doKeyExportCa(&opts, goos.Stdout)
+		})
+	registerConfigurationFlag(cmd, &opts.configuration)
+	cmd.Flag("output", "Output file or - for stdout.").
+		Default(opts.output).
+		PlaceHolder("<path|->").
+		StringVar(&opts.output)
+	cmd.Flag("force", "Replace an existing output file.").
+		BoolVar(&opts.force)
+	cmd.Arg("flowName", "Flow whose SSH certificate authority should be exported.").
+		Required().
+		SetValue(&opts.flow)
+}
+
+func doKeyExportCa(opts *keyExportCaOpts, stdout io.Writer) error {
+	if opts == nil {
+		return fmt.Errorf("nil options")
+	}
+	flow, err := findConfiguredFlow(opts.configuration.Get(), opts.flow)
+	if err != nil {
+		return err
+	}
+	key, identityFile, err := environment.EnsureSshCertificateAuthority(flow)
+	if err != nil {
+		return err
+	}
+	if err := ensureBootstrapOutputIsNotPrivateKey(opts.output, identityFile); err != nil {
+		return err
+	}
+	return writeBootstrapOutput(opts.output, bfcrypto.MarshalPublicKey(key.PublicKey()), opts.force, stdout)
+}
+
+func findConfiguredFlow(conf *configuration.Configuration, name configuration.FlowName) (*configuration.Flow, error) {
+	if conf == nil {
+		return nil, fmt.Errorf("nil configuration")
+	}
+	for i := range conf.Flows {
+		if conf.Flows[i].Name == name {
+			return &conf.Flows[i], nil
+		}
+	}
+	return nil, fmt.Errorf("flow %q does not exist", name)
+}

--- a/cmd/bifroest/key-export-ca_test.go
+++ b/cmd/bifroest/key-export-ca_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	goos "os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/engity-com/bifroest/pkg/configuration"
+)
+
+func TestKeyExportCaUsesFlowConfigurationBeforeServiceStart(t *testing.T) {
+	directory := t.TempDir()
+	identityFile := filepath.Join(directory, "client-key")
+	authorityFile := filepath.Join(directory, "ca")
+	configurationFile := writeKeyExportCaTestConfiguration(t, directory, identityFile, authorityFile, true)
+
+	var ref configuration.Ref
+	require.NoError(t, ref.Set(configurationFile))
+	opts := keyExportCaOpts{configuration: ref, flow: "entry", output: "-"}
+	var stdout bytes.Buffer
+	require.NoError(t, doKeyExportCa(&opts, &stdout))
+
+	privateRaw, err := goos.ReadFile(authorityFile)
+	require.NoError(t, err)
+	private, err := ssh.ParsePrivateKey(privateRaw)
+	require.NoError(t, err)
+	public, comment, options, rest, err := ssh.ParseAuthorizedKey(stdout.Bytes())
+	require.NoError(t, err)
+	require.Empty(t, comment)
+	require.Empty(t, options)
+	require.Empty(t, bytes.TrimSpace(rest))
+	require.Equal(t, private.PublicKey().Marshal(), public.Marshal())
+	require.NoFileExists(t, authorityFile+".pub")
+	require.NoFileExists(t, identityFile)
+}
+
+func TestKeyExportCaFileIsNoClobberUnlessForced(t *testing.T) {
+	directory := t.TempDir()
+	authorityFile := filepath.Join(directory, "ca")
+	configurationFile := writeKeyExportCaTestConfiguration(t, directory, filepath.Join(directory, "client-key"), authorityFile, true)
+	var ref configuration.Ref
+	require.NoError(t, ref.Set(configurationFile))
+	output := filepath.Join(directory, "ca.pub")
+	opts := keyExportCaOpts{configuration: ref, flow: "entry", output: output}
+
+	require.NoError(t, doKeyExportCa(&opts, &bytes.Buffer{}))
+	require.Error(t, doKeyExportCa(&opts, &bytes.Buffer{}))
+	opts.force = true
+	require.NoError(t, doKeyExportCa(&opts, &bytes.Buffer{}))
+}
+
+func TestKeyExportCaDoesNotReplacePrivateKeyWithForce(t *testing.T) {
+	directory := t.TempDir()
+	authorityFile := filepath.Join(directory, "ca")
+	configurationFile := writeKeyExportCaTestConfiguration(t, directory, filepath.Join(directory, "client-key"), authorityFile, true)
+	var ref configuration.Ref
+	require.NoError(t, ref.Set(configurationFile))
+
+	err := doKeyExportCa(&keyExportCaOpts{configuration: ref, flow: "entry", output: authorityFile, force: true}, &bytes.Buffer{})
+	require.ErrorContains(t, err, "must not replace private key")
+	privateRaw, readErr := goos.ReadFile(authorityFile)
+	require.NoError(t, readErr)
+	_, parseErr := ssh.ParsePrivateKey(privateRaw)
+	require.NoError(t, parseErr)
+}
+
+func TestKeyExportCaRejectsUnknownOrInapplicableFlow(t *testing.T) {
+	directory := t.TempDir()
+	configurationFile := writeKeyExportCaTestConfiguration(t, directory, filepath.Join(directory, "client-key"), filepath.Join(directory, "ca"), false)
+	var ref configuration.Ref
+	require.NoError(t, ref.Set(configurationFile))
+
+	for _, flow := range []configuration.FlowName{"missing", "entry"} {
+		err := doKeyExportCa(&keyExportCaOpts{configuration: ref, flow: flow, output: "-"}, &bytes.Buffer{})
+		require.Error(t, err)
+	}
+}
+
+func writeKeyExportCaTestConfiguration(t *testing.T, directory, identityFile, authorityFile string, certificate bool) string {
+	t.Helper()
+	certificateYaml := ""
+	if certificate {
+		certificateYaml = fmt.Sprintf("      certificate:\n        identityFile: %s\n        authorityIdentityFile: %s\n", identityFile, authorityFile)
+	}
+	raw := fmt.Sprintf(`flows:
+  - name: entry
+    authorization:
+      type: simple
+    environment:
+      type: ssh
+      address: target.example.org
+      user: alice
+      acceptAllHostKeys: true
+%s`, certificateYaml)
+	path := filepath.Join(directory, "configuration.yaml")
+	require.NoError(t, goos.WriteFile(path, []byte(raw), 0600))
+	return path
+}

--- a/cmd/bifroest/key-export-host.go
+++ b/cmd/bifroest/key-export-host.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	goos "os"
+
+	"github.com/alecthomas/kingpin/v2"
+
+	"github.com/engity-com/bifroest/pkg/configuration"
+	bfcrypto "github.com/engity-com/bifroest/pkg/crypto"
+	"github.com/engity-com/bifroest/pkg/service"
+)
+
+type keyExportHostOpts struct {
+	configuration string
+	identityFile  string
+	address       string
+	output        string
+	force         bool
+}
+
+func registerKeyExportHostCmd(parent *kingpin.CmdClause) {
+	opts := keyExportHostOpts{output: "-"}
+
+	cmd := parent.Command("host", "Export SSH host keys as known_hosts entries without network access.").
+		Action(func(*kingpin.ParseContext) error {
+			return doKeyExportHost(&opts, goos.Stdout)
+		})
+	cmd.Flag("configuration", "Configuration to use when identityFile is absent. Default: "+defaultConfigurationRef).
+		Short('c').
+		PlaceHolder("<path>").
+		StringVar(&opts.configuration)
+	cmd.Flag("identityFile", "Host private key file to load or create instead of using a configuration.").
+		PlaceHolder("<path>").
+		StringVar(&opts.identityFile)
+	cmd.Flag("address", "Host represented by the host key; port defaults to 22.").
+		Required().
+		PlaceHolder("<host[:port]>").
+		StringVar(&opts.address)
+	cmd.Flag("output", "Output file or - for stdout.").
+		Default(opts.output).
+		PlaceHolder("<path|->").
+		StringVar(&opts.output)
+	cmd.Flag("force", "Replace an existing output file.").
+		BoolVar(&opts.force)
+}
+
+func doKeyExportHost(opts *keyExportHostOpts, stdout io.Writer) error {
+	if opts == nil {
+		return fmt.Errorf("nil options")
+	}
+	if opts.configuration != "" && opts.identityFile != "" {
+		return fmt.Errorf("configuration and identityFile cannot be combined")
+	}
+	var keys []bfcrypto.PrivateKey
+	var identityFiles []string
+	if opts.identityFile != "" {
+		key, err := bfcrypto.EnsureKeyFile(opts.identityFile, &bfcrypto.KeyRequirement{Type: bfcrypto.KeyTypeEd25519}, nil)
+		if err != nil {
+			return err
+		}
+		keys = []bfcrypto.PrivateKey{key}
+		identityFiles = []string{opts.identityFile}
+	} else {
+		configurationFile := opts.configuration
+		if configurationFile == "" {
+			configurationFile = defaultConfigurationRef
+		}
+		var ref configuration.Ref
+		if err := ref.Set(configurationFile); err != nil {
+			return err
+		}
+		var err error
+		if keys, identityFiles, err = service.EnsureHostPrivateKeysWithPaths(ref.Get()); err != nil {
+			return err
+		}
+	}
+	if err := ensureBootstrapOutputIsNotPrivateKey(opts.output, identityFiles...); err != nil {
+		return err
+	}
+	raw, err := bfcrypto.ExportKnownHostKeys(keys, opts.address)
+	if err != nil {
+		return err
+	}
+	return writeBootstrapOutput(opts.output, raw, opts.force, stdout)
+}

--- a/cmd/bifroest/key-export-host_test.go
+++ b/cmd/bifroest/key-export-host_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	goos "os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestKeyExportHostCreatesExplicitKeyAndUsesNoClobber(t *testing.T) {
+	directory := t.TempDir()
+	identityFile := filepath.Join(directory, "identity")
+
+	hostKeyFile := filepath.Join(directory, "host-key")
+	opts := keyExportHostOpts{identityFile: identityFile, address: "host.example", output: hostKeyFile}
+	require.NoError(t, doKeyExportHost(&opts, &bytes.Buffer{}))
+	require.FileExists(t, identityFile)
+	require.Error(t, doKeyExportHost(&opts, &bytes.Buffer{}))
+}
+
+func TestKeyExportHostDoesNotReplacePrivateKeyWithForce(t *testing.T) {
+	identityFile := filepath.Join(t.TempDir(), "identity")
+	opts := keyExportHostOpts{identityFile: identityFile, address: "host.example", output: identityFile, force: true}
+
+	err := doKeyExportHost(&opts, &bytes.Buffer{})
+	require.ErrorContains(t, err, "must not replace private key")
+	privateRaw, readErr := goos.ReadFile(identityFile)
+	require.NoError(t, readErr)
+	_, parseErr := ssh.ParsePrivateKey(privateRaw)
+	require.NoError(t, parseErr)
+}
+
+func TestKeyExportHostUsesAndCreatesAllConfiguredHostKeys(t *testing.T) {
+	directory := t.TempDir()
+	first := filepath.Join(directory, "first")
+	second := filepath.Join(directory, "second")
+	configurationFile := filepath.Join(directory, "configuration.yaml")
+	raw := fmt.Sprintf(`ssh:
+  keys:
+    hostKeys:
+      - %s
+      - %s
+flows:
+  - name: test
+    authorization:
+      type: simple
+    environment:
+      type: dummy
+`, first, second)
+	require.NoError(t, goos.WriteFile(configurationFile, []byte(raw), 0600))
+
+	var stdout bytes.Buffer
+	opts := keyExportHostOpts{configuration: configurationFile, address: "host.example", output: "-"}
+	require.NoError(t, doKeyExportHost(&opts, &stdout))
+	require.FileExists(t, first)
+	require.FileExists(t, second)
+
+	remaining := stdout.Bytes()
+	for range 2 {
+		_, hosts, _, _, rest, err := ssh.ParseKnownHosts(remaining)
+		require.NoError(t, err)
+		require.Equal(t, []string{"host.example"}, hosts)
+		remaining = rest
+	}
+	require.Empty(t, bytes.TrimSpace(remaining))
+
+	opts.output = first
+	opts.force = true
+	require.ErrorContains(t, doKeyExportHost(&opts, &bytes.Buffer{}), "must not replace private key")
+}
+
+func TestKeyExportHostRejectsConfigurationWithIdentityFile(t *testing.T) {
+	err := doKeyExportHost(&keyExportHostOpts{
+		configuration: "configuration.yaml",
+		identityFile:  "identity",
+		address:       "host.example",
+		output:        "-",
+	}, &bytes.Buffer{})
+	require.ErrorContains(t, err, "cannot be combined")
+}
+
+func TestKeyExportHostProtectsRenderedPrivateKeyPath(t *testing.T) {
+	directory := t.TempDir()
+	identityFile := filepath.Join(directory, "host-key")
+	configurationFile := filepath.Join(directory, "configuration.yaml")
+	raw := fmt.Sprintf(`ssh:
+  keys:
+    hostKeys:
+      - '{{if .}}%s{{end}}'
+flows:
+  - name: test
+    authorization:
+      type: simple
+    environment:
+      type: dummy
+`, identityFile)
+	require.NoError(t, goos.WriteFile(configurationFile, []byte(raw), 0600))
+
+	err := doKeyExportHost(&keyExportHostOpts{
+		configuration: configurationFile,
+		address:       "host.example",
+		output:        identityFile,
+		force:         true,
+	}, &bytes.Buffer{})
+	require.ErrorContains(t, err, "must not replace private key")
+	privateRaw, readErr := goos.ReadFile(identityFile)
+	require.NoError(t, readErr)
+	_, parseErr := ssh.ParsePrivateKey(privateRaw)
+	require.NoError(t, parseErr)
+}

--- a/cmd/bifroest/key-export-public.go
+++ b/cmd/bifroest/key-export-public.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"io"
+	goos "os"
+
+	"github.com/alecthomas/kingpin/v2"
+
+	bfcrypto "github.com/engity-com/bifroest/pkg/crypto"
+)
+
+func registerKeyExportPublicCmd(parent *kingpin.CmdClause) {
+	var identityFile string
+	var comment string
+	output := "-"
+	var force bool
+
+	cmd := parent.Command("public", "Export the public key of a local private key.").
+		Action(func(*kingpin.ParseContext) error {
+			return doKeyExportPublic(identityFile, comment, output, force, goos.Stdout)
+		})
+	cmd.Flag("identityFile", "Private key file to read.").
+		Required().
+		PlaceHolder("<path>").
+		StringVar(&identityFile)
+	cmd.Flag("comment", "Optional public key comment.").
+		PlaceHolder("<text>").
+		StringVar(&comment)
+	cmd.Flag("output", "Output file or - for stdout.").
+		Default(output).
+		PlaceHolder("<path|->").
+		StringVar(&output)
+	cmd.Flag("force", "Replace an existing output file.").
+		BoolVar(&force)
+}
+
+func doKeyExportPublic(identityFile, comment, output string, force bool, stdout io.Writer) error {
+	if err := ensureBootstrapOutputIsNotPrivateKey(output, identityFile); err != nil {
+		return err
+	}
+	raw, err := bfcrypto.ExportPublicKey(identityFile, comment)
+	if err != nil {
+		return err
+	}
+	return writeBootstrapOutput(output, raw, force, stdout)
+}

--- a/cmd/bifroest/key-export-public_test.go
+++ b/cmd/bifroest/key-export-public_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bytes"
+	goos "os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestKeyExportPublicWritesOnlyPublicMaterial(t *testing.T) {
+	identityFile := filepath.Join(t.TempDir(), "identity")
+	require.NoError(t, doKeyGenerate(identityFile, ""))
+
+	var stdout bytes.Buffer
+	require.NoError(t, doKeyExportPublic(identityFile, "test", "-", false, &stdout))
+	_, comment, _, rest, err := ssh.ParseAuthorizedKey(stdout.Bytes())
+	require.NoError(t, err)
+	require.Equal(t, "test", comment)
+	require.Empty(t, bytes.TrimSpace(rest))
+	require.NotContains(t, stdout.String(), "PRIVATE KEY")
+}
+
+func TestKeyExportPublicDoesNotReplacePrivateKeyWithForce(t *testing.T) {
+	identityFile := filepath.Join(t.TempDir(), "identity")
+	require.NoError(t, doKeyGenerate(identityFile, ""))
+	before, err := goos.ReadFile(identityFile)
+	require.NoError(t, err)
+
+	err = doKeyExportPublic(identityFile, "", identityFile, true, &bytes.Buffer{})
+	require.ErrorContains(t, err, "must not replace private key")
+	after, err := goos.ReadFile(identityFile)
+	require.NoError(t, err)
+	require.Equal(t, before, after)
+}

--- a/cmd/bifroest/key-export.go
+++ b/cmd/bifroest/key-export.go
@@ -1,0 +1,11 @@
+package main
+
+import "github.com/alecthomas/kingpin/v2"
+
+func registerKeyExportCmd(parent *kingpin.CmdClause) {
+	cmd := parent.Command("export", "Export SSH public key material.")
+
+	registerKeyExportPublicCmd(cmd)
+	registerKeyExportCaCmd(cmd)
+	registerKeyExportHostCmd(cmd)
+}

--- a/cmd/bifroest/key-generate.go
+++ b/cmd/bifroest/key-generate.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	crand "crypto/rand"
+	"errors"
+	"fmt"
+	"io/fs"
+	goos "os"
+	"path/filepath"
+
+	"github.com/alecthomas/kingpin/v2"
+
+	bfcrypto "github.com/engity-com/bifroest/pkg/crypto"
+)
+
+func registerKeyGenerateCmd(parent *kingpin.CmdClause) {
+	var identityFile string
+	var publicFile string
+
+	cmd := parent.Command("generate", "Generate an Ed25519 private key without replacing an existing file.").
+		Action(func(*kingpin.ParseContext) error {
+			return doKeyGenerate(identityFile, publicFile)
+		})
+	cmd.Flag("identityFile", "Private key file to create.").
+		Required().
+		PlaceHolder("<path>").
+		StringVar(&identityFile)
+	cmd.Flag("publicFile", "Optional public key file to create.").
+		PlaceHolder("<path>").
+		StringVar(&publicFile)
+}
+
+func doKeyGenerate(identityFile, publicFile string) error {
+	if publicFile != "" {
+		identityPath, err := filepath.Abs(identityFile)
+		if err != nil {
+			return fmt.Errorf("cannot resolve private key path %q: %w", identityFile, err)
+		}
+		publicPath, err := filepath.Abs(publicFile)
+		if err != nil {
+			return fmt.Errorf("cannot resolve public key path %q: %w", publicFile, err)
+		}
+		if identityPath == publicPath {
+			return fmt.Errorf("private and public key files have to be different")
+		}
+		if _, err := goos.Lstat(publicFile); err == nil {
+			return fmt.Errorf("public key file %q already exists", publicFile)
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("cannot inspect public key file %q: %w", publicFile, err)
+		}
+	}
+	key, err := (bfcrypto.KeyRequirement{Type: bfcrypto.KeyTypeEd25519}).CreateFile(crand.Reader, identityFile)
+	if err != nil {
+		return err
+	}
+	if publicFile == "" {
+		return nil
+	}
+	if err := bfcrypto.WriteBootstrapFile(publicFile, bfcrypto.MarshalPublicKey(key.PublicKey()), false); err != nil {
+		return fmt.Errorf("private key was created at %q but the public key cannot be written: %w", identityFile, err)
+	}
+	return nil
+}

--- a/cmd/bifroest/key-generate_test.go
+++ b/cmd/bifroest/key-generate_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	goos "os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestKeyGenerateKeepsPrivateMaterialOffPublicFile(t *testing.T) {
+	directory := t.TempDir()
+	identityFile := filepath.Join(directory, "identity")
+	publicFile := filepath.Join(directory, "identity.pub")
+
+	require.NoError(t, doKeyGenerate(identityFile, publicFile))
+	require.Error(t, doKeyGenerate(identityFile, publicFile))
+
+	privateRaw, err := goos.ReadFile(identityFile)
+	require.NoError(t, err)
+	private, err := ssh.ParsePrivateKey(privateRaw)
+	require.NoError(t, err)
+	publicRaw, err := goos.ReadFile(publicFile)
+	require.NoError(t, err)
+	public, _, _, rest, err := ssh.ParseAuthorizedKey(publicRaw)
+	require.NoError(t, err)
+	require.Empty(t, bytes.TrimSpace(rest))
+	require.Equal(t, private.PublicKey().Marshal(), public.Marshal())
+	require.NotContains(t, string(publicRaw), "PRIVATE KEY")
+}
+
+func TestKeyGenerateWithoutPublicFile(t *testing.T) {
+	identityFile := filepath.Join(t.TempDir(), "identity")
+	require.NoError(t, doKeyGenerate(identityFile, ""))
+	require.FileExists(t, identityFile)
+}
+
+func TestKeyGenerateRejectsPublicFileBeforeCreatingPrivateKey(t *testing.T) {
+	directory := t.TempDir()
+	identityFile := filepath.Join(directory, "identity")
+	publicFile := filepath.Join(directory, "identity.pub")
+	require.NoError(t, goos.WriteFile(publicFile, []byte("existing"), 0600))
+
+	require.Error(t, doKeyGenerate(identityFile, publicFile))
+	require.NoFileExists(t, identityFile)
+	actual, err := goos.ReadFile(publicFile)
+	require.NoError(t, err)
+	require.Equal(t, []byte("existing"), actual)
+}
+
+func TestKeyGenerateRejectsSamePrivateAndPublicFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "identity")
+	require.Error(t, doKeyGenerate(path, path))
+	require.NoFileExists(t, path)
+}

--- a/cmd/bifroest/key-import-ca.go
+++ b/cmd/bifroest/key-import-ca.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"io"
+	goos "os"
+
+	"github.com/alecthomas/kingpin/v2"
+
+	bfcrypto "github.com/engity-com/bifroest/pkg/crypto"
+)
+
+func registerKeyImportCaCmd(parent *kingpin.CmdClause) {
+	var trustedCAsFile string
+	input := "-"
+	var expectedFingerprint string
+
+	cmd := parent.Command("ca", "Validate and atomically merge trusted SSH certificate authority keys.").
+		Action(func(*kingpin.ParseContext) error {
+			return doKeyImportCa(trustedCAsFile, input, expectedFingerprint, goos.Stdin)
+		})
+	cmd.Flag("trustedCAsFile", "Trusted SSH certificate authority file to update.").
+		Required().
+		PlaceHolder("<path>").
+		StringVar(&trustedCAsFile)
+	cmd.Flag("input", "Input file or - for stdin.").
+		Default(input).
+		PlaceHolder("<path|->").
+		StringVar(&input)
+	cmd.Flag("expectedFingerprint", "Expected SHA256 fingerprint or unknown.").
+		PlaceHolder("<SHA256:...|unknown>").
+		StringVar(&expectedFingerprint)
+}
+
+func doKeyImportCa(trustedCAsFile, input, expectedFingerprint string, stdin io.Reader) error {
+	raw, err := readBootstrapInput(input, stdin)
+	if err != nil {
+		return err
+	}
+	expectedFingerprint = normalizeUnknownFingerprint(expectedFingerprint)
+	_, err = bfcrypto.ImportCertificateAuthoritiesFile(trustedCAsFile, raw, expectedFingerprint)
+	return err
+}

--- a/cmd/bifroest/key-import-ca_test.go
+++ b/cmd/bifroest/key-import-ca_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyImportCaMergesCertificateAuthorities(t *testing.T) {
+	directory := t.TempDir()
+	identityFile := filepath.Join(directory, "ca")
+	require.NoError(t, doKeyGenerate(identityFile, ""))
+	var public bytes.Buffer
+	require.NoError(t, doKeyExportPublic(identityFile, "", "-", false, &public))
+
+	trustedCAsFile := filepath.Join(directory, "trusted-cas")
+	require.NoError(t, doKeyImportCa(trustedCAsFile, "-", "", bytes.NewReader(public.Bytes())))
+	require.NoError(t, doKeyImportCa(trustedCAsFile, "-", "", bytes.NewReader(public.Bytes())))
+	require.FileExists(t, trustedCAsFile)
+}

--- a/cmd/bifroest/key-import-host.go
+++ b/cmd/bifroest/key-import-host.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	goos "os"
+	"strings"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	log "github.com/echocat/slf4g"
+
+	bfcrypto "github.com/engity-com/bifroest/pkg/crypto"
+)
+
+const keyImportHostNetworkTimeout = 10 * time.Second
+
+type keyImportHostOpts struct {
+	knownHostsFile      string
+	input               string
+	address             string
+	expectedFingerprint string
+}
+
+func registerKeyImportHostCmd(parent *kingpin.CmdClause) {
+	var opts keyImportHostOpts
+
+	cmd := parent.Command("host", "Import SSH host keys from a file, stdin or a server.").
+		Action(func(*kingpin.ParseContext) error {
+			return doKeyImportHost(&opts, goos.Stdin)
+		})
+	cmd.Flag("knownHostsFile", "Known hosts file to update.").
+		Required().
+		PlaceHolder("<path>").
+		StringVar(&opts.knownHostsFile)
+	cmd.Flag("input", "Input file or - for stdin; cannot be combined with address.").
+		PlaceHolder("<path|->").
+		StringVar(&opts.input)
+	cmd.Flag("address", "SSH server to retrieve a host key from; port defaults to 22.").
+		PlaceHolder("<host[:port]>").
+		StringVar(&opts.address)
+	cmd.Flag("expectedFingerprint", "Expected SHA256 fingerprint or unknown.").
+		PlaceHolder("<SHA256:...|unknown>").
+		StringVar(&opts.expectedFingerprint)
+}
+
+func doKeyImportHost(opts *keyImportHostOpts, stdin io.Reader) error {
+	if opts == nil {
+		return fmt.Errorf("nil options")
+	}
+	if opts.address != "" && opts.input != "" {
+		return fmt.Errorf("address and input cannot be combined")
+	}
+	expectedFingerprint := strings.TrimSpace(opts.expectedFingerprint)
+	var raw []byte
+	var err error
+	if opts.address != "" {
+		if expectedFingerprint == "" {
+			return fmt.Errorf("expectedFingerprint is required with address; use unknown to explicitly accept an unverified host key")
+		}
+		if expectedFingerprint == "unknown" {
+			log.With("address", opts.address).Warn("The host key fingerprint is unknown; trusting a key retrieved from the network is potentially unsafe")
+			expectedFingerprint = ""
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), keyImportHostNetworkTimeout)
+		defer cancel()
+		raw, err = bfcrypto.FetchKnownHostKey(ctx, opts.address)
+	} else {
+		input := opts.input
+		if input == "" {
+			input = "-"
+		}
+		raw, err = readBootstrapInput(input, stdin)
+		expectedFingerprint = normalizeUnknownFingerprint(expectedFingerprint)
+	}
+	if err != nil {
+		return err
+	}
+	_, err = bfcrypto.ImportKnownHostsFile(opts.knownHostsFile, raw, expectedFingerprint)
+	return err
+}
+
+func normalizeUnknownFingerprint(value string) string {
+	if strings.TrimSpace(value) == "unknown" {
+		return ""
+	}
+	return strings.TrimSpace(value)
+}

--- a/cmd/bifroest/key-import-host_test.go
+++ b/cmd/bifroest/key-import-host_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"net"
+	goos "os"
+	"path/filepath"
+	"testing"
+
+	"github.com/echocat/slf4g/sdk/testlog"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestKeyImportHostUsesExplicitInputAndIsIdempotent(t *testing.T) {
+	directory := t.TempDir()
+	identityFile := filepath.Join(directory, "identity")
+	require.NoError(t, doKeyGenerate(identityFile, ""))
+	hostKeyFile := filepath.Join(directory, "host-key")
+	require.NoError(t, doKeyExportHost(&keyExportHostOpts{identityFile: identityFile, address: "host.example", output: hostKeyFile}, &bytes.Buffer{}))
+
+	knownHostsFile := filepath.Join(directory, "known-hosts")
+	require.NoError(t, doKeyImportHost(&keyImportHostOpts{knownHostsFile: knownHostsFile, input: hostKeyFile}, bytes.NewReader([]byte("unused"))))
+	first, err := goos.ReadFile(knownHostsFile)
+	require.NoError(t, err)
+	require.NoError(t, doKeyImportHost(&keyImportHostOpts{knownHostsFile: knownHostsFile, expectedFingerprint: "unknown"}, bytes.NewReader(first)))
+	second, err := goos.ReadFile(knownHostsFile)
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+}
+
+func TestKeyImportHostRetrievesKeyFromAddress(t *testing.T) {
+	address, key, serverDone := startKeyImportHostTestServer(t)
+	knownHostsFile := filepath.Join(t.TempDir(), "known-hosts")
+	opts := keyImportHostOpts{
+		knownHostsFile:      knownHostsFile,
+		address:             address,
+		expectedFingerprint: ssh.FingerprintSHA256(key),
+	}
+	require.NoError(t, doKeyImportHost(&opts, &bytes.Buffer{}))
+	require.Error(t, <-serverDone)
+	require.FileExists(t, knownHostsFile)
+}
+
+func TestKeyImportHostAllowsExplicitUnknownFingerprint(t *testing.T) {
+	testlog.Hook(t)
+	address, _, serverDone := startKeyImportHostTestServer(t)
+	knownHostsFile := filepath.Join(t.TempDir(), "known-hosts")
+	opts := keyImportHostOpts{
+		knownHostsFile:      knownHostsFile,
+		address:             address,
+		expectedFingerprint: "unknown",
+	}
+	require.NoError(t, doKeyImportHost(&opts, &bytes.Buffer{}))
+	require.Error(t, <-serverDone)
+	require.FileExists(t, knownHostsFile)
+}
+
+func TestKeyImportHostRequiresNetworkFingerprintAndRejectsInput(t *testing.T) {
+	for _, opts := range []keyImportHostOpts{
+		{knownHostsFile: "known-hosts", address: "host.example"},
+		{knownHostsFile: "known-hosts", address: "host.example", input: "input", expectedFingerprint: "unknown"},
+	} {
+		require.Error(t, doKeyImportHost(&opts, &bytes.Buffer{}))
+	}
+}
+
+func TestKeyImportHostFingerprintMismatchDoesNotCreateFile(t *testing.T) {
+	address, _, serverDone := startKeyImportHostTestServer(t)
+	knownHostsFile := filepath.Join(t.TempDir(), "known-hosts")
+	opts := keyImportHostOpts{
+		knownHostsFile:      knownHostsFile,
+		address:             address,
+		expectedFingerprint: "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+	}
+	require.Error(t, doKeyImportHost(&opts, &bytes.Buffer{}))
+	require.Error(t, <-serverDone)
+	require.NoFileExists(t, knownHostsFile)
+}
+
+func startKeyImportHostTestServer(t *testing.T) (string, ssh.PublicKey, <-chan error) {
+	t.Helper()
+	_, private, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(private)
+	require.NoError(t, err)
+	config := &ssh.ServerConfig{NoClientAuth: true}
+	config.AddHostKey(signer)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+	serverDone := make(chan error, 1)
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			serverDone <- acceptErr
+			return
+		}
+		defer connection.Close()
+		server, _, _, serverErr := ssh.NewServerConn(connection, config)
+		if server != nil {
+			_ = server.Close()
+		}
+		serverDone <- serverErr
+	}()
+	return listener.Addr().String(), signer.PublicKey(), serverDone
+}

--- a/cmd/bifroest/key-import.go
+++ b/cmd/bifroest/key-import.go
@@ -1,0 +1,10 @@
+package main
+
+import "github.com/alecthomas/kingpin/v2"
+
+func registerKeyImportCmd(parent *kingpin.CmdClause) {
+	cmd := parent.Command("import", "Import trusted SSH public key material.")
+
+	registerKeyImportCaCmd(cmd)
+	registerKeyImportHostCmd(cmd)
+}

--- a/cmd/bifroest/key.go
+++ b/cmd/bifroest/key.go
@@ -1,0 +1,11 @@
+package main
+
+import "github.com/alecthomas/kingpin/v2"
+
+var _ = registerCommand(func(app *kingpin.Application) {
+	cmd := app.Command("key", "Generate, export and import SSH keys.")
+
+	registerKeyGenerateCmd(cmd)
+	registerKeyExportCmd(cmd)
+	registerKeyImportCmd(cmd)
+})

--- a/cmd/bifroest/run_unix.go
+++ b/cmd/bifroest/run_unix.go
@@ -18,11 +18,7 @@ func configureRunCmd(app *kingpin.Application) *kingpin.Application {
 		Action(func(*kingpin.ParseContext) error {
 			return doRun(conf)
 		})
-	cmd.Flag("configuration", "Configuration which should be used to serve the service. Default: "+defaultConfigurationRef).
-		Short('c').
-		Default(defaultConfigurationRef).
-		PlaceHolder("<path>").
-		SetValue(&conf)
+	registerConfigurationFlag(cmd, &conf)
 	return app
 }
 

--- a/cmd/bifroest/run_windows.go
+++ b/cmd/bifroest/run_windows.go
@@ -26,11 +26,7 @@ func configureRunCmd(app *kingpin.Application) *kingpin.Application {
 		Action(func(*kingpin.ParseContext) error {
 			return doRun(conf, &ws)
 		})
-	cmd.Flag("configuration", "Configuration which should be used to serve the service. Default: "+defaultConfigurationRef).
-		Short('c').
-		Default(defaultConfigurationRef).
-		PlaceHolder("<path>").
-		SetValue(&conf)
+	registerConfigurationFlag(cmd, &conf)
 	ws.registerFlagsAt(cmd)
 	return app
 

--- a/cmd/bifroest/service_windows.go
+++ b/cmd/bifroest/service_windows.go
@@ -48,11 +48,7 @@ var _ = registerCommand(func(app *kingpin.Application) {
 		return svc.registerFlagsAt(cmd)
 	}
 	withConfig := func(cmd *kingpin.CmdClause) *kingpin.CmdClause {
-		cmd.Flag("configuration", "Configuration which should be used to serve the service. Default: "+defaultConfigurationRef).
-			Short('c').
-			Default(defaultConfigurationRef).
-			PlaceHolder("<path>").
-			SetValue(&conf)
+		registerConfigurationFlag(cmd, &conf)
 		return common(cmd)
 	}
 

--- a/docs/reference/authorization/bifroest.md
+++ b/docs/reference/authorization/bifroest.md
@@ -1,0 +1,131 @@
+---
+toc_depth: 4
+description: Authorize certificate-based delegation from another Bifröst instance.
+---
+
+# Bifröst authorization
+
+Authorizes an SSH connection delegated by another Bifröst instance. This authorization accepts only OpenSSH user certificates carrying Bifröst's signed delegation evidence. Password and keyboard-interactive authentication are always rejected.
+
+## Properties
+
+<<property("type", "Authorization Type", default="bifroest", required=True)>>
+Has to be set to `bifroest` to enable Bifröst delegation authorization.
+
+<<property("trustedUserCAs", "Public Keys", "../data-type.md#public-keys")>>
+OpenSSH public keys of the immediately upstream Bifröst certificate authorities. At least this property or [`trustedUserCAsFile`](#property-trustedUserCAsFile) is required.
+
+<<property("trustedUserCAsFile", ref("File Path", "../data-type.md#file-path", ref("Public Keys", "../data-type.md#public-keys")))>>
+Same as [`trustedUserCAs`](#property-trustedUserCAs), but loaded from one file when the authorization is initialized. Both properties can be used together. A configured file must exist and contain at least one valid public key.
+
+<<property("audiences", "list of strings")>>
+Accepted delegation audiences. If omitted, only the name of the local flow is accepted. An explicitly configured non-empty list replaces that default; an explicitly empty list is invalid.
+
+<<property("maxCertificateValidity", "Duration", "../data-type.md#duration", default="15m")>>
+Maximum interval from the evidence issuance time to the certificate's immutable `ValidBefore` boundary. Certificates exceeding this limit are rejected.
+
+## Validation
+
+The presented credential has to satisfy all of these conditions:
+
+* It is a current OpenSSH user certificate signed by a configured immediately upstream CA.
+* The requested SSH username is one of its principals.
+* Its only critical option is `bifroest-delegation@bifroest.engity.org` with an empty value.
+* It contains canonical `bifroest.authorization-evidence/v1` under `evidence-v1@bifroest.engity.org`.
+* The final evidence hop matches the certificate CA, subject key, serial, key ID, validity, target user and effective forwarding capabilities.
+* The final audience is accepted and the original authorization was authenticated.
+* The evidence is at most 4 KiB, has at most eight hops and contains no repeated subject-key fingerprint.
+* Every downstream hop can only shorten validity and remove PTY, port-forwarding or agent-forwarding capabilities.
+
+The evidence is verified again after the SSH client proves possession of the certificate subject key. No session is created before that proof succeeds.
+
+## Example: Entry Gateway to Target Gateway
+
+**Bifröst A** sits between the Internet and the internal network. It authenticates `alice` with `simple`; internal **Bifröst B** is not Internet-accessible and trusts delegations from A.
+
+1. Configure A:
+
+    ```yaml title="/etc/engity/bifroest/configuration.yaml"
+    flows:
+      - name: to-target
+        authorization:
+          type: simple
+          entries:
+            - name: alice
+              password: plain:change-me
+        environment:
+          type: ssh
+          address: target.example.org
+          user: '{{ .session.created.remote.user }}'
+          knownHostsFile: /etc/engity/bifroest/known_hosts
+          certificate:
+            audience: from-entry
+            extensions:
+              permit-pty: ""
+              permit-port-forwarding: ""
+              permit-agent-forwarding: ""
+    ```
+
+    !!! warning
+         The plain password is only for this minimal example. Use a password hash or another authorization in production.
+
+2. Configure B:
+    ```yaml title="/etc/engity/bifroest/configuration.yaml"
+    flows:
+      - name: from-entry
+        authorization:
+          type: bifroest
+          trustedUserCAsFile: /etc/engity/bifroest/trusted-cas
+        environment:
+          type: local
+    ```
+
+3. Run on B:
+    ```shell
+    bifroest key export host \
+      --identityFile /etc/engity/bifroest/key \
+      --address target.example.org
+    ```
+4. To trust B, run on A:
+    ```shell
+    echo "<output of command executed on B>" | bifroest key import host \
+      --knownHostsFile /etc/engity/bifroest/known_hosts
+    ```
+
+5. Export A's CA before its first start:
+    ```shell
+    bifroest key export ca \
+      -c /etc/engity/bifroest/configuration.yaml \
+      to-target
+    ```
+
+    !!! note
+         `bifroest key export ca` creates A's missing CA without creating a `.pub` companion file. The same CA is used when A starts.
+
+6. To trust the CA of A, run on B:
+    ```shell
+    echo "<output of command executed on A>" | bifroest key import ca \
+      --trustedCAsFile /etc/engity/bifroest/trusted-cas
+    ```
+
+7. Start B:
+    ```shell
+    bifroest run -c /etc/engity/bifroest/configuration.yaml
+    ```
+
+8. Start A:
+    ```shell
+    bifroest run -c /etc/engity/bifroest/configuration.yaml
+    ```
+
+B verifies A's CA signature, the `from-entry` audience, the signed evidence and possession of A's persistent `client-key`.
+
+## Context
+
+This authorization produces a context of type [Authorization Bifröst](../context/authorization.md#bifroest).
+
+## Compatibility
+
+| <<dist("linux")>> | <<dist("windows")>> |
+| - | - |
+| <<compatibility_editions(True,True,"linux")>> | <<compatibility_editions(True,None,"windows")>> |

--- a/docs/reference/authorization/index.md
+++ b/docs/reference/authorization/index.md
@@ -12,7 +12,8 @@ Everything in Bifröst starts here. Firstly, a user must be authorized. Bifröst
 2. `oidc`: [OpenID Connect (OIDC)](oidc.md)
 3. `simple`: [Simple](simple.md)
 4. `htpasswd`: [Htpasswd](htpasswd.md)
-5. `none`: [None](none.md)
+5. `bifroest`: [Bifröst delegation](bifroest.md)
+6. `none`: [None](none.md)
 
 ## Examples
 

--- a/docs/reference/authorization/local.md
+++ b/docs/reference/authorization/local.md
@@ -14,8 +14,16 @@ Authorizes a user request via the local user database of the host on which Bifr√
 <<property("type", "Authorization Type", default="local", required=True)>>
 Has to be set to `local` to enable the local authorization.
 
+<<property("trustedUserCAs", "Public Keys", "../data-type.md#public-keys")>>
+OpenSSH public keys of certificate authorities that may sign user certificates for existing local users. The requested SSH username must be included in the certificate's principals.
+
+<<property("trustedUserCAsFile", ref("File Path", "../data-type.md#file-path", ref("Public Keys", "../data-type.md#public-keys")))>>
+Same as [`trustedUserCAs`](#property-trustedUserCAs), but loaded from one file when the authorization is initialized. Both properties can be used together. A configured file must exist and contain at least one valid public key.
+
 <<property("authorizedKeys", array_ref("File Path", "../data-type.md#file-path", ref("Authorized Keys", "../data-type.md#authorized-keys")), template_context="../context/core.md", default=["{{.user.homeDir}}/.ssh/authorized_keys"])>>
 Contains files with the format of classic [authorized keys](../data-type.md#authorized-keys), in which Bifr√∂st will look for [SSH Public Keys](../data-type.md#ssh-public-key).
+
+An entry with the `cert-authority` option treats its key as a user certificate authority for that local user. The optional `principals="..."` option restricts it further. An empty `authorizedKeys` list does not disable certificate authentication through `trustedUserCAs` or `trustedUserCAsFile`.
 
 <<property("password", "Password", "#password")>>
 See [below](#password).
@@ -52,6 +60,15 @@ If `true`, the user is allowed to use empty passwords.
 This authorization will produce a context of type [Authorization Local](../context/authorization.md#local).
 
 ## Examples
+
+```yaml
+type: local
+trustedUserCAsFile: /etc/engity/bifroest/trusted-user-cas
+authorizedKeys:
+  - "{{.user.homeDir}}/.ssh/authorized_keys"
+```
+
+User certificates must be current, signed by the selected CA, have the requested SSH username as a principal, and contain no critical options. Missing `permit-pty`, `permit-port-forwarding`, or `permit-agent-forwarding` certificate extensions disable the corresponding capability. Authorized-key options can only restrict these capabilities further.
 
 ## Compatibility
 

--- a/docs/reference/authorization/simple.md
+++ b/docs/reference/authorization/simple.md
@@ -12,17 +12,25 @@ Authorizes a user request via stored credentials.
 <<property("type", "Authorization Type", default="simple", required=True)>>
 Has to be set to `simple` to enable simple authorization.
 
+<<property("trustedUserCAs", "Public Keys", "../data-type.md#public-keys")>>
+OpenSSH public keys of certificate authorities that may sign user certificates for every entry in this authorization. The requested SSH username must be included in the certificate's principals.
+
+<<property("trustedUserCAsFile", ref("File Path", "../data-type.md#file-path", ref("Public Keys", "../data-type.md#public-keys")))>>
+Same as [`trustedUserCAs`](#property-trustedUserCAs), but loaded from one file when the authorization is initialized. Both properties can be used together. A configured file must exist and contain at least one valid public key.
+
 <<property("entries", array_ref("Entry", "#entry"))>>
 Each entry will be inspected to check if a remote user should be authorized.
 
 ## Entry
 
-Always one property of the following properties has to match in combination with [`name`](#entry-property-name):
+One of the following properties normally has to match in combination with [`name`](#entry-property-name):
 
 * [`authorizedKeys`](#entry-property-authorizedKeys)
 * [`authorizedKeysFile`](#entry-property-authorizedKeysFile)
 * [`password`](#entry-property-password)
 * [`passwordFile`](#entry-property-passwordFile)
+
+An entry containing only `name` can additionally be authenticated by a user certificate signed by [`trustedUserCAs`](#property-trustedUserCAs) or [`trustedUserCAsFile`](#property-trustedUserCAsFile).
 
 ### Properties {: #entry-properties }
 
@@ -33,6 +41,8 @@ Like: `ssh <name>@my-great-domain.tld` to match this entry.
 
 <<property("authorizedKeys", "Authorized Keys", "../data-type.md#authorized-keys", id_prefix="entry-", heading=4)>>
 Contains [SSH Public Keys](../data-type.md#ssh-public-key) in the format of classic [authorized keys](../data-type.md#authorized-keys).
+
+An entry with the `cert-authority` option treats its key as a user certificate authority for this simple entry. The optional `principals="..."` option restricts it further.
 
 <<property("authorizedKeysFile", ref("File Path", "../data-type.md#file-path", ref("Authorized Keys", "../data-type.md#authorized-keys")), id_prefix="entry-", heading=4)>>
 Similar to [`authorizedKeys`](#entry-property-authorizedKeys), but in a dedicated file.
@@ -71,8 +81,18 @@ This authorization will produce a context of type [Authorization Simple](../cont
    entries:
      - name: foo
        authorizedKeys: |
-         ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC80lm5FQbbyRUut6RwZJRbxTLO3W4f08ITDi9fA3+jx foo@foo.tld
+          ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC80lm5FQbbyRUut6RwZJRbxTLO3W4f08ITDi9fA3+jx foo@foo.tld
+    ```
+3. Using an OpenSSH user certificate authority:
+   ```yaml
+   type: simple
+   trustedUserCAs: |
+     ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleOrganizationCA
+   entries:
+     - name: foo
    ```
+
+User certificates must be current, signed by the selected CA, have the requested SSH username as a principal, and contain no critical options. Missing `permit-pty`, `permit-port-forwarding`, or `permit-agent-forwarding` certificate extensions disable the corresponding capability. Authorized-key options can only restrict these capabilities further.
 
 ## Compatibility
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -29,6 +29,144 @@ Syntax: `bifroest verion [flags]`
 
 Includes [all general flags](#general-flags).
 
+## SSH trust bootstrap {: #ssh-trust-bootstrap}
+
+These commands generate and exchange SSH trust material for an [SSH environment](environment/ssh.md) and [Bifröst delegation authorization](authorization/bifroest.md). Only `key import host --address` contacts a remote host.
+
+Exchange exported public material and SHA256 fingerprints over an independently trusted channel.
+
+### Generate a key
+
+Syntax: `bifroest key generate [flags]`
+
+Creates an Ed25519 private key in OpenSSH format. The command never replaces an existing file and never writes private key material to stdout. Private files use mode `0400` on Unix and a protected DACL on Windows. If `--publicFile` is set, the corresponding public key is additionally written as one LF-terminated OpenSSH public-key line.
+
+#### Flags {. #key-generate-flags}
+
+Includes [all general flags](#general-flags).
+
+<<flag("identityFile", "File Path", "data-type.md#file-path", required=True, id_prefix="key-generate-", heading=5)>>
+Private key file to create.
+
+<<flag("publicFile", "File Path", "data-type.md#file-path", id_prefix="key-generate-", heading=5)>>
+Optional public key file to create. It has to differ from `identityFile` and is never replaced. This explicit output does not enable automatic `.pub` companion files.
+
+### Export a public key
+
+Syntax: `bifroest key export public [flags]`
+
+Writes exactly one LF-terminated OpenSSH public-key line. `--output` defaults to `-` for stdout. A file is written atomically and is not replaced unless `--force` is set.
+
+#### Flags {. #key-export-public-flags}
+
+Includes [all general flags](#general-flags).
+
+<<flag("identityFile", "File Path", "data-type.md#file-path", required=True, id_prefix="key-export-public-", heading=5)>>
+Private key file whose public key is exported.
+
+<<flag("comment", "string", id_prefix="key-export-public-", heading=5)>>
+Optional OpenSSH public-key comment. Line breaks are not accepted.
+
+<<flag("output", ref("File Path", "data-type.md#file-path"), default="-", id_prefix="key-export-public-", heading=5)>>
+Output file. `-` writes to stdout.
+
+<<flag("force", "bool", default=False, id_prefix="key-export-public-", heading=5)>>
+Replace an existing output file. Without this flag, an existing file is never modified.
+
+### Export a certificate authority
+
+Syntax: `bifroest key export ca [flags] <flowName>`
+
+Loads the same configuration as `bifroest run` and exports the effective SSH certificate authority of the selected flow. If the private CA does not exist, it is generated before its public key is exported. No `.pub` companion file is created.
+
+#### Argument
+
+`flowName` is the name of an SSH-environment flow with certificate authentication enabled.
+
+#### Flags {. #key-export-ca-flags}
+
+Includes [all general flags](#general-flags).
+
+<<flag("configuration", "File Path", "data-type.md#file-path", id_prefix="key-export-ca-", heading=5)>>
+Configuration to load. The default is `/etc/engity/bifroest/configuration.yaml` on Unix and `C:\ProgramData\Engity\Bifroest\configuration.yaml` on Windows. Short form: `-c`.
+
+<<flag("output", ref("File Path", "data-type.md#file-path"), default="-", id_prefix="key-export-ca-", heading=5)>>
+Output file. `-` writes exactly one LF-terminated OpenSSH public-key line to stdout.
+
+<<flag("force", "bool", default=False, id_prefix="key-export-ca-", heading=5)>>
+Replace an existing output file.
+
+### Export host keys
+
+Syntax: `bifroest key export host [flags]`
+
+Creates `known_hosts` entries for an address without network access. With `--identityFile`, that key is loaded or generated. Otherwise all host keys from the selected configuration are loaded or generated.
+
+#### Flags {. #key-export-host-flags}
+
+Includes [all general flags](#general-flags).
+
+<<flag("configuration", "File Path", "data-type.md#file-path", id_prefix="key-export-host-", heading=5)>>
+Configuration to load when `identityFile` is absent. It uses the same platform default as `bifroest run`. Short form: `-c`.
+
+<<flag("identityFile", "File Path", "data-type.md#file-path", id_prefix="key-export-host-", heading=5)>>
+Specific host private-key file to load or create. This cannot be combined with `configuration`.
+
+<<flag("address", "string", required=True, id_prefix="key-export-host-", heading=5)>>
+Host represented by the generated entries. Port `22` can be omitted; non-default IPv6 ports use `[address]:port`.
+
+<<flag("output", ref("File Path", "data-type.md#file-path"), default="-", id_prefix="key-export-host-", heading=5)>>
+Output file. `-` writes to stdout.
+
+<<flag("force", "bool", default=False, id_prefix="key-export-host-", heading=5)>>
+Replace an existing output file.
+
+### Import certificate authorities
+
+Syntax: `bifroest key import ca [flags]`
+
+Validates and atomically merges plain OpenSSH certificate-authority public keys. Certificates, private keys and authorized-key options are rejected.
+
+#### Flags {. #key-import-ca-flags}
+
+Includes [all general flags](#general-flags).
+
+<<flag("trustedCAsFile", "File Path", "data-type.md#file-path", required=True, id_prefix="key-import-ca-", heading=5)>>
+Public-key file containing the trusted SSH certificate authorities to update.
+
+<<flag("input", ref("File Path", "data-type.md#file-path"), default="-", id_prefix="key-import-ca-", heading=5)>>
+File containing the public CA keys. `-` reads from stdin.
+
+<<flag("expectedFingerprint", "string", id_prefix="key-import-ca-", heading=5)>>
+Expected OpenSSH SHA256 fingerprint of every imported CA, or `unknown`. A mismatch leaves the destination unchanged; omission implies `unknown`.
+
+### Import host keys
+
+Syntax: `bifroest key import host [flags]`
+
+Validates and atomically merges normal `known_hosts` entries from a file, stdin or an SSH server. Incoming `@revoked`, `@cert-authority` and certificate entries are rejected.
+
+#### Flags {. #key-import-host-flags}
+
+Includes [all general flags](#general-flags).
+
+<<flag("knownHostsFile", "File Path", "data-type.md#file-path", required=True, id_prefix="key-import-host-", heading=5)>>
+OpenSSH `known_hosts` file to update.
+
+<<flag("input", ref("File Path", "data-type.md#file-path"), default="-", id_prefix="key-import-host-", heading=5)>>
+File containing entries to import. `-` or omission reads from stdin. This cannot be combined with `address`.
+
+<<flag("address", "string", id_prefix="key-import-host-", heading=5)>>
+SSH server from which one negotiated host key is retrieved. Port `22` can be omitted.
+
+<<flag("expectedFingerprint", "string", id_prefix="key-import-host-", heading=5)>>
+Expected OpenSSH SHA256 fingerprint, or `unknown`. It is required with `address`; omission for file or stdin input implies `unknown`.
+
+!!! warning
+     `--expectedFingerprint unknown` with `--address` explicitly trusts a key obtained from an unverified network peer and can expose the connection to an on-path attack. The command also emits a warning to stderr.
+
+Both import commands lock concurrent merge operations and preserve existing valid entries. A supplied SHA256 fingerprint has to match every imported key, including keys that are already present; any mismatch leaves the destination unchanged.
+
 ## Service management {. #service}
 
 !!! note

--- a/docs/reference/context/authorization.md
+++ b/docs/reference/context/authorization.md
@@ -10,11 +10,32 @@ There are more specialized variants of the authorization available, based on whi
 
 | Variant                        | Authorization                                     |
 |--------------------------------|---------------------------------------------------|
+| [Bifröst](#bifroest)           | [Bifröst delegation](../authorization/bifroest.md) |
 | [Htpasswd](#htpasswd)          | [Htpasswd](../authorization/htpasswd.md)          |
 | [Local](#local)                | [Local](../authorization/local.md)                |
 | [OpenID Connect (OIDC)](#oidc) | [OpenID Connect (OIDC)](../authorization/oidc.md) |
 | [Simple](#simple)              | [Simple](../authorization/simple.md)              |
 | [None](#none)                  | [None](../authorization/none.md)                  |
+
+## Bifröst {: #bifroest}
+
+Is the result of a successful certificate-based delegation from another [Bifröst authorization](../authorization/bifroest.md). The common authorization `remote` remains the immediately connected SSH peer; use `origin` for the unchanged original identity.
+
+### Properties
+
+<<property("origin", "object", id_prefix="bifroest-", heading=4)>>
+The original `user`, `host` and `authorizationKind` from the first Bifröst instance.
+
+<<property("peer", "object", id_prefix="bifroest-", heading=4)>>
+The final, immediately verified hop. It contains the CA and subject-key fingerprints, serial, key ID, upstream session ID and flow, authorization kind, audience, target user, validity boundaries, and effective capability booleans.
+
+<<property("hops", "list of objects", id_prefix="bifroest-", heading=4)>>
+The complete normalized delegation path. Each object has the same fields as `peer`. The list has at most eight entries.
+
+<<property("policy", "object", id_prefix="bifroest-", heading=4)>>
+The effective `ptyAllowed`, `portForwardingAllowed` and `agentForwardingAllowed` values after all hops.
+
+Passwords, tokens, unrestricted identity-provider claims and arbitrary environment maps are never included in this context.
 
 ## Htpasswd
 

--- a/docs/reference/data-type.md
+++ b/docs/reference/data-type.md
@@ -87,6 +87,12 @@ Can be one of:
 * `at-least-384-bits`
 * `at-least-521-bits`
 
+## Environment Variable Name {: #environment-variable-name }
+The name of an environment variable. It has to fulfill the portable ASCII pattern `[A-Za-z_][A-Za-z0-9_]*`.
+
+## Environment Variables {: #environment-variables }
+A map from [Environment Variable Name](#environment-variable-name) keys to string values. Values can use the template context documented by the property accepting this data type and cannot contain NUL characters.
+
 ## Flow Name
 Identifies flows. It has to fulfill the regular expression `[a-z][a-z0-9]+`.
 

--- a/docs/reference/data-type.md
+++ b/docs/reference/data-type.md
@@ -34,8 +34,10 @@ Bifröst supports the following OpenSSH `authorized_keys` options:
 | `permitopen="host:port"` | Restricts local and dynamic port-forwarding destinations. May be specified more than once. |
 | `permitlisten="[host:]port"` | Restricts reverse port-forwarding listeners. May be specified more than once. |
 | `agent-forwarding`, `no-agent-forwarding` | Enables or disables access to a forwarded SSH agent. |
+| `cert-authority` | Treats the entry as a user certificate authority instead of a directly authorized key. Supported by the `simple` and `local` authorizations. |
+| `principals="name,..."` | Further restricts a `cert-authority` entry to certificates containing at least one listed principal. The requested SSH username must still be a certificate principal. |
 
-Options not listed above are not supported. A key entry using an unsupported option, such as `cert-authority`, `principals`, `tunnel`, `user-rc`, `x11-forwarding`, `no-touch-required`, or `verify-required`, is rejected instead of being treated as unrestricted.
+Options not listed above are not supported. A key entry using an unsupported option, such as `tunnel`, `user-rc`, `x11-forwarding`, `no-touch-required`, or `verify-required`, is rejected instead of being treated as unrestricted. `principals` without `cert-authority` is also rejected.
 
 !!! warning
      Environment variables can change how commands and shells behave. Only configure `environment=` values that you trust, especially variables such as `PATH`, shell startup variables, or dynamic-loader settings.
@@ -145,6 +147,15 @@ Can be one of:
 
 * `plain`
 * `bcrypt`
+
+## Public Keys
+
+A string containing one or more OpenSSH public-key lines. Empty lines and lines beginning with `#` are ignored. Unlike [Authorized Keys](#authorized-keys), these lines cannot contain options. Certificate-authority configuration also rejects certificate lines because each trust anchor must be a plain public key.
+
+```text
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI... organization-user-ca
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQ... legacy-user-ca
+```
 
 ## Pull Policy
 Can be one of:

--- a/docs/reference/environment/docker.md
+++ b/docs/reference/environment/docker.md
@@ -16,6 +16,9 @@ In another use case you can set up a [Bastion/Jump host](../../usecases.md#basti
 <<property("type", "Environment Type", default="docker", required=True)>>
 Has to be set to `docker` to enable the docker environment.
 
+<<property("variables", "Environment Variables", "../data-type.md#environment-variables", template_context="../context/authorization.md")>>
+Defines environment variables for commands and shells in the container. They override image values and values received from the SSH client, `authorized_keys` and authorization. Bifröst-generated runtime variables take precedence.
+
 <<property("loginAllowed", "bool", template_context="../context/authorization.md", default=True)>>
 Has to be true (after being evaluated) that the user is allowed to use this environment.
 
@@ -247,6 +250,9 @@ Holds the tag of the image to be downloaded.
    ## because it does exist in the image
    shellCommand: [/bin/bash]
    execCommand: [/bin/bash, -c]
+
+   variables:
+     APPLICATION_ENV: production
 
    ## Only allow login if the OIDC's groups has "my-great-group-uuid"
    ## ...and the tid (tenant ID) is "my-great-tenant-uuid"

--- a/docs/reference/environment/index.md
+++ b/docs/reference/environment/index.md
@@ -11,7 +11,8 @@ Bifröst executes user sessions within environments. These environments can eith
 1. `docker`: [Docker](docker.md) executes each user session inside a separate Docker container.
 2. `kubernetes`: [Kubernetes](kubernetes.md) executes each user session inside a separate POD in a defined cluster.
 3. `local`: [Local](local.md) executes on the host itself (same host on which Bifröst is running).
-4. `dummy`: [Dummy](dummy.md) for demonstration purposes, it simply prints a message and exists immediately.
+4. `ssh`: [SSH](ssh.md) connects to another SSH server and forwards sessions and direct TCP channels.
+5. `dummy`: [Dummy](dummy.md) for demonstration purposes, it simply prints a message and exists immediately.
 
 ## Examples
 
@@ -56,7 +57,16 @@ Bifröst executes user sessions within environments. These environments can eith
    shellCommand: [/bin/bash]
    execCommand: [/bin/bash, -c]
    ```
-6. Using [dummy environment](dummy.md) with a simple message:
+6. Using an [SSH environment](ssh.md):
+   ```yaml
+   type: ssh
+   address: target.example.org:22
+   user: service-user
+   knownHostsFile: /etc/engity/bifroest/known_hosts
+   identityFiles:
+     - /etc/engity/bifroest/id_target
+   ```
+7. Using [dummy environment](dummy.md) with a simple message:
    ```yaml
    type: dummy
    banner: "Hello, {{.authorization.idToken.name}}!\n"

--- a/docs/reference/environment/index.md
+++ b/docs/reference/environment/index.md
@@ -60,7 +60,7 @@ Bifröst executes user sessions within environments. These environments can eith
 6. Using an [SSH environment](ssh.md):
    ```yaml
    type: ssh
-   address: target.example.org:22
+   address: target.example.org
    user: service-user
    knownHostsFile: /etc/engity/bifroest/known_hosts
    identityFiles:

--- a/docs/reference/environment/kubernetes.md
+++ b/docs/reference/environment/kubernetes.md
@@ -39,6 +39,9 @@ Or to interact with resources inside the cluster itself (like connect to a datab
 <<property("type", "Environment Type", default="kubernetes", required=True)>>
 Has to be set to `kubernetes` to enable the Kubernetes environment.
 
+<<property("variables", "Environment Variables", "../data-type.md#environment-variables", template_context="../context/authorization.md")>>
+Defines environment variables for commands and shells in the Pod. They override image values and values received from the SSH client, `authorized_keys` and authorization. Bifröst-generated runtime variables take precedence.
+
 <<property("config", "Kubeconfig", "../data-type.md#kubeconfig", template_context="../context/core.md")>>
 Holds a [kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) (in YAML format) which defines the access to the desired Kubernetes cluster.
 
@@ -334,6 +337,9 @@ Namespace of the existing Pod. See [property namespace](#property-namespace) for
     ## because it does exist in the image
     shellCommand: [/bin/bash]
     execCommand: [/bin/bash, -c]
+
+    variables:
+      APPLICATION_ENV: production
 
     ## Only allow login if the OIDC's groups has "my-great-group-uuid"
     ## ...and the tid (tenant ID) is "my-great-tenant-uuid"

--- a/docs/reference/environment/local.md
+++ b/docs/reference/environment/local.md
@@ -33,6 +33,9 @@ See the evaluation matrix of [`createIfAbsent`](#linux-property-createIfAbsent-e
 <<property("type", "Environment Type", default="local", required=True, id_prefix="linux-", heading=4)>>
 Has to be set to `local` to enable the local environment.
 
+<<property("variables", "Environment Variables", "../data-type.md#environment-variables", template_context="../context/authorization.md", id_prefix="linux-", heading=4)>>
+Defines environment variables for commands and shells. They override values received from the SSH client, `authorized_keys` and authorization. Bifröst-generated runtime and local account identity variables take precedence.
+
 <<property("loginAllowed", "bool", template_context="../context/authorization.md", default=True, id_prefix="linux-", heading=4)>>
 Has to be true (after being evaluated) that the user is allowed to use this environment.
 
@@ -203,6 +206,9 @@ Defines what happens if an environment is disposed.
 
    shell: "/bin/bash"
 
+   variables:
+     BIFROEST_ORIGINAL_USER: "{{.session.created.remote.user}}"
+
    ## Only allow login if the OIDC's groups has "my-great-group-uuid"
    ## ...and the tid (tenant ID) is "my-great-tenant-uuid"
    loginAllowed: |
@@ -261,6 +267,9 @@ The Windows variant is supported by Windows 10, Windows Server 2016, and later v
 <<property("type", "Environment Type", default="local", required=True, id_prefix="windows-", heading=4)>>
 Has to be set to `local` to enable the local environment.
 
+<<property("variables", "Environment Variables", "../data-type.md#environment-variables", template_context="../context/authorization.md", id_prefix="windows-", heading=4)>>
+Defines environment variables for commands and shells. Names are handled case-insensitively. They override values received from the SSH client, `authorized_keys` and authorization. Bifröst-generated runtime and local account identity variables take precedence.
+
 <<property("loginAllowed", "bool", template_context="../context/authorization.md", default=True, id_prefix="windows-", heading=4)>>
 Has to be true (after being evaluated) that the user is allowed to use this environment.
 
@@ -310,6 +319,9 @@ If `true`, users are allowed to use SSH's port forwarding mechanism.
    ## Use the PowerShell Core without banner as Shell
    shellCommand: ["pwsh.exe", "-NoLogo"]
    directory: "C:\\my\\home"
+
+   variables:
+     BIFROEST_ORIGINAL_USER: "{{.session.created.remote.user}}"
 
    ## Only allow login if the OIDC's groups has "my-great-group-uuid"
    ## ...and the tid (tenant ID) is "my-great-tenant-uuid"

--- a/docs/reference/environment/ssh.md
+++ b/docs/reference/environment/ssh.md
@@ -18,7 +18,7 @@ Has to be set to `ssh` to enable the SSH environment.
 Defines environment variables sent to the target for commands, shells and SFTP. They override values received from the SSH client, `authorized_keys` and authorization. Bifröst-generated runtime variables take precedence. Variables are sent as best-effort SSH `env` requests; the target server decides which variables it accepts, commonly through OpenSSH `AcceptEnv`.
 
 <<property("address", "string", template_context="../context/authorization.md", required=True)>>
-Target address in `host:port` form. IPv6 addresses have to use `[address]:port` form.
+Target SSH address. The port defaults to `22`. DNS names, IPv4 addresses and IPv6 addresses can omit it; an explicit IPv6 port uses `[address]:port` form.
 
 <<property("user", "string", template_context="../context/authorization.md", required=True)>>
 User used to authenticate at the target SSH server.
@@ -66,17 +66,24 @@ Bifröst issues exactly one certificate for each persistent Bifröst session. Re
 
 ### Configuration {: #certificate-configuration}
 
-<<property("identityFile", "File Path", "../data-type.md#file-path", required=True, id_prefix="certificate-", heading=4)>>
-Static path to the private subject key used with the certificate. If the file does not exist when Bifröst starts, an Ed25519 key is generated. Existing unreadable, encrypted or invalid files cause startup to fail and are never overwritten. The private key is not copied into session storage.
+<<property("identityFile", "File Path", "../data-type.md#file-path", id_prefix="certificate-", heading=4)>>
+Static path to the private subject key used with the certificate. The default is `/etc/engity/bifroest/client-key` on Unix and `C:\ProgramData\Engity\Bifroest\client-key` on Windows. The default key is shared by all certificate-enabled flows of one Bifröst instance. If the file does not exist, an Ed25519 key is generated. Existing unreadable, encrypted or invalid files cause startup to fail and are never overwritten. The private key is not copied into session storage.
 
 <<property("authorityIdentityFile", "File Path", "../data-type.md#file-path", id_prefix="certificate-", heading=4)>>
-Static path to the private OpenSSH user-CA key. If absent, the first configured Bifröst server host key signs new user certificates. An invalid explicit CA file never activates this fallback. Existing certificates remain bound to their original CA after a configured CA rotation.
+Static path to the private SSH certificate-authority key. The default is `/etc/engity/bifroest/ca` on Unix and `C:\ProgramData\Engity\Bifroest\ca` on Windows. The default CA is shared by all certificate-enabled flows of one Bifröst instance. If the file does not exist, an Ed25519 key is generated. Existing unreadable, encrypted or invalid files cause startup to fail and are never overwritten. The server host key is never used as certificate authority. Existing certificates remain bound to their original CA after a configured CA rotation.
 
-<<property("validity", "duration", required=True, id_prefix="certificate-", heading=4)>>
+Bifröst does not create a `.pub` companion file for either private key. The CA public key is logged at every startup and can be exported for a specific flow with `bifroest key export ca`.
+
+<<property("validity", "duration", default="15m", id_prefix="certificate-", heading=4)>>
 Positive lifetime of a newly issued certificate. The first issuance persists `MaxValidUntil`, and reconnects, activity and later configuration increases never move that boundary. This lifetime is separate from the dynamic Bifröst session idle timeout.
+
+Certificate expiry does not disconnect an already authenticated downstream SSH transport, the incoming client connection or the Bifröst session. It only prevents the expired certificate from authenticating a new or re-established downstream SSH connection. Connection and session timeouts control their respective lifetimes independently.
 
 <<property("validAfterSkew", "duration", default="30s", id_prefix="certificate-", heading=4)>>
 Non-negative clock skew subtracted from the issuance time for the OpenSSH `ValidAfter` field.
+
+<<property("audience", "string", template_context="../context/authorization.md", id_prefix="certificate-", heading=4)>>
+Enables the Bifröst delegation profile and identifies the intended downstream authorization, normally its flow name. If absent, the certificate uses the interoperable audit profile. The two profiles are described [below](#certificate-profiles).
 
 <<property("principals", "list of strings", template_context="../context/authorization.md", id_prefix="certificate-", heading=4)>>
 Additional OpenSSH principals. The rendered target `user` is always included and empty rendered principals are rejected.
@@ -84,29 +91,15 @@ Additional OpenSSH principals. The rendered target `user` is always included and
 <<property("extensions", "map of strings", template_context="../context/authorization.md", id_prefix="certificate-", heading=4)>>
 OpenSSH certificate extensions and their values. Standard extensions such as `permit-pty`, `permit-port-forwarding` and `permit-agent-forwarding` are removed when the effective incoming authorization policy denies the corresponding capability. Names ending in `@bifroest.engity.org` are reserved for Bifröst metadata.
 
-### Example {: #certificate-example}
+Certificate metadata uses only the reserved `evidence-v1@bifroest.engity.org` extension. The size-limited evidence document contains allowlisted origin, hop, target and capability fields; passwords, OAuth tokens and unrestricted authorization data are never included.
 
-```yaml
-type: ssh
-address: target.example.org:22
-user: '{{ .session.created.remote.user }}'
-knownHostsFile: /etc/engity/bifroest/known_hosts
-certificate:
-  identityFile: /var/lib/engity/bifroest/downstream-client
-  authorityIdentityFile: /etc/engity/bifroest/downstream-user-ca
-  validity: 24h
-  validAfterSkew: 30s
-  principals:
-    - '{{ .session.created.remote.user }}'
-  extensions:
-    permit-pty: ""
-    permit-port-forwarding: ""
-    permit-agent-forwarding: ""
-```
+### Certificate profiles {: #certificate-profiles}
 
-The target OpenSSH server must trust the corresponding CA public key, commonly through `TrustedUserCAKeys`. Deploy a new CA public key to targets before changing `authorityIdentityFile`; keep the old public key trusted until all certificates issued by it have expired.
+Without `audience`, Bifröst issues an audit-profile certificate. Its evidence is a non-critical extension, so standard OpenSSH and Bifröst's `simple` and `local` authorizations can authenticate it while ignoring the metadata.
 
-Certificate metadata uses the reserved extensions `session-id@bifroest.engity.org`, `original-user@bifroest.engity.org`, `original-host@bifroest.engity.org`, `authorization-kind@bifroest.engity.org` and `evidence-v1@bifroest.engity.org`. The size-limited evidence document contains only allowlisted session identity, target and capability fields; passwords, OAuth tokens and unrestricted authorization data are never included. OpenSSH ignores unknown extensions unless a target-side integration evaluates them.
+With `audience`, Bifröst additionally sets the critical option `bifroest-delegation@bifroest.engity.org`. Standard OpenSSH and authorization types that do not understand this option reject the certificate. Only [`authorization.type: bifroest`](../authorization/bifroest.md) validates the signed evidence and accepts the delegation.
+
+When a `bifroest` authorization forwards to another SSH environment, the original identity and validated hop history are retained. The new hop cannot move `ValidAfter` earlier, extend `ValidBefore`, or restore a PTY, port-forwarding or agent-forwarding capability denied upstream. Because destination-specific `permitopen` and `permitlisten` rules are hop-local, their presence conservatively disables delegated port forwarding rather than broadening it downstream.
 
 ## Supported operations
 
@@ -128,11 +121,13 @@ Arbitrary subsystems and SSH break requests are not forwarded.
 !!! warning
      OpenSSH agent forwarding is scoped to an SSH connection rather than an individual session. After one permitted session enables forwarding, the target can access that source agent until the incoming SSH connection ends. Only enable agent forwarding for trusted targets.
 
-## Example
+## Examples
+
+### Private key authentication
 
 ```yaml
 type: ssh
-address: target.example.org:22
+address: target.example.org
 user: '{{ .session.created.remote.user }}'
 knownHosts: |
   target.example.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA...
@@ -141,6 +136,64 @@ identityFiles:
 variables:
   LC_ALL: C.UTF-8
 ```
+
+### OpenSSH certificate authentication
+
+1. Import the running OpenSSH server's host key, then use this flow:
+    ```shell
+    bifroest key import host \
+      --knownHostsFile /etc/engity/bifroest/known_hosts \
+      --address internal.example.org \
+      --expectedFingerprint SHA256:...
+    ```
+
+    !!! warning
+         A plain password and `--expectedFingerprint unknown` are suitable only for testing. Verify production host-key fingerprints independently and use a password hash or another authorization.
+
+2. Configure Bifröst:
+    ```yaml title="/etc/engity/bifroest/configuration.yaml"
+    flows:
+      - name: openssh
+        authorization:
+          type: simple
+          entries:
+            - name: alice
+              password: plain:change-me
+        environment:
+          type: ssh
+          address: internal.example.org
+          user: alice
+          knownHostsFile: /etc/engity/bifroest/known_hosts
+          certificate:
+            extensions:
+              permit-pty: ""
+    ```
+
+    !!! note
+         The OpenSSH server needs a local `alice` account. Leave `audience` unset because OpenSSH does not understand Bifröst's delegation critical option.
+
+3. Export the CA and deploy the output as `/etc/ssh/bifroest-ca.pub` on the OpenSSH server:
+    ```shell
+    bifroest key export ca \
+      -c /etc/engity/bifroest/configuration.yaml \
+      openssh \
+      --output /tmp/ca.pub
+    ```
+
+4. Configure `sshd`:
+    ```text title="/etc/ssh/sshd_config.d/bifroest.conf"
+    PubkeyAuthentication yes
+    TrustedUserCAKeys /etc/ssh/bifroest-ca.pub
+    ```
+
+5. Restart `sshd`:
+    ```shell
+    systemctl restart sshd
+    ```
+
+### Bifröst delegation
+
+For Bifröst-to-Bifröst certificate delegation, see the [Bifröst authorization example](../authorization/bifroest.md#example-entry-gateway-to-target-gateway).
 
 ## Compatibility
 

--- a/docs/reference/environment/ssh.md
+++ b/docs/reference/environment/ssh.md
@@ -43,26 +43,8 @@ Private SSH keys offered to the target. Every configured file has to exist and c
 
 `identityFiles` and `certificate` are mutually exclusive. If neither is configured, the server-host-key fallback remains active.
 
-<<property("certificate", "SSH User Certificate")>>
-Enables a persistent OpenSSH user certificate for the target connection. Bifröst issues exactly one certificate for each persistent Bifröst session. Reconnecting and restarting Bifröst reuse the byte-identical certificate until its immutable validity boundary is reached.
-
-<<property("certificate.identityFile", "File Path", "../data-type.md#file-path", required=True)>>
-Static path to the private subject key used with the certificate. If the file does not exist when Bifröst starts, an Ed25519 key is generated. Existing unreadable, encrypted or invalid files cause startup to fail and are never overwritten. The private key is not copied into session storage.
-
-<<property("certificate.authorityIdentityFile", "File Path", "../data-type.md#file-path")>>
-Static path to the private OpenSSH user-CA key. If absent, the first configured Bifröst server host key signs new user certificates. An invalid explicit CA file never activates this fallback. Existing certificates remain bound to their original CA after a configured CA rotation.
-
-<<property("certificate.validity", "duration", required=True)>>
-Positive lifetime of a newly issued certificate. The first issuance persists `MaxValidUntil`, and reconnects, activity and later configuration increases never move that boundary. This lifetime is separate from the dynamic Bifröst session idle timeout.
-
-<<property("certificate.validAfterSkew", "duration", default="30s")>>
-Non-negative clock skew subtracted from the issuance time for the OpenSSH `ValidAfter` field.
-
-<<property("certificate.principals", "list of strings", template_context="../context/authorization.md")>>
-Additional OpenSSH principals. The rendered target `user` is always included and empty rendered principals are rejected.
-
-<<property("certificate.extensions", "map of strings", template_context="../context/authorization.md")>>
-OpenSSH certificate extensions and their values. Standard extensions such as `permit-pty`, `permit-port-forwarding` and `permit-agent-forwarding` are removed when the effective incoming authorization policy denies the corresponding capability. Names ending in `@bifroest.engity.org` are reserved for Bifröst metadata.
+<<property("certificate", "SSH User Certificate", "#certificate")>>
+Enables a persistent OpenSSH user certificate for the target connection. See [below](#certificate).
 
 <<property("connectTimeout", "duration", template_context="../context/authorization.md", default="10s")>>
 Maximum duration for TCP connection establishment and SSH handshake. `0` disables this timeout.
@@ -77,6 +59,54 @@ Displayed before an interactive target shell is opened.
 Controls local and dynamic forwarding after the applicable authorized-key policy has also been checked. Reverse forwarding is not supported by the SSH environment.
 
 At least one host-key verification source is required unless `acceptAllHostKeys` is explicitly enabled.
+
+## SSH User Certificate {: #certificate}
+
+Bifröst issues exactly one certificate for each persistent Bifröst session. Reconnecting and restarting Bifröst reuse the byte-identical certificate until its immutable validity boundary is reached.
+
+### Configuration {: #certificate-configuration}
+
+<<property("identityFile", "File Path", "../data-type.md#file-path", required=True, id_prefix="certificate-", heading=4)>>
+Static path to the private subject key used with the certificate. If the file does not exist when Bifröst starts, an Ed25519 key is generated. Existing unreadable, encrypted or invalid files cause startup to fail and are never overwritten. The private key is not copied into session storage.
+
+<<property("authorityIdentityFile", "File Path", "../data-type.md#file-path", id_prefix="certificate-", heading=4)>>
+Static path to the private OpenSSH user-CA key. If absent, the first configured Bifröst server host key signs new user certificates. An invalid explicit CA file never activates this fallback. Existing certificates remain bound to their original CA after a configured CA rotation.
+
+<<property("validity", "duration", required=True, id_prefix="certificate-", heading=4)>>
+Positive lifetime of a newly issued certificate. The first issuance persists `MaxValidUntil`, and reconnects, activity and later configuration increases never move that boundary. This lifetime is separate from the dynamic Bifröst session idle timeout.
+
+<<property("validAfterSkew", "duration", default="30s", id_prefix="certificate-", heading=4)>>
+Non-negative clock skew subtracted from the issuance time for the OpenSSH `ValidAfter` field.
+
+<<property("principals", "list of strings", template_context="../context/authorization.md", id_prefix="certificate-", heading=4)>>
+Additional OpenSSH principals. The rendered target `user` is always included and empty rendered principals are rejected.
+
+<<property("extensions", "map of strings", template_context="../context/authorization.md", id_prefix="certificate-", heading=4)>>
+OpenSSH certificate extensions and their values. Standard extensions such as `permit-pty`, `permit-port-forwarding` and `permit-agent-forwarding` are removed when the effective incoming authorization policy denies the corresponding capability. Names ending in `@bifroest.engity.org` are reserved for Bifröst metadata.
+
+### Example {: #certificate-example}
+
+```yaml
+type: ssh
+address: target.example.org:22
+user: '{{ .session.created.remote.user }}'
+knownHostsFile: /etc/engity/bifroest/known_hosts
+certificate:
+  identityFile: /var/lib/engity/bifroest/downstream-client
+  authorityIdentityFile: /etc/engity/bifroest/downstream-user-ca
+  validity: 24h
+  validAfterSkew: 30s
+  principals:
+    - '{{ .session.created.remote.user }}'
+  extensions:
+    permit-pty: ""
+    permit-port-forwarding: ""
+    permit-agent-forwarding: ""
+```
+
+The target OpenSSH server must trust the corresponding CA public key, commonly through `TrustedUserCAKeys`. Deploy a new CA public key to targets before changing `authorityIdentityFile`; keep the old public key trusted until all certificates issued by it have expired.
+
+Certificate metadata uses the reserved extensions `session-id@bifroest.engity.org`, `original-user@bifroest.engity.org`, `original-host@bifroest.engity.org`, `authorization-kind@bifroest.engity.org` and `evidence-v1@bifroest.engity.org`. The size-limited evidence document contains only allowlisted session identity, target and capability fields; passwords, OAuth tokens and unrestricted authorization data are never included. OpenSSH ignores unknown extensions unless a target-side integration evaluates them.
 
 ## Supported operations
 
@@ -111,30 +141,6 @@ identityFiles:
 variables:
   LC_ALL: C.UTF-8
 ```
-
-## User certificate example
-
-```yaml
-type: ssh
-address: target.example.org:22
-user: '{{ .session.created.remote.user }}'
-knownHostsFile: /etc/engity/bifroest/known_hosts
-certificate:
-  identityFile: /var/lib/engity/bifroest/downstream-client
-  authorityIdentityFile: /etc/engity/bifroest/downstream-user-ca
-  validity: 24h
-  validAfterSkew: 30s
-  principals:
-    - '{{ .session.created.remote.user }}'
-  extensions:
-    permit-pty: ""
-    permit-port-forwarding: ""
-    permit-agent-forwarding: ""
-```
-
-The target OpenSSH server must trust the corresponding CA public key, commonly through `TrustedUserCAKeys`. Deploy a new CA public key to targets before changing `authorityIdentityFile`; keep the old public key trusted until all certificates issued by it have expired.
-
-Certificate metadata uses the reserved extensions `session-id@bifroest.engity.org`, `original-user@bifroest.engity.org`, `original-host@bifroest.engity.org`, `authorization-kind@bifroest.engity.org` and `evidence-v1@bifroest.engity.org`. The size-limited evidence document contains only allowlisted session identity, target and capability fields; passwords, OAuth tokens and unrestricted authorization data are never included. OpenSSH ignores unknown extensions unless a target-side integration evaluates them.
 
 ## Compatibility
 

--- a/docs/reference/environment/ssh.md
+++ b/docs/reference/environment/ssh.md
@@ -1,0 +1,96 @@
+---
+description: Connect a Bifröst flow to another SSH server.
+toc_depth: 5
+---
+
+# SSH environment
+
+The SSH environment terminates the incoming SSH connection at Bifröst and creates a separately authenticated SSH connection to a target server. All sessions and direct TCP forwarding channels of one incoming connection share one target SSH transport.
+
+Each target transport allows up to 64 concurrently active or pending shell, SFTP, forwarding and agent channels. Additional locally requested channels wait for capacity; excess agent channels initiated by the target are rejected.
+
+## Configuration {: #configuration}
+
+<<property("type", "Environment Type", default="ssh", required=True)>>
+Has to be set to `ssh` to enable the SSH environment.
+
+<<property("variables", "Environment Variables", "../data-type.md#environment-variables", template_context="../context/authorization.md")>>
+Defines environment variables sent to the target for commands, shells and SFTP. They override values received from the SSH client, `authorized_keys` and authorization. Bifröst-generated runtime variables take precedence. Variables are sent as best-effort SSH `env` requests; the target server decides which variables it accepts, commonly through OpenSSH `AcceptEnv`.
+
+<<property("address", "string", template_context="../context/authorization.md", required=True)>>
+Target address in `host:port` form. IPv6 addresses have to use `[address]:port` form.
+
+<<property("user", "string", template_context="../context/authorization.md", required=True)>>
+User used to authenticate at the target SSH server.
+
+<<property("os", "Os", "../data-type.md#os", default="linux")>>
+Operating system of the target. This controls case-sensitive or case-insensitive environment-variable precedence.
+
+<<property("knownHosts", "string")>>
+Inline OpenSSH `known_hosts` content. A YAML block string can contain multiple entries.
+
+<<property("knownHostsFile", "string")>>
+Explicit path to one OpenSSH `known_hosts` file. Bifröst never implicitly reads user or system `known_hosts` files. `knownHosts` and `knownHostsFile` can be used together.
+
+<<property("acceptAllHostKeys", "bool", default=False)>>
+Disables target host-key verification. This cannot be combined with `knownHosts` or `knownHostsFile` and should only be used in controlled test environments.
+
+!!! danger
+     Setting `acceptAllHostKeys: true` makes the target connection vulnerable to on-path attacks.
+
+<<property("identityFiles", "list of strings", template_context="../context/authorization.md")>>
+Private SSH keys offered to the target. Every configured file has to exist and contain an unencrypted private key. If the list is absent or empty, Bifröst offers all configured server host keys as client identities. An invalid explicit entry never activates this fallback.
+
+<<property("connectTimeout", "duration", template_context="../context/authorization.md", default="10s")>>
+Maximum duration for TCP connection establishment and SSH handshake. `0` disables this timeout.
+
+<<property("loginAllowed", "bool", template_context="../context/authorization.md", default=True)>>
+Controls whether the environment accepts an authorization.
+
+<<property("banner", "string", template_context="../context/authorization.md", default="")>>
+Displayed before an interactive target shell is opened.
+
+<<property("portForwardingAllowed", "bool", template_context="../context/authorization.md", default=True)>>
+Controls local and dynamic forwarding after the applicable authorized-key policy has also been checked. Reverse forwarding is not supported by the SSH environment.
+
+At least one host-key verification source is required unless `acceptAllHostKeys` is explicitly enabled.
+
+## Supported operations
+
+| Operation | Behavior |
+| --- | --- |
+| Shell and exec | Opened as separate channels on the shared target transport |
+| stdin, stdout and stderr | Forwarded without merging stderr into stdout |
+| Exit status | Returned from the target command |
+| PTY and resize | Terminal type, modes, dimensions and later window changes are forwarded |
+| Signals | Forwarded to the target session |
+| SFTP | The target `sftp` subsystem is streamed directly |
+| SCP | Modern SCP uses SFTP; legacy SCP is handled as an exec command |
+| Agent forwarding | Forwarded only when requested and permitted by the authorization policy |
+| `ssh -L` and `ssh -D` | Connections originate from the target SSH server's network |
+| `ssh -R` | Rejected; reverse forwarding is not supported by the SSH environment |
+
+Arbitrary subsystems and SSH break requests are not forwarded.
+
+!!! warning
+     OpenSSH agent forwarding is scoped to an SSH connection rather than an individual session. After one permitted session enables forwarding, the target can access that source agent until the incoming SSH connection ends. Only enable agent forwarding for trusted targets.
+
+## Example
+
+```yaml
+type: ssh
+address: target.example.org:22
+user: '{{ .session.created.remote.user }}'
+knownHosts: |
+  target.example.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA...
+identityFiles:
+  - /etc/engity/bifroest/id_target
+variables:
+  LC_ALL: C.UTF-8
+```
+
+## Compatibility
+
+| <<dist("linux")>> | <<dist("windows")>> |
+| - | - |
+| <<compatibility_editions(True,True,"linux")>> | <<compatibility_editions(True,None,"windows")>> |

--- a/docs/reference/environment/ssh.md
+++ b/docs/reference/environment/ssh.md
@@ -41,6 +41,29 @@ Disables target host-key verification. This cannot be combined with `knownHosts`
 <<property("identityFiles", "list of strings", template_context="../context/authorization.md")>>
 Private SSH keys offered to the target. Every configured file has to exist and contain an unencrypted private key. If the list is absent or empty, Bifröst offers all configured server host keys as client identities. An invalid explicit entry never activates this fallback.
 
+`identityFiles` and `certificate` are mutually exclusive. If neither is configured, the server-host-key fallback remains active.
+
+<<property("certificate", "SSH User Certificate")>>
+Enables a persistent OpenSSH user certificate for the target connection. Bifröst issues exactly one certificate for each persistent Bifröst session. Reconnecting and restarting Bifröst reuse the byte-identical certificate until its immutable validity boundary is reached.
+
+<<property("certificate.identityFile", "File Path", "../data-type.md#file-path", required=True)>>
+Static path to the private subject key used with the certificate. If the file does not exist when Bifröst starts, an Ed25519 key is generated. Existing unreadable, encrypted or invalid files cause startup to fail and are never overwritten. The private key is not copied into session storage.
+
+<<property("certificate.authorityIdentityFile", "File Path", "../data-type.md#file-path")>>
+Static path to the private OpenSSH user-CA key. If absent, the first configured Bifröst server host key signs new user certificates. An invalid explicit CA file never activates this fallback. Existing certificates remain bound to their original CA after a configured CA rotation.
+
+<<property("certificate.validity", "duration", required=True)>>
+Positive lifetime of a newly issued certificate. The first issuance persists `MaxValidUntil`, and reconnects, activity and later configuration increases never move that boundary. This lifetime is separate from the dynamic Bifröst session idle timeout.
+
+<<property("certificate.validAfterSkew", "duration", default="30s")>>
+Non-negative clock skew subtracted from the issuance time for the OpenSSH `ValidAfter` field.
+
+<<property("certificate.principals", "list of strings", template_context="../context/authorization.md")>>
+Additional OpenSSH principals. The rendered target `user` is always included and empty rendered principals are rejected.
+
+<<property("certificate.extensions", "map of strings", template_context="../context/authorization.md")>>
+OpenSSH certificate extensions and their values. Standard extensions such as `permit-pty`, `permit-port-forwarding` and `permit-agent-forwarding` are removed when the effective incoming authorization policy denies the corresponding capability. Names ending in `@bifroest.engity.org` are reserved for Bifröst metadata.
+
 <<property("connectTimeout", "duration", template_context="../context/authorization.md", default="10s")>>
 Maximum duration for TCP connection establishment and SSH handshake. `0` disables this timeout.
 
@@ -88,6 +111,30 @@ identityFiles:
 variables:
   LC_ALL: C.UTF-8
 ```
+
+## User certificate example
+
+```yaml
+type: ssh
+address: target.example.org:22
+user: '{{ .session.created.remote.user }}'
+knownHostsFile: /etc/engity/bifroest/known_hosts
+certificate:
+  identityFile: /var/lib/engity/bifroest/downstream-client
+  authorityIdentityFile: /etc/engity/bifroest/downstream-user-ca
+  validity: 24h
+  validAfterSkew: 30s
+  principals:
+    - '{{ .session.created.remote.user }}'
+  extensions:
+    permit-pty: ""
+    permit-port-forwarding: ""
+    permit-agent-forwarding: ""
+```
+
+The target OpenSSH server must trust the corresponding CA public key, commonly through `TrustedUserCAKeys`. Deploy a new CA public key to targets before changing `authorityIdentityFile`; keep the old public key trusted until all certificates issued by it have expired.
+
+Certificate metadata uses the reserved extensions `session-id@bifroest.engity.org`, `original-user@bifroest.engity.org`, `original-host@bifroest.engity.org`, `authorization-kind@bifroest.engity.org` and `evidence-v1@bifroest.engity.org`. The size-limited evidence document contains only allowlisted session identity, target and capability fields; passwords, OAuth tokens and unrestricted authorization data are never included. OpenSSH ignores unknown extensions unless a target-side integration evaluates them.
 
 ## Compatibility
 

--- a/docs/reference/session/fs.md
+++ b/docs/reference/session/fs.md
@@ -4,7 +4,7 @@ description: How to store Bifröst sessions on the local filesystem.
 
 # Filesystem session
 
-This variant of [session](index.md) is stored on the same local filesystem onb which also Bifröst is running.
+This variant of [session](index.md) is stored on the same local filesystem on which Bifröst is running.
 
 ## Properties
 
@@ -23,6 +23,8 @@ The maximum amount of parallel connections of one session. Each new connecting c
 <<property("storage", "File Path", "../data-type.md#file-path", default='<os specific>')>>
 Where the session information is stored locally.
 
+Only one Bifröst process can open a filesystem session repository at a time. A non-blocking operating-system lock is held for the repository lifetime; startup fails if another process already owns the same storage or if the lock state cannot be determined safely. Session state updates use atomic file replacement so a process interruption cannot expose a partially written token.
+
 The default value is different, depending on the platform Bifröst runs on:
 
 * Linux: `/var/lib/engity/bifroest/sessions`
@@ -36,4 +38,3 @@ All files/directories inside the session storage will be stored with this mode. 
 | <<dist("linux")>> | <<dist("windows")>> |
 | - | - |
 | <<compatibility_editions(True,True,"linux")>> | <<compatibility_editions(True,None,"windows")>> |
-

--- a/mise.toml
+++ b/mise.toml
@@ -73,6 +73,16 @@ run_windows = [
     '''del var\doc\requirements.txt'''
 ]
 
+[tasks."serve:docs"]
+run = [
+    "mkdocs --color serve -c",
+    "rm -f var/doc/requirements.txt"
+]
+run_windows = [
+    'mkdocs --color serve -c',
+    '''del var\doc\requirements.txt'''
+]
+
 [tasks."build:var"]
 hide = true
 run = "mkdir -p var"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,6 +144,7 @@ nav:
           - Local: reference/authorization/local.md
           - OIDC: reference/authorization/oidc.md
           - Simple: reference/authorization/simple.md
+          - Bifröst: reference/authorization/bifroest.md
           - Htpasswd: reference/authorization/htpasswd.md
           - None: reference/authorization/none.md
       - Environments:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,6 +151,7 @@ nav:
           - Docker: reference/environment/docker.md
           - Kubernetes: reference/environment/kubernetes.md
           - Local: reference/environment/local.md
+          - SSH: reference/environment/ssh.md
           - Dummy: reference/environment/dummy.md
       - Sessions:
           - reference/session/index.md

--- a/pkg/authorization/authorized-key-policy.go
+++ b/pkg/authorization/authorized-key-policy.go
@@ -53,6 +53,10 @@ func (this *AuthorizedKeyPolicy) AllowsListen(host string, port uint32) bool {
 	return this.PortForwardingAllowed && matchesAuthorizedKeyHostPortPatterns(this.permitListen, host, port)
 }
 
+func (this *AuthorizedKeyPolicy) HasPortForwardingDestinationRestrictions() bool {
+	return this != nil && (len(this.permitOpen) > 0 || len(this.permitListen) > 0)
+}
+
 func evaluateAuthorizedKeyOptions(options []crypto.AuthorizedKeyOption, remote bnet.Host, now time.Time) (*AuthorizedKeyPolicy, bool, error) {
 	if len(options) == 0 {
 		return nil, true, nil

--- a/pkg/authorization/bifroest-authorizer.go
+++ b/pkg/authorization/bifroest-authorizer.go
@@ -1,0 +1,212 @@
+package authorization
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"slices"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/engity-com/bifroest/pkg/configuration"
+	"github.com/engity-com/bifroest/pkg/errors"
+	"github.com/engity-com/bifroest/pkg/session"
+)
+
+var _ = RegisterAuthorizer(NewBifroest)
+
+type BifroestAuthorizer struct {
+	flow           configuration.FlowName
+	conf           *configuration.AuthorizationBifroest
+	trustedUserCAs []ssh.PublicKey
+	audiences      []string
+}
+
+func NewBifroest(_ context.Context, flow configuration.FlowName, conf *configuration.AuthorizationBifroest) (*BifroestAuthorizer, error) {
+	failf := func(msg string, args ...any) (*BifroestAuthorizer, error) {
+		return nil, errors.Newf(errors.Config, msg, args...)
+	}
+	if conf == nil {
+		return failf("nil configuration")
+	}
+	trustedUserCAs, err := loadTrustedUserCAs(&conf.UserCertificateAuthorityProperties)
+	if err != nil {
+		return failf("cannot load trusted user CAs: %w", err)
+	}
+	if len(trustedUserCAs) == 0 {
+		return failf("at least one trusted user CA is required")
+	}
+	var audiences []string
+	if conf.Audiences == nil {
+		audiences = []string{flow.String()}
+	} else {
+		audiences = append([]string{}, conf.Audiences...)
+	}
+	return &BifroestAuthorizer{
+		flow:           flow,
+		conf:           conf,
+		trustedUserCAs: trustedUserCAs,
+		audiences:      audiences,
+	}, nil
+}
+
+func (*BifroestAuthorizer) SupportsUserCertificates() {}
+
+func (this *BifroestAuthorizer) AuthorizePublicKey(req PublicKeyRequest) (Authorization, error) {
+	fail := func(err error) (Authorization, error) {
+		return nil, fmt.Errorf("cannot authorize bifroest %q via SSH user certificate: %w", req.Connection().Remote().User(), err)
+	}
+	evidence, policy, accepted, err := evaluateBifroestUserCertificate(
+		req.RemotePublicKey(), req.Connection().Remote().User(), this.trustedUserCAs, this.audiences,
+		this.conf.MaxCertificateValidity.Native(), time.Now(),
+	)
+	if err != nil {
+		req.Connection().Logger().
+			WithError(err).
+			Debug("presented Bifroest delegation certificate is invalid")
+		return Forbidden(req.Connection().Remote()), nil
+	}
+	if !accepted {
+		return Forbidden(req.Connection().Remote()), nil
+	}
+	auth := &BifroestAuthorization{
+		remote:   req.Connection().Remote(),
+		flow:     this.flow,
+		evidence: evidence,
+		policy:   policy,
+	}
+	accepted, err = req.Validate(auth)
+	if err != nil {
+		return fail(fmt.Errorf("cannot validate request: %w", err))
+	}
+	if !accepted {
+		return Forbidden(req.Connection().Remote()), nil
+	}
+	if !isPublicKeyVerified(req) {
+		return auth, nil
+	}
+	token, err := encodeBifroestAuthorizationToken(auth)
+	if err != nil {
+		return fail(err)
+	}
+	sess, err := req.Sessions().FindByAccessToken(req.Context(), token, (&session.FindOpts{}).WithPredicate(
+		session.IsFlow(this.flow),
+		session.IsStillValid,
+		session.IsRemoteName(req.Connection().Remote().User()),
+	))
+	if errors.Is(err, session.ErrNoSuchSession) {
+		sess, err = req.Sessions().Create(req.Context(), this.flow, req.Connection().Remote(), token)
+	}
+	if err != nil {
+		return fail(fmt.Errorf("cannot ensure session: %w", err))
+	}
+	auth.session = sess
+	return auth, nil
+}
+
+func (this *BifroestAuthorizer) AuthorizePassword(req PasswordRequest) (Authorization, error) {
+	return Forbidden(req.Connection().Remote()), nil
+}
+
+func (this *BifroestAuthorizer) AuthorizeInteractive(req InteractiveRequest) (Authorization, error) {
+	return Forbidden(req.Connection().Remote()), nil
+}
+
+func (this *BifroestAuthorizer) RestoreFromSession(ctx context.Context, sess session.Session, _ *RestoreOpts) (Authorization, error) {
+	failf := func(msg string, args ...any) (Authorization, error) {
+		args = append([]any{sess}, args...)
+		return nil, errors.Newf(errors.System, "cannot restore authorization from session %v: "+msg, args...)
+	}
+	if !sess.Flow().IsEqualTo(this.flow) {
+		return nil, ErrNoSuchAuthorization
+	}
+	raw, err := sess.AuthorizationToken(ctx)
+	if err != nil {
+		return failf("cannot retrieve token: %w", err)
+	}
+	if len(raw) == 0 {
+		return nil, ErrNoSuchAuthorization
+	}
+	token, err := decodeBifroestAuthorizationToken(raw)
+	if err != nil {
+		return failf("cannot decode token: %w", err)
+	}
+	info, err := sess.Info(ctx)
+	if err != nil {
+		return failf("cannot retrieve session info: %w", err)
+	}
+	lastAccessed, err := info.LastAccessed(ctx)
+	if err != nil {
+		return failf("cannot retrieve session last access: %w", err)
+	}
+	last := token.Evidence.LastHop()
+	now := time.Now()
+	if last == nil || token.Evidence.Origin.AuthorizationKind == "none" || last.Audience == "" || !slices.Contains(this.audiences, last.Audience) ||
+		now.Before(last.ValidAfter) || !now.Before(last.ValidBefore) || last.IssuedAt.After(now.Add(maxAuthorizationEvidenceClockSkew)) ||
+		this.conf.MaxCertificateValidity.Native() <= 0 || last.ValidBefore.Sub(last.IssuedAt) > this.conf.MaxCertificateValidity.Native() {
+		return failf("persisted delegation evidence is no longer valid")
+	}
+	if lastAccessed.Remote() == nil || last.TargetUser != lastAccessed.Remote().User() {
+		return failf("persisted delegation target does not match the session remote")
+	}
+	policy := &AuthorizedKeyPolicy{
+		PtyAllowed:             token.Policy.PtyAllowed,
+		PortForwardingAllowed:  token.Policy.PortForwardingAllowed,
+		AgentForwardingAllowed: token.Policy.AgentForwardingAllowed,
+	}
+	return &BifroestAuthorization{
+		remote:   lastAccessed.Remote(),
+		flow:     this.flow.Clone(),
+		session:  sess,
+		evidence: token.Evidence.Clone(),
+		policy:   policy,
+	}, nil
+}
+
+func (*BifroestAuthorizer) Close() error { return nil }
+
+func encodeBifroestAuthorizationToken(auth *BifroestAuthorization) ([]byte, error) {
+	if auth == nil || auth.evidence == nil || auth.policy == nil {
+		return nil, fmt.Errorf("cannot encode incomplete Bifroest authorization")
+	}
+	token := bifroestAuthorizationToken{
+		Schema:   bifroestAuthorizationTokenSchema,
+		Evidence: *auth.evidence.Clone(),
+		Policy: AuthorizationEvidencePolicy{
+			PtyAllowed:             auth.policy.PtyAllowed,
+			PortForwardingAllowed:  auth.policy.PortForwardingAllowed,
+			AgentForwardingAllowed: auth.policy.AgentForwardingAllowed,
+		},
+	}
+	raw, err := json.Marshal(token)
+	if err != nil {
+		return nil, fmt.Errorf("cannot encode Bifroest authorization token: %w", err)
+	}
+	return raw, nil
+}
+
+func decodeBifroestAuthorizationToken(raw []byte) (*bifroestAuthorizationToken, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var token bifroestAuthorizationToken
+	if err := decoder.Decode(&token); err != nil {
+		return nil, err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return nil, fmt.Errorf("authorization token contains trailing data")
+	}
+	if token.Schema != bifroestAuthorizationTokenSchema {
+		return nil, fmt.Errorf("unsupported authorization token schema %q", token.Schema)
+	}
+	if err := token.Evidence.Validate(); err != nil {
+		return nil, err
+	}
+	if token.Evidence.Policy() != token.Policy {
+		return nil, fmt.Errorf("authorization token policy does not match evidence")
+	}
+	return &token, nil
+}

--- a/pkg/authorization/bifroest-authorizer_test.go
+++ b/pkg/authorization/bifroest-authorizer_test.go
@@ -1,0 +1,47 @@
+package authorization
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestBifroestAuthorizationTokenBindsIdentityAndCredential(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	evidence := &AuthorizationEvidence{
+		Schema: AuthorizationEvidenceSchema,
+		Origin: AuthorizationEvidenceOrigin{User: "alice", Host: "203.0.113.1", AuthorizationKind: "simple"},
+		Hops: []AuthorizationEvidenceHop{{
+			CaFingerprint: ssh.FingerprintSHA256(newEvidenceTestSigner(t).PublicKey()), SubjectKeyFingerprint: ssh.FingerprintSHA256(newEvidenceTestSigner(t).PublicKey()),
+			Serial: 1, KeyId: "bifroest:source:" + uuid.NewString(), SessionId: uuid.NewString(), Flow: "source", AuthorizationKind: "simple",
+			Audience: "destination", TargetUser: "deploy", IssuedAt: now, ValidAfter: now.Add(-30 * time.Second), ValidBefore: now.Add(10 * time.Minute),
+			PtyAllowed: true,
+		}},
+	}
+	auth := &BifroestAuthorization{evidence: evidence, policy: &AuthorizedKeyPolicy{PtyAllowed: true}}
+	first, err := encodeBifroestAuthorizationToken(auth)
+	require.NoError(t, err)
+	restored, err := decodeBifroestAuthorizationToken(first)
+	require.NoError(t, err)
+	require.Equal(t, evidence, &restored.Evidence)
+	require.Equal(t, evidence.Policy(), restored.Policy)
+
+	otherOrigin := evidence.Clone()
+	otherOrigin.Origin.User = "bob"
+	second, err := encodeBifroestAuthorizationToken(&BifroestAuthorization{evidence: otherOrigin, policy: auth.policy})
+	require.NoError(t, err)
+	require.False(t, bytes.Equal(first, second))
+
+	otherCredential := evidence.Clone()
+	otherCredential.Hops[0].KeyId = "bifroest:source:" + uuid.NewString()
+	third, err := encodeBifroestAuthorizationToken(&BifroestAuthorization{evidence: otherCredential, policy: auth.policy})
+	require.NoError(t, err)
+	require.False(t, bytes.Equal(first, third))
+
+	_, err = decodeBifroestAuthorizationToken(append(first, []byte("{}")...))
+	require.ErrorContains(t, err, "trailing")
+}

--- a/pkg/authorization/bifroest.go
+++ b/pkg/authorization/bifroest.go
@@ -1,0 +1,89 @@
+package authorization
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/engity-com/bifroest/pkg/configuration"
+	"github.com/engity-com/bifroest/pkg/net"
+	"github.com/engity-com/bifroest/pkg/session"
+	"github.com/engity-com/bifroest/pkg/sys"
+)
+
+const bifroestAuthorizationTokenSchema = "bifroest.authorization/v1"
+
+type BifroestAuthorization struct {
+	remote   net.Remote
+	flow     configuration.FlowName
+	session  session.Session
+	evidence *AuthorizationEvidence
+	policy   *AuthorizedKeyPolicy
+}
+
+func (*BifroestAuthorization) AuthorizationKind() string { return "bifroest" }
+
+func (this *BifroestAuthorization) Remote() net.Remote { return this.remote }
+
+func (*BifroestAuthorization) IsAuthorized() bool { return true }
+
+func (*BifroestAuthorization) EnvVars() sys.EnvVars { return nil }
+
+func (this *BifroestAuthorization) Flow() configuration.FlowName { return this.flow }
+
+func (this *BifroestAuthorization) FindSession() session.Session { return this.session }
+
+func (*BifroestAuthorization) FindSessionsPublicKey() ssh.PublicKey { return nil }
+
+func (this *BifroestAuthorization) AuthorizedKeyPolicy() *AuthorizedKeyPolicy {
+	return cloneAuthorizedKeyPolicy(this.policy)
+}
+
+func (this *BifroestAuthorization) AuthorizationEvidence() *AuthorizationEvidence {
+	return this.evidence.Clone()
+}
+
+func (this *BifroestAuthorization) GetField(name string, ce ContextEnabled) (any, bool, error) {
+	return getField(name, ce, this, func() (any, bool, error) {
+		switch name {
+		case "origin":
+			return this.evidence.Origin, true, nil
+		case "peer":
+			return this.evidence.LastHop(), true, nil
+		case "hops":
+			return append([]AuthorizationEvidenceHop(nil), this.evidence.Hops...), true, nil
+		case "policy":
+			return this.evidence.Policy(), true, nil
+		default:
+			return nil, false, fmt.Errorf("unknown field %q", name)
+		}
+	})
+}
+
+func (this *BifroestAuthorization) Dispose(ctx context.Context) (bool, error) {
+	if this.session == nil {
+		return false, nil
+	}
+	if err := this.session.SetAuthorizationToken(ctx, nil); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+type bifroestAuthorizationToken struct {
+	Schema   string                      `json:"schema"`
+	Evidence AuthorizationEvidence       `json:"evidence"`
+	Policy   AuthorizationEvidencePolicy `json:"policy"`
+}
+
+func cloneAuthorizedKeyPolicy(value *AuthorizedKeyPolicy) *AuthorizedKeyPolicy {
+	if value == nil {
+		return nil
+	}
+	result := *value
+	result.Environment = value.Environment.Clone()
+	result.permitOpen = append([]authorizedKeyHostPortPattern(nil), value.permitOpen...)
+	result.permitListen = append([]authorizedKeyHostPortPattern(nil), value.permitListen...)
+	return &result
+}

--- a/pkg/authorization/evidence.go
+++ b/pkg/authorization/evidence.go
@@ -418,8 +418,9 @@ func validateAuthorizationEvidenceFingerprint(value string) error {
 	if !strings.HasPrefix(value, prefix) {
 		return fmt.Errorf("expected an SHA256 fingerprint")
 	}
-	raw, err := base64.RawStdEncoding.DecodeString(strings.TrimPrefix(value, prefix))
-	if err != nil || len(raw) != 32 {
+	encoded := strings.TrimPrefix(value, prefix)
+	raw, err := base64.RawStdEncoding.Strict().DecodeString(encoded)
+	if err != nil || len(raw) != 32 || base64.RawStdEncoding.EncodeToString(raw) != encoded {
 		return fmt.Errorf("expected an SHA256 fingerprint")
 	}
 	return nil

--- a/pkg/authorization/evidence.go
+++ b/pkg/authorization/evidence.go
@@ -1,0 +1,514 @@
+package authorization
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/engity-com/bifroest/pkg/configuration"
+)
+
+const (
+	AuthorizationEvidenceSchema        = "bifroest.authorization-evidence/v1"
+	AuthorizationEvidenceExtension     = "evidence-v1@bifroest.engity.org"
+	BifroestDelegationCriticalOption   = "bifroest-delegation@bifroest.engity.org"
+	MaxAuthorizationEvidenceSize       = 4 * 1024
+	MaxAuthorizationEvidenceHops       = 8
+	maxAuthorizationEvidenceStringSize = 1024
+	maxAuthorizationEvidenceClockSkew  = 30 * time.Second
+)
+
+type AuthorizationEvidence struct {
+	Schema string                      `json:"schema"`
+	Origin AuthorizationEvidenceOrigin `json:"origin"`
+	Hops   []AuthorizationEvidenceHop  `json:"hops"`
+}
+
+type AuthorizationEvidenceOrigin struct {
+	User              string `json:"user"`
+	Host              string `json:"host"`
+	AuthorizationKind string `json:"authorizationKind"`
+}
+
+func (this AuthorizationEvidenceOrigin) GetField(name string) (any, bool, error) {
+	switch name {
+	case "user":
+		return this.User, true, nil
+	case "host":
+		return this.Host, true, nil
+	case "authorizationKind":
+		return this.AuthorizationKind, true, nil
+	default:
+		return nil, false, fmt.Errorf("unknown field %q", name)
+	}
+}
+
+type AuthorizationEvidenceHop struct {
+	CaFingerprint          string    `json:"caFingerprint"`
+	SubjectKeyFingerprint  string    `json:"subjectKeyFingerprint"`
+	Serial                 uint64    `json:"serial"`
+	KeyId                  string    `json:"keyId"`
+	SessionId              string    `json:"sessionId"`
+	Flow                   string    `json:"flow"`
+	AuthorizationKind      string    `json:"authorizationKind"`
+	Audience               string    `json:"audience,omitempty"`
+	TargetUser             string    `json:"targetUser"`
+	IssuedAt               time.Time `json:"issuedAt"`
+	ValidAfter             time.Time `json:"validAfter"`
+	ValidBefore            time.Time `json:"validBefore"`
+	PtyAllowed             bool      `json:"ptyAllowed"`
+	PortForwardingAllowed  bool      `json:"portForwardingAllowed"`
+	AgentForwardingAllowed bool      `json:"agentForwardingAllowed"`
+}
+
+func (this AuthorizationEvidenceHop) GetField(name string) (any, bool, error) {
+	switch name {
+	case "caFingerprint":
+		return this.CaFingerprint, true, nil
+	case "subjectKeyFingerprint":
+		return this.SubjectKeyFingerprint, true, nil
+	case "serial":
+		return this.Serial, true, nil
+	case "keyId":
+		return this.KeyId, true, nil
+	case "sessionId":
+		return this.SessionId, true, nil
+	case "flow":
+		return this.Flow, true, nil
+	case "authorizationKind":
+		return this.AuthorizationKind, true, nil
+	case "audience":
+		return this.Audience, true, nil
+	case "targetUser":
+		return this.TargetUser, true, nil
+	case "issuedAt":
+		return this.IssuedAt, true, nil
+	case "validAfter":
+		return this.ValidAfter, true, nil
+	case "validBefore":
+		return this.ValidBefore, true, nil
+	case "ptyAllowed":
+		return this.PtyAllowed, true, nil
+	case "portForwardingAllowed":
+		return this.PortForwardingAllowed, true, nil
+	case "agentForwardingAllowed":
+		return this.AgentForwardingAllowed, true, nil
+	default:
+		return nil, false, fmt.Errorf("unknown field %q", name)
+	}
+}
+
+type AuthorizationEvidencePolicy struct {
+	PtyAllowed             bool `json:"ptyAllowed"`
+	PortForwardingAllowed  bool `json:"portForwardingAllowed"`
+	AgentForwardingAllowed bool `json:"agentForwardingAllowed"`
+}
+
+func (this AuthorizationEvidencePolicy) GetField(name string) (any, bool, error) {
+	switch name {
+	case "ptyAllowed":
+		return this.PtyAllowed, true, nil
+	case "portForwardingAllowed":
+		return this.PortForwardingAllowed, true, nil
+	case "agentForwardingAllowed":
+		return this.AgentForwardingAllowed, true, nil
+	default:
+		return nil, false, fmt.Errorf("unknown field %q", name)
+	}
+}
+
+type AuthorizationEvidenceProvider interface {
+	AuthorizationEvidence() *AuthorizationEvidence
+}
+
+func AuthorizationEvidenceOf(auth Authorization) *AuthorizationEvidence {
+	provider, ok := auth.(AuthorizationEvidenceProvider)
+	if !ok {
+		return nil
+	}
+	return provider.AuthorizationEvidence()
+}
+
+func (this *AuthorizationEvidence) Clone() *AuthorizationEvidence {
+	if this == nil {
+		return nil
+	}
+	result := *this
+	result.Hops = append([]AuthorizationEvidenceHop(nil), this.Hops...)
+	return &result
+}
+
+func (this *AuthorizationEvidence) LastHop() *AuthorizationEvidenceHop {
+	if this == nil || len(this.Hops) == 0 {
+		return nil
+	}
+	result := this.Hops[len(this.Hops)-1]
+	return &result
+}
+
+func (this *AuthorizationEvidence) Policy() AuthorizationEvidencePolicy {
+	last := this.LastHop()
+	if last == nil {
+		return AuthorizationEvidencePolicy{}
+	}
+	return AuthorizationEvidencePolicy{
+		PtyAllowed:             last.PtyAllowed,
+		PortForwardingAllowed:  last.PortForwardingAllowed,
+		AgentForwardingAllowed: last.AgentForwardingAllowed,
+	}
+}
+
+func (this *AuthorizationEvidence) Append(hop AuthorizationEvidenceHop) error {
+	if this == nil {
+		return fmt.Errorf("authorization evidence is absent")
+	}
+	this.Hops = append(this.Hops, normalizeAuthorizationEvidenceHop(hop))
+	if err := this.Validate(); err != nil {
+		this.Hops = this.Hops[:len(this.Hops)-1]
+		return err
+	}
+	return nil
+}
+
+func (this *AuthorizationEvidence) Validate() error {
+	if this == nil {
+		return fmt.Errorf("authorization evidence is absent")
+	}
+	if this.Schema != AuthorizationEvidenceSchema {
+		return fmt.Errorf("unsupported authorization evidence schema %q", this.Schema)
+	}
+	if err := validateAuthorizationEvidenceString("origin.user", this.Origin.User, true); err != nil {
+		return err
+	}
+	if err := validateAuthorizationEvidenceString("origin.host", this.Origin.Host, true); err != nil {
+		return err
+	}
+	if err := validateAuthorizationEvidenceString("origin.authorizationKind", this.Origin.AuthorizationKind, true); err != nil {
+		return err
+	}
+	if len(this.Hops) == 0 {
+		return fmt.Errorf("authorization evidence does not contain a hop")
+	}
+	if len(this.Hops) > MaxAuthorizationEvidenceHops {
+		return fmt.Errorf("authorization evidence exceeds %d hops", MaxAuthorizationEvidenceHops)
+	}
+
+	seenSubjects := make(map[string]int, len(this.Hops))
+	for i := range this.Hops {
+		hop := &this.Hops[i]
+		for name, value := range map[string]string{
+			"caFingerprint": hop.CaFingerprint, "subjectKeyFingerprint": hop.SubjectKeyFingerprint,
+			"keyId": hop.KeyId, "sessionId": hop.SessionId, "flow": hop.Flow,
+			"authorizationKind": hop.AuthorizationKind, "targetUser": hop.TargetUser,
+		} {
+			if err := validateAuthorizationEvidenceString(fmt.Sprintf("hops[%d].%s", i, name), value, true); err != nil {
+				return err
+			}
+		}
+		if err := validateAuthorizationEvidenceString(fmt.Sprintf("hops[%d].audience", i), hop.Audience, false); err != nil {
+			return err
+		}
+		if err := validateAuthorizationEvidenceFingerprint(hop.CaFingerprint); err != nil {
+			return fmt.Errorf("authorization evidence hops[%d].caFingerprint is invalid: %w", i, err)
+		}
+		if err := validateAuthorizationEvidenceFingerprint(hop.SubjectKeyFingerprint); err != nil {
+			return fmt.Errorf("authorization evidence hops[%d].subjectKeyFingerprint is invalid: %w", i, err)
+		}
+		parsedSessionId, err := uuid.Parse(hop.SessionId)
+		if err != nil {
+			return fmt.Errorf("authorization evidence hops[%d].sessionId is invalid: %w", i, err)
+		}
+		if parsedSessionId == uuid.Nil || parsedSessionId.String() != hop.SessionId {
+			return fmt.Errorf("authorization evidence hops[%d].sessionId is invalid", i)
+		}
+		flow := configuration.FlowName(hop.Flow)
+		if err := flow.Validate(); err != nil {
+			return fmt.Errorf("authorization evidence hops[%d].flow is invalid: %w", i, err)
+		}
+		if hop.Serial == 0 {
+			return fmt.Errorf("authorization evidence hops[%d].serial is zero", i)
+		}
+		if hop.IssuedAt.IsZero() || hop.ValidAfter.IsZero() || hop.ValidBefore.IsZero() {
+			return fmt.Errorf("authorization evidence hops[%d] has incomplete timestamps", i)
+		}
+		if hop.ValidAfter.After(hop.IssuedAt) || !hop.ValidBefore.After(hop.IssuedAt) {
+			return fmt.Errorf("authorization evidence hops[%d] has illegal validity boundaries", i)
+		}
+		if previous, exists := seenSubjects[hop.SubjectKeyFingerprint]; exists {
+			return fmt.Errorf("authorization evidence hops[%d].subjectKeyFingerprint duplicates hops[%d]", i, previous)
+		}
+		seenSubjects[hop.SubjectKeyFingerprint] = i
+		if i == 0 && hop.AuthorizationKind != this.Origin.AuthorizationKind {
+			return fmt.Errorf("authorization evidence first hop does not match the origin authorization kind")
+		}
+		if i > 0 {
+			previous := this.Hops[i-1]
+			if hop.AuthorizationKind != "bifroest" {
+				return fmt.Errorf("authorization evidence hops[%d] is not a Bifroest delegation", i)
+			}
+			if hop.ValidAfter.Before(previous.ValidAfter) {
+				return fmt.Errorf("authorization evidence hops[%d] extends the previous valid-after boundary", i)
+			}
+			if hop.ValidBefore.After(previous.ValidBefore) {
+				return fmt.Errorf("authorization evidence hops[%d] extends the previous validity", i)
+			}
+			if hop.PtyAllowed && !previous.PtyAllowed ||
+				hop.PortForwardingAllowed && !previous.PortForwardingAllowed ||
+				hop.AgentForwardingAllowed && !previous.AgentForwardingAllowed {
+				return fmt.Errorf("authorization evidence hops[%d] extends previous capabilities", i)
+			}
+		}
+	}
+	return nil
+}
+
+func EncodeAuthorizationEvidence(evidence *AuthorizationEvidence) ([]byte, error) {
+	if err := evidence.Validate(); err != nil {
+		return nil, err
+	}
+	normalized := evidence.Clone()
+	normalized.Origin.User = strings.TrimSpace(normalized.Origin.User)
+	normalized.Origin.Host = strings.TrimSpace(normalized.Origin.Host)
+	normalized.Origin.AuthorizationKind = strings.TrimSpace(normalized.Origin.AuthorizationKind)
+	for i := range normalized.Hops {
+		normalized.Hops[i] = normalizeAuthorizationEvidenceHop(normalized.Hops[i])
+	}
+	raw, err := json.Marshal(normalized)
+	if err != nil {
+		return nil, fmt.Errorf("cannot encode authorization evidence: %w", err)
+	}
+	if len(raw) > MaxAuthorizationEvidenceSize {
+		return nil, fmt.Errorf("authorization evidence exceeds %d bytes", MaxAuthorizationEvidenceSize)
+	}
+	return raw, nil
+}
+
+func DecodeAuthorizationEvidence(raw []byte) (*AuthorizationEvidence, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("authorization evidence is empty")
+	}
+	if len(raw) > MaxAuthorizationEvidenceSize {
+		return nil, fmt.Errorf("authorization evidence exceeds %d bytes", MaxAuthorizationEvidenceSize)
+	}
+	if err := rejectDuplicateAuthorizationEvidenceFields(raw); err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var result AuthorizationEvidence
+	if err := decoder.Decode(&result); err != nil {
+		return nil, fmt.Errorf("cannot decode authorization evidence: %w", err)
+	}
+	if err := ensureAuthorizationEvidenceJSONEnd(decoder); err != nil {
+		return nil, err
+	}
+	if err := result.Validate(); err != nil {
+		return nil, err
+	}
+	canonical, err := EncodeAuthorizationEvidence(&result)
+	if err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(raw, canonical) {
+		return nil, fmt.Errorf("authorization evidence is not canonically encoded")
+	}
+	return &result, nil
+}
+
+func ValidateBifroestDelegationEvidence(evidence *AuthorizationEvidence, certificate *ssh.Certificate, username string, audiences []string, maxValidity time.Duration, now time.Time) (*AuthorizedKeyPolicy, error) {
+	policy, err := ValidateAuthorizationEvidenceCertificate(evidence, certificate, username, now)
+	if err != nil {
+		return nil, err
+	}
+	last := evidence.LastHop()
+	if last == nil || last.Audience == "" || !slices.Contains(audiences, last.Audience) {
+		return nil, fmt.Errorf("authorization evidence audience %q is not accepted", lastAudience(last))
+	}
+	if evidence.Origin.AuthorizationKind == "none" {
+		return nil, fmt.Errorf("authorization evidence has an unauthenticated origin")
+	}
+	validAfter := last.ValidAfter
+	validBefore := last.ValidBefore
+	if last.IssuedAt.After(now.Add(maxAuthorizationEvidenceClockSkew)) || last.IssuedAt.Before(validAfter) || !last.IssuedAt.Before(validBefore) {
+		return nil, fmt.Errorf("authorization evidence issuance time is outside of the certificate validity")
+	}
+	if maxValidity <= 0 || validBefore.Sub(last.IssuedAt) > maxValidity {
+		return nil, fmt.Errorf("SSH certificate exceeds the maximum validity of %s", maxValidity)
+	}
+	return policy, nil
+}
+
+func ValidateAuthorizationEvidenceCertificate(evidence *AuthorizationEvidence, certificate *ssh.Certificate, username string, now time.Time) (*AuthorizedKeyPolicy, error) {
+	if err := evidence.Validate(); err != nil {
+		return nil, err
+	}
+	if certificate == nil {
+		return nil, fmt.Errorf("SSH user certificate is absent")
+	}
+	if certificate.Key == nil || certificate.SignatureKey == nil {
+		return nil, fmt.Errorf("SSH user certificate has incomplete key material")
+	}
+	last := evidence.LastHop()
+	validAfter, err := sshCertificateTime(certificate.ValidAfter)
+	if err != nil {
+		return nil, fmt.Errorf("certificate valid-after is invalid: %w", err)
+	}
+	validBefore, err := sshCertificateTime(certificate.ValidBefore)
+	if err != nil {
+		return nil, fmt.Errorf("certificate valid-before is invalid: %w", err)
+	}
+	if last.CaFingerprint != ssh.FingerprintSHA256(certificate.SignatureKey) ||
+		last.SubjectKeyFingerprint != ssh.FingerprintSHA256(certificate.Key) ||
+		last.Serial != certificate.Serial || last.KeyId != certificate.KeyId ||
+		last.TargetUser != username || !last.ValidAfter.Equal(validAfter) || !last.ValidBefore.Equal(validBefore) {
+		return nil, fmt.Errorf("authorization evidence does not match its SSH certificate")
+	}
+	if len(certificate.Nonce) == 0 {
+		return nil, fmt.Errorf("SSH certificate nonce is absent")
+	}
+	if last.IssuedAt.After(now.Add(maxAuthorizationEvidenceClockSkew)) || last.IssuedAt.Before(validAfter) || !last.IssuedAt.Before(validBefore) {
+		return nil, fmt.Errorf("authorization evidence issuance time is outside of the certificate validity")
+	}
+	policy, err := authorizedKeyPolicyForCertificate(nil, certificate)
+	if err != nil {
+		return nil, err
+	}
+	if last.PtyAllowed != policy.PtyAllowed || last.PortForwardingAllowed != policy.PortForwardingAllowed || last.AgentForwardingAllowed != policy.AgentForwardingAllowed {
+		return nil, fmt.Errorf("authorization evidence capabilities do not match the SSH certificate")
+	}
+	return policy, nil
+}
+
+func normalizeAuthorizationEvidenceHop(hop AuthorizationEvidenceHop) AuthorizationEvidenceHop {
+	hop.CaFingerprint = strings.TrimSpace(hop.CaFingerprint)
+	hop.SubjectKeyFingerprint = strings.TrimSpace(hop.SubjectKeyFingerprint)
+	hop.KeyId = strings.TrimSpace(hop.KeyId)
+	hop.SessionId = strings.TrimSpace(hop.SessionId)
+	hop.Flow = strings.TrimSpace(hop.Flow)
+	hop.AuthorizationKind = strings.TrimSpace(hop.AuthorizationKind)
+	hop.Audience = strings.TrimSpace(hop.Audience)
+	hop.TargetUser = strings.TrimSpace(hop.TargetUser)
+	hop.IssuedAt = hop.IssuedAt.UTC().Truncate(time.Second)
+	hop.ValidAfter = hop.ValidAfter.UTC().Truncate(time.Second)
+	hop.ValidBefore = hop.ValidBefore.UTC().Truncate(time.Second)
+	return hop
+}
+
+func validateAuthorizationEvidenceString(name, value string, required bool) error {
+	if required && strings.TrimSpace(value) == "" {
+		return fmt.Errorf("authorization evidence %s is empty", name)
+	}
+	if len(value) > maxAuthorizationEvidenceStringSize || strings.IndexByte(value, 0) >= 0 {
+		return fmt.Errorf("authorization evidence %s is illegal", name)
+	}
+	return nil
+}
+
+func validateAuthorizationEvidenceFingerprint(value string) error {
+	const prefix = "SHA256:"
+	if !strings.HasPrefix(value, prefix) {
+		return fmt.Errorf("expected an SHA256 fingerprint")
+	}
+	raw, err := base64.RawStdEncoding.DecodeString(strings.TrimPrefix(value, prefix))
+	if err != nil || len(raw) != 32 {
+		return fmt.Errorf("expected an SHA256 fingerprint")
+	}
+	return nil
+}
+
+func sshCertificateTime(value uint64) (time.Time, error) {
+	if value == ssh.CertTimeInfinity || value > math.MaxInt64 {
+		return time.Time{}, fmt.Errorf("unsupported infinite or out-of-range value")
+	}
+	return time.Unix(int64(value), 0).UTC(), nil
+}
+
+func lastAudience(hop *AuthorizationEvidenceHop) string {
+	if hop == nil {
+		return ""
+	}
+	return hop.Audience
+}
+
+func rejectDuplicateAuthorizationEvidenceFields(raw []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	if err := readUniqueAuthorizationEvidenceJSONValue(decoder); err != nil {
+		return fmt.Errorf("cannot decode authorization evidence: %w", err)
+	}
+	return ensureAuthorizationEvidenceJSONEnd(decoder)
+}
+
+func readUniqueAuthorizationEvidenceJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delim {
+	case '{':
+		seen := make(map[string]struct{})
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return fmt.Errorf("object key is not a string")
+			}
+			if _, exists := seen[key]; exists {
+				return fmt.Errorf("duplicate JSON field %q", key)
+			}
+			seen[key] = struct{}{}
+			if err := readUniqueAuthorizationEvidenceJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		end, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		if end != json.Delim('}') {
+			return fmt.Errorf("object is not terminated")
+		}
+	case '[':
+		for decoder.More() {
+			if err := readUniqueAuthorizationEvidenceJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		end, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		if end != json.Delim(']') {
+			return fmt.Errorf("array is not terminated")
+		}
+	default:
+		return fmt.Errorf("unexpected JSON delimiter %q", delim)
+	}
+	return nil
+}
+
+func ensureAuthorizationEvidenceJSONEnd(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("authorization evidence contains a second JSON value")
+		}
+		return fmt.Errorf("authorization evidence has trailing data: %w", err)
+	}
+	return nil
+}

--- a/pkg/authorization/evidence_test.go
+++ b/pkg/authorization/evidence_test.go
@@ -3,6 +3,7 @@ package authorization
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/base64"
 	"strings"
 	"testing"
 	"time"
@@ -110,6 +111,9 @@ func TestAuthorizationEvidenceRejectsCapabilityExpansionAndCycles(t *testing.T) 
 	invalid = evidence.Clone()
 	invalid.Hops[0].CaFingerprint = "SHA256:not-a-fingerprint"
 	require.ErrorContains(t, invalid.Validate(), "caFingerprint")
+	invalid = evidence.Clone()
+	invalid.Hops[0].SubjectKeyFingerprint = nonCanonicalEvidenceTestFingerprint(t, invalid.Hops[0].SubjectKeyFingerprint)
+	require.ErrorContains(t, invalid.Validate(), "subjectKeyFingerprint")
 	extendedValidAfter := base
 	extendedValidAfter.SubjectKeyFingerprint = ssh.FingerprintSHA256(newEvidenceTestSigner(t).PublicKey())
 	extendedValidAfter.Serial = 4
@@ -119,6 +123,23 @@ func TestAuthorizationEvidenceRejectsCapabilityExpansionAndCycles(t *testing.T) 
 	extendedValidAfter.AuthorizationKind = "bifroest"
 	extendedValidAfter.ValidAfter = base.ValidAfter.Add(-time.Second)
 	require.ErrorContains(t, evidence.Append(extendedValidAfter), "valid-after")
+}
+
+func nonCanonicalEvidenceTestFingerprint(t *testing.T, fingerprint string) string {
+	t.Helper()
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+	encoded := strings.TrimPrefix(fingerprint, "SHA256:")
+	require.Len(t, encoded, 43)
+	last := strings.IndexByte(alphabet, encoded[len(encoded)-1])
+	require.GreaterOrEqual(t, last, 0)
+	alternative := alphabet[(last&^3)|1]
+	nonCanonical := encoded[:len(encoded)-1] + string(alternative)
+	canonicalRaw, err := base64.RawStdEncoding.DecodeString(encoded)
+	require.NoError(t, err)
+	nonCanonicalRaw, err := base64.RawStdEncoding.DecodeString(nonCanonical)
+	require.NoError(t, err)
+	require.Equal(t, canonicalRaw, nonCanonicalRaw)
+	return "SHA256:" + nonCanonical
 }
 
 func TestEvaluateBifroestUserCertificateRejectsInvalidDelegations(t *testing.T) {

--- a/pkg/authorization/evidence_test.go
+++ b/pkg/authorization/evidence_test.go
@@ -1,0 +1,210 @@
+package authorization
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestAuthorizationEvidenceRoundtripAndCertificateValidation(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0).UTC()
+	authority := newEvidenceTestSigner(t)
+	subject := newEvidenceTestSigner(t)
+	certificate := &ssh.Certificate{
+		Key:             subject.PublicKey(),
+		Serial:          42,
+		CertType:        ssh.UserCert,
+		KeyId:           "bifroest:source:" + uuid.NewString(),
+		ValidPrincipals: []string{"deploy"},
+		ValidAfter:      uint64(now.Add(-30 * time.Second).Unix()),
+		ValidBefore:     uint64(now.Add(10 * time.Minute).Unix()),
+		Permissions: ssh.Permissions{
+			CriticalOptions: map[string]string{BifroestDelegationCriticalOption: ""},
+			Extensions:      map[string]string{"permit-pty": ""},
+		},
+	}
+	evidence := &AuthorizationEvidence{
+		Schema: AuthorizationEvidenceSchema,
+		Origin: AuthorizationEvidenceOrigin{User: "alice", Host: "203.0.113.1", AuthorizationKind: "simple"},
+	}
+	require.NoError(t, evidence.Append(AuthorizationEvidenceHop{
+		CaFingerprint:         ssh.FingerprintSHA256(authority.PublicKey()),
+		SubjectKeyFingerprint: ssh.FingerprintSHA256(subject.PublicKey()),
+		Serial:                certificate.Serial,
+		KeyId:                 certificate.KeyId,
+		SessionId:             uuid.NewString(),
+		Flow:                  "source",
+		AuthorizationKind:     "simple",
+		Audience:              "destination",
+		TargetUser:            "deploy",
+		IssuedAt:              now,
+		ValidAfter:            now.Add(-30 * time.Second),
+		ValidBefore:           now.Add(10 * time.Minute),
+		PtyAllowed:            true,
+	}))
+	raw, err := EncodeAuthorizationEvidence(evidence)
+	require.NoError(t, err)
+	certificate.Extensions[AuthorizationEvidenceExtension] = string(raw)
+	require.NoError(t, certificate.SignCert(rand.Reader, authority))
+
+	decoded, err := DecodeAuthorizationEvidence(raw)
+	require.NoError(t, err)
+	require.Equal(t, evidence, decoded)
+	policy, err := ValidateBifroestDelegationEvidence(decoded, certificate, "deploy", []string{"destination"}, 15*time.Minute, now)
+	require.NoError(t, err)
+	require.True(t, policy.PtyAllowed)
+	require.False(t, policy.PortForwardingAllowed)
+}
+
+func TestAuthorizationEvidenceStrictDecoding(t *testing.T) {
+	for name, raw := range map[string]string{
+		"duplicate":  `{"schema":"bifroest.authorization-evidence/v1","schema":"bifroest.authorization-evidence/v1"}`,
+		"unknown":    `{"schema":"bifroest.authorization-evidence/v1","unknown":true}`,
+		"suffix":     `{}` + `{}`,
+		"whitespace": ` {}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := DecodeAuthorizationEvidence([]byte(raw))
+			require.Error(t, err)
+		})
+	}
+	_, err := DecodeAuthorizationEvidence([]byte(strings.Repeat("x", MaxAuthorizationEvidenceSize+1)))
+	require.ErrorContains(t, err, "exceeds")
+}
+
+func TestAuthorizationEvidenceRejectsCapabilityExpansionAndCycles(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	first := newEvidenceTestSigner(t)
+	second := newEvidenceTestSigner(t)
+	base := AuthorizationEvidenceHop{
+		CaFingerprint: ssh.FingerprintSHA256(first.PublicKey()), SubjectKeyFingerprint: ssh.FingerprintSHA256(second.PublicKey()), Serial: 1,
+		KeyId: "one", SessionId: uuid.NewString(), Flow: "one", AuthorizationKind: "simple",
+		Audience: "two", TargetUser: "deploy", IssuedAt: now, ValidAfter: now.Add(-time.Second), ValidBefore: now.Add(time.Minute),
+	}
+	evidence := &AuthorizationEvidence{Schema: AuthorizationEvidenceSchema, Origin: AuthorizationEvidenceOrigin{User: "alice", Host: "host", AuthorizationKind: "simple"}}
+	require.NoError(t, evidence.Append(base))
+	expanded := base
+	expanded.SubjectKeyFingerprint = ssh.FingerprintSHA256(newEvidenceTestSigner(t).PublicKey())
+	expanded.Serial = 2
+	expanded.KeyId = "two"
+	expanded.SessionId = uuid.NewString()
+	expanded.Flow = "two"
+	expanded.AuthorizationKind = "bifroest"
+	expanded.PtyAllowed = true
+	require.ErrorContains(t, evidence.Append(expanded), "extends previous capabilities")
+	cycled := base
+	cycled.Serial = 3
+	cycled.KeyId = "three"
+	cycled.SessionId = uuid.NewString()
+	cycled.Flow = "three"
+	require.ErrorContains(t, evidence.Append(cycled), "duplicates")
+	invalid := evidence.Clone()
+	invalid.Hops[0].SessionId = uuid.Nil.String()
+	require.ErrorContains(t, invalid.Validate(), "sessionId")
+	invalid = evidence.Clone()
+	invalid.Hops[0].CaFingerprint = "SHA256:not-a-fingerprint"
+	require.ErrorContains(t, invalid.Validate(), "caFingerprint")
+	extendedValidAfter := base
+	extendedValidAfter.SubjectKeyFingerprint = ssh.FingerprintSHA256(newEvidenceTestSigner(t).PublicKey())
+	extendedValidAfter.Serial = 4
+	extendedValidAfter.KeyId = "four"
+	extendedValidAfter.SessionId = uuid.NewString()
+	extendedValidAfter.Flow = "four"
+	extendedValidAfter.AuthorizationKind = "bifroest"
+	extendedValidAfter.ValidAfter = base.ValidAfter.Add(-time.Second)
+	require.ErrorContains(t, evidence.Append(extendedValidAfter), "valid-after")
+}
+
+func TestEvaluateBifroestUserCertificateRejectsInvalidDelegations(t *testing.T) {
+	for _, scenario := range []string{
+		"missing-marker", "missing-evidence", "wrong-audience", "wrong-ca", "wrong-principal",
+		"inconsistent-hop", "unauthenticated-origin", "too-long", "expired", "not-yet-valid",
+	} {
+		t.Run(scenario, func(t *testing.T) {
+			now := time.Now().UTC().Truncate(time.Second)
+			authority := newEvidenceTestSigner(t)
+			subject := newEvidenceTestSigner(t)
+			username := "deploy"
+			certificate := &ssh.Certificate{
+				Key: subject.PublicKey(), Serial: 42, CertType: ssh.UserCert, KeyId: "bifroest:source:" + uuid.NewString(),
+				ValidPrincipals: []string{username}, ValidAfter: uint64(now.Add(-30 * time.Second).Unix()), ValidBefore: uint64(now.Add(10 * time.Minute).Unix()),
+				Permissions: ssh.Permissions{
+					CriticalOptions: map[string]string{BifroestDelegationCriticalOption: ""},
+					Extensions:      map[string]string{"permit-pty": ""},
+				},
+			}
+			evidence := &AuthorizationEvidence{
+				Schema: AuthorizationEvidenceSchema,
+				Origin: AuthorizationEvidenceOrigin{User: "alice", Host: "203.0.113.1", AuthorizationKind: "simple"},
+				Hops: []AuthorizationEvidenceHop{{
+					CaFingerprint: ssh.FingerprintSHA256(authority.PublicKey()), SubjectKeyFingerprint: ssh.FingerprintSHA256(subject.PublicKey()),
+					Serial: certificate.Serial, KeyId: certificate.KeyId, SessionId: uuid.NewString(), Flow: "source", AuthorizationKind: "simple",
+					Audience: "destination", TargetUser: username, IssuedAt: now,
+					ValidAfter: now.Add(-30 * time.Second), ValidBefore: now.Add(10 * time.Minute), PtyAllowed: true,
+				}},
+			}
+			trusted := []ssh.PublicKey{authority.PublicKey()}
+			includeEvidence := true
+			switch scenario {
+			case "missing-marker":
+				delete(certificate.CriticalOptions, BifroestDelegationCriticalOption)
+			case "missing-evidence":
+				includeEvidence = false
+			case "wrong-audience":
+				evidence.Hops[0].Audience = "another-destination"
+			case "wrong-ca":
+				trusted = []ssh.PublicKey{newEvidenceTestSigner(t).PublicKey()}
+			case "wrong-principal":
+				username = "another-user"
+			case "inconsistent-hop":
+				evidence.Hops[0].Serial++
+			case "unauthenticated-origin":
+				evidence.Origin.AuthorizationKind = "none"
+				evidence.Hops[0].AuthorizationKind = "none"
+			case "too-long":
+				certificate.ValidBefore = uint64(now.Add(16 * time.Minute).Unix())
+				evidence.Hops[0].ValidBefore = now.Add(16 * time.Minute)
+			case "expired":
+				certificate.ValidAfter = uint64(now.Add(-2 * time.Minute).Unix())
+				certificate.ValidBefore = uint64(now.Add(-time.Minute).Unix())
+				evidence.Hops[0].IssuedAt = now.Add(-90 * time.Second)
+				evidence.Hops[0].ValidAfter = now.Add(-2 * time.Minute)
+				evidence.Hops[0].ValidBefore = now.Add(-time.Minute)
+			case "not-yet-valid":
+				certificate.ValidAfter = uint64(now.Add(time.Minute).Unix())
+				certificate.ValidBefore = uint64(now.Add(2 * time.Minute).Unix())
+				evidence.Hops[0].IssuedAt = now.Add(90 * time.Second)
+				evidence.Hops[0].ValidAfter = now.Add(time.Minute)
+				evidence.Hops[0].ValidBefore = now.Add(2 * time.Minute)
+			}
+			if includeEvidence {
+				raw, err := EncodeAuthorizationEvidence(evidence)
+				require.NoError(t, err)
+				certificate.Extensions[AuthorizationEvidenceExtension] = string(raw)
+			}
+			require.NoError(t, certificate.SignCert(rand.Reader, authority))
+
+			actualEvidence, policy, accepted, _ := evaluateBifroestUserCertificate(
+				certificate, username, trusted, []string{"destination"}, 15*time.Minute, now,
+			)
+			require.False(t, accepted)
+			require.Nil(t, actualEvidence)
+			require.Nil(t, policy)
+		})
+	}
+}
+
+func newEvidenceTestSigner(t *testing.T) ssh.Signer {
+	t.Helper()
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	require.NoError(t, err)
+	return signer
+}

--- a/pkg/authorization/facade-authorizer.go
+++ b/pkg/authorization/facade-authorizer.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"golang.org/x/crypto/ssh"
+
 	"github.com/engity-com/bifroest/pkg/common"
 	"github.com/engity-com/bifroest/pkg/configuration"
 	"github.com/engity-com/bifroest/pkg/errors"
@@ -31,7 +33,13 @@ type AuthorizerFacade struct {
 }
 
 func (this *AuthorizerFacade) AuthorizePublicKey(req PublicKeyRequest) (Authorization, error) {
+	_, isCertificate := req.RemotePublicKey().(*ssh.Certificate)
 	for _, candidate := range this.entries {
+		if isCertificate {
+			if _, supported := candidate.CloseableAuthorizer.(userCertificateAuthorizer); !supported {
+				continue
+			}
+		}
 		if ok, err := candidate.canHandle(req); err != nil {
 			return nil, fmt.Errorf("[%v] %w", candidate.flow, err)
 		} else if ok {

--- a/pkg/authorization/htpasswd-authorizer.go
+++ b/pkg/authorization/htpasswd-authorizer.go
@@ -50,6 +50,11 @@ func (this *HtpasswdAuthorizer) AuthorizePublicKey(req PublicKeyRequest) (Author
 	failf := func(message string, args ...any) (Authorization, error) {
 		return fail(fmt.Errorf(message, args...))
 	}
+	auth := &htpasswd{
+		remote: req.Connection().Remote(),
+		flow:   this.flow,
+	}
+	setAuthorizationContext(req, auth)
 
 	sess, err := req.Sessions().FindByPublicKey(req.Context(), req.RemotePublicKey(), (&session.FindOpts{}).WithPredicate(
 		session.IsFlow(this.flow),
@@ -62,13 +67,8 @@ func (this *HtpasswdAuthorizer) AuthorizePublicKey(req PublicKeyRequest) (Author
 		return failf("cannot find session: %w", err)
 	}
 
-	auth := &htpasswd{
-		remote:            req.Connection().Remote(),
-		envVars:           nil,
-		flow:              this.flow,
-		session:           sess,
-		sessionsPublicKey: req.RemotePublicKey(),
-	}
+	auth.session = sess
+	auth.sessionsPublicKey = req.RemotePublicKey()
 
 	if accepted, err := req.Validate(auth); err != nil {
 		return nil, fmt.Errorf("cannot validate request: %w", err)

--- a/pkg/authorization/htpasswd.go
+++ b/pkg/authorization/htpasswd.go
@@ -20,6 +20,8 @@ type htpasswd struct {
 	sessionsPublicKey ssh.PublicKey
 }
 
+func (*htpasswd) AuthorizationKind() string { return "htpasswd" }
+
 func (this *htpasswd) Remote() net.Remote {
 	return this.remote
 }

--- a/pkg/authorization/kind.go
+++ b/pkg/authorization/kind.go
@@ -1,0 +1,12 @@
+package authorization
+
+type kindAware interface {
+	AuthorizationKind() string
+}
+
+func KindOf(auth Authorization) string {
+	if value, ok := auth.(kindAware); ok {
+		return value.AuthorizationKind()
+	}
+	return ""
+}

--- a/pkg/authorization/local-authorizer.go
+++ b/pkg/authorization/local-authorizer.go
@@ -3,7 +3,6 @@
 package authorization
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -27,8 +26,9 @@ var (
 )
 
 type LocalAuthorizer struct {
-	flow configuration.FlowName
-	conf *configuration.AuthorizationLocal
+	flow           configuration.FlowName
+	conf           *configuration.AuthorizationLocal
+	trustedUserCAs []ssh.PublicKey
 
 	Logger log.Logger
 
@@ -57,9 +57,17 @@ func NewLocal(ctx context.Context, flow configuration.FlowName, conf *configurat
 		conf:           conf,
 		userRepository: userRepository,
 	}
+	trustedUserCAs, err := loadTrustedUserCAs(&conf.UserCertificateAuthorityProperties)
+	if err != nil {
+		_ = userRepository.Close()
+		return failf("cannot load trusted user CAs: %w", err)
+	}
+	result.trustedUserCAs = trustedUserCAs
 
 	return &result, nil
 }
+
+func (*LocalAuthorizer) SupportsUserCertificates() {}
 
 func (this *LocalAuthorizer) AuthorizePublicKey(req PublicKeyRequest) (Authorization, error) {
 	fail := func(err error) (Authorization, error) {
@@ -69,7 +77,7 @@ func (this *LocalAuthorizer) AuthorizePublicKey(req PublicKeyRequest) (Authoriza
 		return fail(fmt.Errorf(message, args...))
 	}
 
-	if len(this.conf.AuthorizedKeys) == 0 {
+	if len(this.conf.AuthorizedKeys) == 0 && len(this.trustedUserCAs) == 0 {
 		req.Connection().Logger().Debug("authorized keys disabled for local user")
 		return Forbidden(req.Connection().Remote()), nil
 	}
@@ -98,7 +106,7 @@ func (this *LocalAuthorizer) AuthorizePublicKey(req PublicKeyRequest) (Authoriza
 	} else if !ok {
 		return Forbidden(req.Connection().Remote()), nil
 	}
-	policy, accepted, err := this.authorizedKeyPolicy(req, u)
+	policy, accepted, isCertificate, err := this.authorizedKeyPolicy(req, u)
 	if err != nil {
 		return fail(err)
 	}
@@ -106,6 +114,18 @@ func (this *LocalAuthorizer) AuthorizePublicKey(req PublicKeyRequest) (Authoriza
 		return Forbidden(req.Connection().Remote()), nil
 	}
 	candidate.authorizedKeyPolicy = policy
+
+	if isCertificate {
+		if !isPublicKeyVerified(req) {
+			return &candidate, nil
+		}
+		sess, err := this.ensureSessionFor(req, u)
+		if err != nil {
+			return fail(err)
+		}
+		candidate.session = sess
+		return &candidate, nil
+	}
 
 	sess, err := req.Sessions().FindByPublicKey(req.Context(), req.RemotePublicKey(), (&session.FindOpts{}).WithPredicate(
 		session.IsFlow(this.flow),
@@ -129,11 +149,11 @@ func (this *LocalAuthorizer) AuthorizePublicKey(req PublicKeyRequest) (Authoriza
 	return &candidate, nil
 }
 
-func (this *LocalAuthorizer) authorizedKeyPolicy(req PublicKeyRequest, u *user.User) (*AuthorizedKeyPolicy, bool, error) {
-	fail := func(err error) (*AuthorizedKeyPolicy, bool, error) {
-		return nil, false, err
+func (this *LocalAuthorizer) authorizedKeyPolicy(req PublicKeyRequest, u *user.User) (*AuthorizedKeyPolicy, bool, bool, error) {
+	fail := func(err error) (*AuthorizedKeyPolicy, bool, bool, error) {
+		return nil, false, false, err
 	}
-	failf := func(msg string, args ...any) (*AuthorizedKeyPolicy, bool, error) {
+	failf := func(msg string, args ...any) (*AuthorizedKeyPolicy, bool, bool, error) {
 		return fail(errors.Newf(errors.System, msg, args...))
 	}
 
@@ -141,44 +161,30 @@ func (this *LocalAuthorizer) authorizedKeyPolicy(req PublicKeyRequest, u *user.U
 	if err != nil {
 		return failf("cannot get authorized keys files of user: %w", err)
 	}
-	if len(files) == 0 {
+	if len(files) == 0 && len(this.trustedUserCAs) == 0 {
 		req.Connection().Logger().Debug("local user does not has any authorized keys file")
-		return nil, false, nil
+		return nil, false, false, nil
 	}
 
-	foundMatch := false
-	var policy *AuthorizedKeyPolicy
-	_, err = crypto.DoWithEachAuthorizedKey[bool](false, func(candidate ssh.PublicKey, options []crypto.AuthorizedKeyOption) (ok bool, canContinue bool, err error) {
-		remote := req.RemotePublicKey()
-
-		if remote.Type() != candidate.Type() {
-			return false, true, nil
-		}
-		if !bytes.Equal(remote.Marshal(), candidate.Marshal()) {
-			return false, true, nil
-		}
-
-		candidatePolicy, accepted, err := evaluateAuthorizedKeyOptions(options, req.Connection().Remote().Host(), time.Now())
-		if err != nil {
-			return false, false, err
-		}
-		if !accepted {
-			return false, true, nil
-		}
-		foundMatch = true
-		policy = candidatePolicy
-		return true, false, nil
-	}, files...)
+	policy, accepted, err := evaluatePublicKeyCredential(
+		req.RemotePublicKey(), req.Connection().Remote().User(), req.Connection().Remote().Host(), this.trustedUserCAs,
+		func(consumer func(ssh.PublicKey, []crypto.AuthorizedKeyOption) (bool, error)) error {
+			_, err := crypto.DoWithEachAuthorizedKey[bool](false, func(candidate ssh.PublicKey, options []crypto.AuthorizedKeyOption) (bool, bool, error) {
+				canContinue, err := consumer(candidate, options)
+				return !canContinue, canContinue, err
+			}, files...)
+			return err
+		}, time.Now())
 	if err != nil {
 		return fail(err)
 	}
 
-	if !foundMatch {
+	if !accepted {
 		req.Connection().Logger().Debug("presented public key does not match any authorized keys of local user")
-		return nil, false, nil
+		return nil, false, false, nil
 	}
-
-	return policy, true, nil
+	_, isCertificate := req.RemotePublicKey().(*ssh.Certificate)
+	return policy, true, isCertificate, nil
 }
 
 type userEnabledRequest struct {

--- a/pkg/authorization/local.go
+++ b/pkg/authorization/local.go
@@ -25,6 +25,8 @@ type local struct {
 	authorizedKeyPolicy *AuthorizedKeyPolicy
 }
 
+func (*local) AuthorizationKind() string { return "local" }
+
 func (this *local) Remote() net.Remote {
 	return this.remote
 }

--- a/pkg/authorization/none-authorizer.go
+++ b/pkg/authorization/none-authorizer.go
@@ -57,6 +57,7 @@ func (this *NoneAuthorizer) AuthorizePublicKey(req PublicKeyRequest) (Authorizat
 		nil,
 		nil,
 	}
+	setAuthorizationContext(req, auth)
 
 	sess, err := req.Sessions().FindByPublicKey(req.Context(), req.RemotePublicKey(), (&session.FindOpts{}).WithPredicate(
 		session.IsFlow(this.flow),

--- a/pkg/authorization/none.go
+++ b/pkg/authorization/none.go
@@ -20,6 +20,8 @@ type none struct {
 	sessionsPublicKey ssh.PublicKey
 }
 
+func (*none) AuthorizationKind() string { return "none" }
+
 func (this *none) Remote() net.Remote {
 	return this.remote
 }

--- a/pkg/authorization/oidc-device-auth-authorizer.go
+++ b/pkg/authorization/oidc-device-auth-authorizer.go
@@ -359,10 +359,42 @@ func (this *OidcDeviceAuthAuthorizer) AuthorizePublicKey(req PublicKeyRequest) (
 		return fail(fmt.Errorf(message, args...))
 	}
 
+	var selectedAuth *oidc
+	var selectedToken *oidcToken
+	restoreCandidate := func(ctx context.Context, candidate session.Session) (bool, error) {
+		at, err := candidate.AuthorizationToken(ctx)
+		if err != nil {
+			return false, err
+		}
+		if len(at) == 0 {
+			return false, nil
+		}
+		var token oidcToken
+		if err := json.Unmarshal(at, &token); err != nil {
+			return false, err
+		}
+		auth, err := this.finalizeAuth(ctx, req.Connection().Logger(), &token, true)
+		if errors.IsType(err, errors.Expired) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		auth.session = candidate
+		auth.sessionsPublicKey = req.RemotePublicKey()
+		accepted, err := req.Validate(auth)
+		if err != nil || !accepted {
+			return accepted, err
+		}
+		selectedAuth = auth
+		selectedToken = &token
+		return true, nil
+	}
 	sess, err := req.Sessions().FindByPublicKey(req.Context(), req.RemotePublicKey(), (&session.FindOpts{}).WithPredicate(
 		session.IsFlow(this.flow),
 		session.IsStillValid,
 		session.IsRemoteName(req.Connection().Remote().User()),
+		restoreCandidate,
 	))
 	if errors.Is(err, session.ErrNoSuchSession) {
 		return Forbidden(req.Connection().Remote()), nil
@@ -371,41 +403,14 @@ func (this *OidcDeviceAuthAuthorizer) AuthorizePublicKey(req PublicKeyRequest) (
 		return failf("cannot find session: %w", err)
 	}
 
-	at, err := sess.AuthorizationToken(req.Context())
-	if err != nil {
-		return fail(err)
-	}
-	if len(at) == 0 {
-		return Forbidden(req.Connection().Remote()), nil
-	}
-
-	var t oidcToken
-	if err := json.Unmarshal(at, &t); err != nil {
-		return fail(err)
-	}
-	// TODO! Refresh the token
-
 	req.Connection().Logger().Debug("token restored")
-
-	auth, err := this.finalizeAuth(req.Context(), req.Connection().Logger(), &t, true)
-	if err != nil {
+	if selectedAuth == nil || selectedToken == nil || selectedAuth.session != sess {
+		return failf("selected session was not restored")
+	}
+	if err := this.updateSessionWith(req.Context(), selectedToken, sess); err != nil {
 		return fail(err)
 	}
-	auth.sessionsPublicKey = req.RemotePublicKey()
-
-	if ok, err := req.Validate(auth); err != nil {
-		return fail(err)
-	} else if !ok {
-		return Forbidden(req.Connection().Remote()), nil
-	}
-
-	if err := this.updateSessionWith(req.Context(), &t, sess); err != nil {
-		return fail(err)
-	}
-
-	auth.session = sess
-
-	return auth, nil
+	return selectedAuth, nil
 }
 
 func (this *OidcDeviceAuthAuthorizer) finalizeAuth(ctx context.Context, logger log.Logger, t *oidcToken, retrieveArtifactsAllowed bool) (*oidc, error) {

--- a/pkg/authorization/oidc.go
+++ b/pkg/authorization/oidc.go
@@ -25,6 +25,8 @@ type oidc struct {
 	sessionsPublicKey ssh.PublicKey
 }
 
+func (*oidc) AuthorizationKind() string { return "oidc-device-auth" }
+
 func (this *oidc) GetField(name string, ce ContextEnabled) (any, bool, error) {
 	return getField(name, ce, this, func() (any, bool, error) {
 		switch name {

--- a/pkg/authorization/request.go
+++ b/pkg/authorization/request.go
@@ -31,3 +31,13 @@ type InteractiveRequest interface {
 	SendError(string) error
 	Prompt(msg string, echoOn bool) (string, error)
 }
+
+type authorizationContextSetter interface {
+	SetAuthorizationContext(Authorization)
+}
+
+func setAuthorizationContext(req Request, auth Authorization) {
+	if setter, ok := req.(authorizationContextSetter); ok {
+		setter.SetAuthorizationContext(auth)
+	}
+}

--- a/pkg/authorization/request.go
+++ b/pkg/authorization/request.go
@@ -20,6 +20,15 @@ type PublicKeyRequest interface {
 	RemotePublicKey() gossh.PublicKey
 }
 
+type verifiedPublicKeyRequest interface {
+	PublicKeyVerified() bool
+}
+
+func isPublicKeyVerified(req PublicKeyRequest) bool {
+	verified, ok := req.(verifiedPublicKeyRequest)
+	return ok && verified.PublicKeyVerified()
+}
+
 type PasswordRequest interface {
 	Request
 	RemotePassword() string

--- a/pkg/authorization/simple-authorizer.go
+++ b/pkg/authorization/simple-authorizer.go
@@ -1,7 +1,6 @@
 package authorization
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -22,8 +21,9 @@ var (
 )
 
 type SimpleAuthorizer struct {
-	flow configuration.FlowName
-	conf *configuration.AuthorizationSimple
+	flow           configuration.FlowName
+	conf           *configuration.AuthorizationSimple
+	trustedUserCAs []ssh.PublicKey
 
 	Logger log.Logger
 }
@@ -44,9 +44,16 @@ func NewSimple(_ context.Context, flow configuration.FlowName, conf *configurati
 		flow: flow,
 		conf: conf,
 	}
+	trustedUserCAs, err := loadTrustedUserCAs(&conf.UserCertificateAuthorityProperties)
+	if err != nil {
+		return failf("cannot load trusted user CAs: %w", err)
+	}
+	result.trustedUserCAs = trustedUserCAs
 
 	return &result, nil
 }
+
+func (*SimpleAuthorizer) SupportsUserCertificates() {}
 
 func (this *SimpleAuthorizer) AuthorizePublicKey(req PublicKeyRequest) (Authorization, error) {
 	fail := func(err error) (Authorization, error) {
@@ -63,7 +70,7 @@ func (this *SimpleAuthorizer) AuthorizePublicKey(req PublicKeyRequest) (Authoriz
 	if !accepted {
 		return Forbidden(req.Connection().Remote()), nil
 	}
-	policy, accepted, err := this.authorizedKeyPolicy(req, entry)
+	policy, accepted, isCertificate, err := this.authorizedKeyPolicy(req, entry)
 	if err != nil {
 		return fail(err)
 	}
@@ -71,6 +78,18 @@ func (this *SimpleAuthorizer) AuthorizePublicKey(req PublicKeyRequest) (Authoriz
 		return Forbidden(req.Connection().Remote()), nil
 	}
 	auth.authorizedKeyPolicy = policy
+
+	if isCertificate {
+		if !isPublicKeyVerified(req) {
+			return auth, nil
+		}
+		sess, err := this.ensureSessionFor(req, entry)
+		if err != nil {
+			return fail(err)
+		}
+		auth.session = sess
+		return auth, nil
+	}
 
 	sess, err := req.Sessions().FindByPublicKey(req.Context(), req.RemotePublicKey(), (&session.FindOpts{}).WithPredicate(
 		session.IsFlow(this.flow),
@@ -125,56 +144,43 @@ func (this *SimpleAuthorizer) lookupEntry(req Request) (entry *configuration.Aut
 	return entry, auth, accepted, nil
 }
 
-func (this *SimpleAuthorizer) authorizedKeyPolicy(req PublicKeyRequest, entry *configuration.AuthorizationSimpleEntry) (*AuthorizedKeyPolicy, bool, error) {
-	fail := func(err error) (*AuthorizedKeyPolicy, bool, error) {
-		return nil, false, err
+func (this *SimpleAuthorizer) authorizedKeyPolicy(req PublicKeyRequest, entry *configuration.AuthorizationSimpleEntry) (*AuthorizedKeyPolicy, bool, bool, error) {
+	fail := func(err error) (*AuthorizedKeyPolicy, bool, bool, error) {
+		return nil, false, false, err
 	}
-	failf := func(msg string, args ...any) (*AuthorizedKeyPolicy, bool, error) {
+	failf := func(msg string, args ...any) (*AuthorizedKeyPolicy, bool, bool, error) {
 		return fail(errors.Newf(errors.System, msg, args...))
 	}
 
-	foundMatch := false
-	var policy *AuthorizedKeyPolicy
-	evaluate := func(key ssh.PublicKey, options []crypto.AuthorizedKeyOption) (bool, error) {
-		if !bytes.Equal(req.RemotePublicKey().Marshal(), key.Marshal()) {
-			return true, nil
-		}
-		candidate, accepted, err := evaluateAuthorizedKeyOptions(options, req.Connection().Remote().Host(), time.Now())
-		if err != nil {
-			return false, err
-		}
-		if !accepted {
-			return true, nil
-		}
-		foundMatch = true
-		policy = candidate
-		return false, nil
-	}
-
-	if v := entry.AuthorizedKeysFile; !v.IsZero() {
-		if err := v.ForEach(func(_ int, key ssh.PublicKey, _ string, options []crypto.AuthorizedKeyOption) (canContinue bool, err error) {
-			return evaluate(key, options)
-		}); err != nil {
-			return failf("cannot resolve authorized keys of user %q: %w", entry.Name, err)
-		}
-	}
-
-	if !foundMatch {
-		if v := entry.AuthorizedKeys; !v.IsZero() {
-			if err := v.ForEach(func(_ int, key ssh.PublicKey, _ string, options []crypto.AuthorizedKeyOption) (canContinue bool, err error) {
-				return evaluate(key, options)
-			}); err != nil {
-				return failf("cannot resolve authorized keys of user %q: %w", entry.Name, err)
+	policy, accepted, err := evaluatePublicKeyCredential(
+		req.RemotePublicKey(), req.Connection().Remote().User(), req.Connection().Remote().Host(), this.trustedUserCAs,
+		func(consumer func(ssh.PublicKey, []crypto.AuthorizedKeyOption) (bool, error)) error {
+			if v := entry.AuthorizedKeysFile; !v.IsZero() {
+				stopped := false
+				if err := v.ForEach(func(_ int, key ssh.PublicKey, _ string, options []crypto.AuthorizedKeyOption) (bool, error) {
+					canContinue, err := consumer(key, options)
+					stopped = !canContinue
+					return canContinue, err
+				}); err != nil {
+					return err
+				}
+				if stopped {
+					return nil
+				}
 			}
-		}
+			return entry.AuthorizedKeys.ForEach(func(_ int, key ssh.PublicKey, _ string, options []crypto.AuthorizedKeyOption) (bool, error) {
+				return consumer(key, options)
+			})
+		}, time.Now())
+	if err != nil {
+		return failf("cannot resolve authorized keys of user %q: %w", entry.Name, err)
 	}
-
-	if !foundMatch {
+	if !accepted {
 		req.Connection().Logger().Debug("presented public key does not match any authorized keys of simple user")
-		return nil, false, nil
+		return nil, false, false, nil
 	}
-
-	return policy, true, nil
+	_, isCertificate := req.RemotePublicKey().(*ssh.Certificate)
+	return policy, true, isCertificate, nil
 }
 
 func (this *SimpleAuthorizer) ensureSessionFor(req Request, entry *configuration.AuthorizationSimpleEntry) (session.Session, error) {

--- a/pkg/authorization/simple.go
+++ b/pkg/authorization/simple.go
@@ -22,6 +22,8 @@ type simple struct {
 	authorizedKeyPolicy *AuthorizedKeyPolicy
 }
 
+func (*simple) AuthorizationKind() string { return "simple" }
+
 func (this *simple) Remote() net.Remote {
 	return this.remote
 }

--- a/pkg/authorization/user-certificate.go
+++ b/pkg/authorization/user-certificate.go
@@ -1,0 +1,198 @@
+package authorization
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/engity-com/bifroest/pkg/configuration"
+	"github.com/engity-com/bifroest/pkg/crypto"
+	bnet "github.com/engity-com/bifroest/pkg/net"
+)
+
+type userCertificateAuthorizer interface {
+	SupportsUserCertificates()
+}
+
+type authorizedKeySource func(func(ssh.PublicKey, []crypto.AuthorizedKeyOption) (bool, error)) error
+
+func loadTrustedUserCAs(conf *configuration.UserCertificateAuthorityProperties) ([]ssh.PublicKey, error) {
+	inline, err := conf.TrustedUserCAs.Get()
+	if err != nil {
+		return nil, fmt.Errorf("cannot load trustedUserCAs: %w", err)
+	}
+	if !conf.TrustedUserCAs.IsZero() && len(inline) == 0 {
+		return nil, fmt.Errorf("trustedUserCAs does not contain a public key")
+	}
+	fromFile, err := conf.TrustedUserCAsFile.Get()
+	if err != nil {
+		return nil, fmt.Errorf("cannot load trustedUserCAsFile: %w", err)
+	}
+	if !conf.TrustedUserCAsFile.IsZero() && len(fromFile) == 0 {
+		return nil, fmt.Errorf("trustedUserCAsFile does not contain a public key")
+	}
+	return append(inline, fromFile...), nil
+}
+
+func evaluatePublicKeyCredential(remote ssh.PublicKey, username string, remoteHost bnet.Host, trustedUserCAs []ssh.PublicKey, source authorizedKeySource, now time.Time) (*AuthorizedKeyPolicy, bool, error) {
+	certificate, isCertificate := remote.(*ssh.Certificate)
+	if isCertificate {
+		for _, ca := range trustedUserCAs {
+			if publicKeysEqual(certificate.SignatureKey, ca) && checkUserCertificate(certificate, username, nil, now) {
+				policy, err := authorizedKeyPolicyForCertificate(nil, certificate)
+				if err != nil {
+					return nil, false, nil
+				}
+				return policy, true, nil
+			}
+		}
+	}
+
+	var result *AuthorizedKeyPolicy
+	accepted := false
+	err := source(func(candidate ssh.PublicKey, options []crypto.AuthorizedKeyOption) (bool, error) {
+		if isCertificate {
+			if !publicKeysEqual(certificate.SignatureKey, candidate) {
+				return true, nil
+			}
+			certificateAuthority, principals, remaining, err := splitCertificateAuthorityOptions(options)
+			if err != nil {
+				return false, err
+			}
+			if !certificateAuthority {
+				return true, nil
+			}
+			if !checkUserCertificate(certificate, username, principals, now) {
+				return true, nil
+			}
+			base, permitted, err := evaluateAuthorizedKeyOptions(remaining, remoteHost, now)
+			if err != nil {
+				return false, err
+			}
+			if !permitted {
+				return true, nil
+			}
+			result, err = authorizedKeyPolicyForCertificate(base, certificate)
+			if err != nil {
+				return true, nil
+			}
+			accepted = true
+			return false, nil
+		}
+
+		if !publicKeysEqual(remote, candidate) {
+			return true, nil
+		}
+		certificateAuthority, _, remaining, err := splitCertificateAuthorityOptions(options)
+		if err != nil {
+			return false, err
+		}
+		if certificateAuthority {
+			return true, nil
+		}
+		result, accepted, err = evaluateAuthorizedKeyOptions(remaining, remoteHost, now)
+		if err != nil {
+			return false, err
+		}
+		if !accepted {
+			return true, nil
+		}
+		return false, nil
+	})
+	return result, accepted, err
+}
+
+func splitCertificateAuthorityOptions(options []crypto.AuthorizedKeyOption) (certificateAuthority bool, principals []string, remaining []crypto.AuthorizedKeyOption, err error) {
+	for _, option := range options {
+		switch option.Type {
+		case crypto.AuthorizedKeyCertAuthority:
+			if certificateAuthority {
+				return false, nil, nil, fmt.Errorf("authorized key option %q is configured more than once", option.Type)
+			}
+			certificateAuthority = true
+		case crypto.AuthorizedKeyPrincipals:
+			if principals != nil {
+				return false, nil, nil, fmt.Errorf("authorized key option %q is configured more than once", option.Type)
+			}
+			for _, principal := range strings.Split(option.Value, ",") {
+				principal = strings.TrimSpace(principal)
+				if principal == "" {
+					return false, nil, nil, fmt.Errorf("illegal empty authorized key principal")
+				}
+				principals = append(principals, principal)
+			}
+		default:
+			remaining = append(remaining, option)
+		}
+	}
+	if principals != nil && !certificateAuthority {
+		return false, nil, nil, fmt.Errorf("authorized key option %q requires %q", crypto.AuthorizedKeyPrincipals, crypto.AuthorizedKeyCertAuthority)
+	}
+	return certificateAuthority, principals, remaining, nil
+}
+
+func checkUserCertificate(certificate *ssh.Certificate, username string, allowedPrincipals []string, now time.Time) bool {
+	if certificate == nil || certificate.CertType != ssh.UserCert || username == "" || len(certificate.ValidPrincipals) == 0 {
+		return false
+	}
+	if !containsString(certificate.ValidPrincipals, username) {
+		return false
+	}
+	if len(allowedPrincipals) > 0 {
+		matched := false
+		for _, principal := range allowedPrincipals {
+			if containsString(certificate.ValidPrincipals, principal) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	checker := ssh.CertChecker{Clock: func() time.Time { return now }}
+	return checker.CheckCert(username, certificate) == nil
+}
+
+func authorizedKeyPolicyForCertificate(base *AuthorizedKeyPolicy, certificate *ssh.Certificate) (*AuthorizedKeyPolicy, error) {
+	for name, value := range certificate.Extensions {
+		switch name {
+		case "permit-pty", "permit-port-forwarding", "permit-agent-forwarding":
+			if value != "" {
+				return nil, fmt.Errorf("certificate extension %q must not have a value", name)
+			}
+		}
+	}
+	if base == nil {
+		base = &AuthorizedKeyPolicy{
+			PtyAllowed:             true,
+			PortForwardingAllowed:  true,
+			AgentForwardingAllowed: true,
+		}
+	}
+	base.PtyAllowed = base.PtyAllowed && hasCertificateExtension(certificate, "permit-pty")
+	base.PortForwardingAllowed = base.PortForwardingAllowed && hasCertificateExtension(certificate, "permit-port-forwarding")
+	base.AgentForwardingAllowed = base.AgentForwardingAllowed && hasCertificateExtension(certificate, "permit-agent-forwarding")
+	return base, nil
+}
+
+func hasCertificateExtension(certificate *ssh.Certificate, name string) bool {
+	_, ok := certificate.Extensions[name]
+	return ok
+}
+
+func containsString(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func publicKeysEqual(a, b ssh.PublicKey) bool {
+	return a != nil && b != nil && a.Type() == b.Type() && bytes.Equal(a.Marshal(), b.Marshal())
+}

--- a/pkg/authorization/user-certificate.go
+++ b/pkg/authorization/user-certificate.go
@@ -135,6 +135,10 @@ func splitCertificateAuthorityOptions(options []crypto.AuthorizedKeyOption) (cer
 }
 
 func checkUserCertificate(certificate *ssh.Certificate, username string, allowedPrincipals []string, now time.Time) bool {
+	return checkUserCertificateWithCriticalOptions(certificate, username, allowedPrincipals, nil, now)
+}
+
+func checkUserCertificateWithCriticalOptions(certificate *ssh.Certificate, username string, allowedPrincipals, supportedCriticalOptions []string, now time.Time) bool {
 	if certificate == nil || certificate.CertType != ssh.UserCert || username == "" || len(certificate.ValidPrincipals) == 0 {
 		return false
 	}
@@ -153,8 +157,45 @@ func checkUserCertificate(certificate *ssh.Certificate, username string, allowed
 			return false
 		}
 	}
-	checker := ssh.CertChecker{Clock: func() time.Time { return now }}
+	checker := ssh.CertChecker{
+		SupportedCriticalOptions: supportedCriticalOptions,
+		Clock:                    func() time.Time { return now },
+	}
 	return checker.CheckCert(username, certificate) == nil
+}
+
+func evaluateBifroestUserCertificate(remote ssh.PublicKey, username string, trustedUserCAs []ssh.PublicKey, audiences []string, maxValidity time.Duration, now time.Time) (*AuthorizationEvidence, *AuthorizedKeyPolicy, bool, error) {
+	certificate, ok := remote.(*ssh.Certificate)
+	if !ok {
+		return nil, nil, false, nil
+	}
+	marker, exists := certificate.CriticalOptions[BifroestDelegationCriticalOption]
+	if !exists || marker != "" || len(certificate.CriticalOptions) != 1 {
+		return nil, nil, false, nil
+	}
+	trusted := false
+	for _, ca := range trustedUserCAs {
+		if publicKeysEqual(certificate.SignatureKey, ca) {
+			trusted = true
+			break
+		}
+	}
+	if !trusted || !checkUserCertificateWithCriticalOptions(certificate, username, nil, []string{BifroestDelegationCriticalOption}, now) {
+		return nil, nil, false, nil
+	}
+	raw, exists := certificate.Extensions[AuthorizationEvidenceExtension]
+	if !exists {
+		return nil, nil, false, nil
+	}
+	evidence, err := DecodeAuthorizationEvidence([]byte(raw))
+	if err != nil {
+		return nil, nil, false, err
+	}
+	policy, err := ValidateBifroestDelegationEvidence(evidence, certificate, username, audiences, maxValidity, now)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	return evidence, policy, true, nil
 }
 
 func authorizedKeyPolicyForCertificate(base *AuthorizedKeyPolicy, certificate *ssh.Certificate) (*AuthorizedKeyPolicy, error) {

--- a/pkg/authorization/user-certificate_test.go
+++ b/pkg/authorization/user-certificate_test.go
@@ -1,0 +1,213 @@
+package authorization
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/engity-com/bifroest/pkg/configuration"
+	"github.com/engity-com/bifroest/pkg/crypto"
+	bnet "github.com/engity-com/bifroest/pkg/net"
+)
+
+func TestEvaluateGlobalUserCertificate(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	authority := newUserCertificateTestSigner(t)
+	subject := newUserCertificateTestSigner(t)
+	certificate := newUserCertificateTestCertificate(t, authority, subject.PublicKey(), now)
+
+	policy, accepted, err := evaluatePublicKeyCredential(certificate, "alice", bnet.Host{}, []ssh.PublicKey{authority.PublicKey()}, emptyAuthorizedKeySource, now)
+	require.NoError(t, err)
+	require.True(t, accepted)
+	require.True(t, policy.PtyAllowed)
+	require.False(t, policy.PortForwardingAllowed)
+	require.False(t, policy.AgentForwardingAllowed)
+}
+
+func TestEvaluateGlobalUserCertificateRejectsInvalidCertificate(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	authority := newUserCertificateTestSigner(t)
+	otherAuthority := newUserCertificateTestSigner(t)
+	subject := newUserCertificateTestSigner(t)
+
+	for name, mutate := range map[string]func(*ssh.Certificate){
+		"wrong-principal":  func(cert *ssh.Certificate) { cert.ValidPrincipals = []string{"bob"} },
+		"no-principals":    func(cert *ssh.Certificate) { cert.ValidPrincipals = nil },
+		"expired":          func(cert *ssh.Certificate) { cert.ValidBefore = uint64(now.Unix()) },
+		"not-yet-valid":    func(cert *ssh.Certificate) { cert.ValidAfter = uint64(now.Add(time.Minute).Unix()) },
+		"host-certificate": func(cert *ssh.Certificate) { cert.CertType = ssh.HostCert },
+		"critical-option":  func(cert *ssh.Certificate) { cert.CriticalOptions["force-command"] = "id" },
+		"unknown-critical": func(cert *ssh.Certificate) { cert.CriticalOptions["custom@example.org"] = "value" },
+		"extension-value":  func(cert *ssh.Certificate) { cert.Extensions["permit-pty"] = "invalid" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			certificate := newUserCertificateTestCertificateWithMutation(t, authority, subject.PublicKey(), now, mutate)
+			_, accepted, err := evaluatePublicKeyCredential(certificate, "alice", bnet.Host{}, []ssh.PublicKey{authority.PublicKey()}, emptyAuthorizedKeySource, now)
+			require.NoError(t, err)
+			require.False(t, accepted)
+		})
+	}
+
+	certificate := newUserCertificateTestCertificate(t, authority, subject.PublicKey(), now)
+	_, accepted, err := evaluatePublicKeyCredential(certificate, "alice", bnet.Host{}, []ssh.PublicKey{otherAuthority.PublicKey()}, emptyAuthorizedKeySource, now)
+	require.NoError(t, err)
+	require.False(t, accepted)
+}
+
+func TestEvaluateGlobalUserCertificateRejectsInvalidSignature(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	authority := newUserCertificateTestSigner(t)
+	certificate := newUserCertificateTestCertificate(t, authority, newUserCertificateTestSigner(t).PublicKey(), now)
+	certificate.ValidBefore++
+
+	_, accepted, err := evaluatePublicKeyCredential(certificate, "alice", bnet.Host{}, []ssh.PublicKey{authority.PublicKey()}, emptyAuthorizedKeySource, now)
+	require.NoError(t, err)
+	require.False(t, accepted)
+}
+
+func TestLoadTrustedUserCAsCreatesCombinedSnapshot(t *testing.T) {
+	inline := newUserCertificateTestSigner(t).PublicKey()
+	fromFile := newUserCertificateTestSigner(t).PublicKey()
+	replacement := newUserCertificateTestSigner(t).PublicKey()
+	filename := filepath.Join(t.TempDir(), "cas")
+	require.NoError(t, os.WriteFile(filename, ssh.MarshalAuthorizedKey(fromFile), 0600))
+	conf := configuration.UserCertificateAuthorityProperties{
+		TrustedUserCAs:     crypto.PublicKeys(strings.TrimSpace(string(ssh.MarshalAuthorizedKey(inline)))),
+		TrustedUserCAsFile: crypto.PublicKeysFile(filename),
+	}
+
+	actual, err := loadTrustedUserCAs(&conf)
+	require.NoError(t, err)
+	require.Len(t, actual, 2)
+	require.True(t, publicKeysEqual(inline, actual[0]))
+	require.True(t, publicKeysEqual(fromFile, actual[1]))
+	require.NoError(t, os.WriteFile(filename, ssh.MarshalAuthorizedKey(replacement), 0600))
+	require.True(t, publicKeysEqual(fromFile, actual[1]))
+}
+
+func TestLoadTrustedUserCAsRejectsEmptyExplicitSource(t *testing.T) {
+	filename := filepath.Join(t.TempDir(), "cas")
+	require.NoError(t, os.WriteFile(filename, []byte("# empty\n"), 0600))
+	_, err := loadTrustedUserCAs(&configuration.UserCertificateAuthorityProperties{TrustedUserCAsFile: crypto.PublicKeysFile(filename)})
+	require.ErrorContains(t, err, "does not contain")
+}
+
+func TestEvaluateAuthorizedKeysCertificateAuthority(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	authority := newUserCertificateTestSigner(t)
+	subject := newUserCertificateTestSigner(t)
+	certificate := newUserCertificateTestCertificate(t, authority, subject.PublicKey(), now)
+	source := oneAuthorizedKeySource(authority.PublicKey(), []crypto.AuthorizedKeyOption{
+		{Type: crypto.AuthorizedKeyCertAuthority},
+		{Type: crypto.AuthorizedKeyPrincipals, Value: "alice,automation"},
+		{Type: crypto.AuthorizedKeyRestrict},
+		{Type: crypto.AuthorizedKeyPty},
+	})
+
+	policy, accepted, err := evaluatePublicKeyCredential(certificate, "alice", bnet.Host{}, nil, source, now)
+	require.NoError(t, err)
+	require.True(t, accepted)
+	require.True(t, policy.PtyAllowed)
+	require.False(t, policy.PortForwardingAllowed)
+	require.False(t, policy.AgentForwardingAllowed)
+}
+
+func TestCertificateCannotReenableAuthorizedKeyRestrictions(t *testing.T) {
+	certificate := &ssh.Certificate{Permissions: ssh.Permissions{Extensions: map[string]string{
+		"permit-pty":              "",
+		"permit-port-forwarding":  "",
+		"permit-agent-forwarding": "",
+	}}}
+	policy, err := authorizedKeyPolicyForCertificate(&AuthorizedKeyPolicy{}, certificate)
+	require.NoError(t, err)
+	require.False(t, policy.PtyAllowed)
+	require.False(t, policy.PortForwardingAllowed)
+	require.False(t, policy.AgentForwardingAllowed)
+}
+
+func TestEvaluateAuthorizedKeysCertificateAuthorityRestrictions(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	authority := newUserCertificateTestSigner(t)
+	subject := newUserCertificateTestSigner(t)
+	certificate := newUserCertificateTestCertificate(t, authority, subject.PublicKey(), now)
+
+	for name, test := range map[string]struct {
+		key     ssh.PublicKey
+		options []crypto.AuthorizedKeyOption
+	}{
+		"principal-mismatch": {authority.PublicKey(), []crypto.AuthorizedKeyOption{{Type: crypto.AuthorizedKeyCertAuthority}, {Type: crypto.AuthorizedKeyPrincipals, Value: "bob"}}},
+		"ordinary-ca-key":    {authority.PublicKey(), nil},
+		"subject-key":        {subject.PublicKey(), nil},
+		"ca-as-direct-key":   {authority.PublicKey(), []crypto.AuthorizedKeyOption{{Type: crypto.AuthorizedKeyCertAuthority}}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			remote := ssh.PublicKey(certificate)
+			if name == "ca-as-direct-key" {
+				remote = authority.PublicKey()
+			}
+			_, accepted, err := evaluatePublicKeyCredential(remote, "alice", bnet.Host{}, nil, oneAuthorizedKeySource(test.key, test.options), now)
+			require.NoError(t, err)
+			require.False(t, accepted)
+		})
+	}
+}
+
+func TestEvaluateAuthorizedKeysRejectsPrincipalsWithoutCertificateAuthority(t *testing.T) {
+	key := newUserCertificateTestSigner(t).PublicKey()
+	_, _, err := evaluatePublicKeyCredential(key, "alice", bnet.Host{}, nil, oneAuthorizedKeySource(key, []crypto.AuthorizedKeyOption{{Type: crypto.AuthorizedKeyPrincipals, Value: "alice"}}), time.Now())
+	require.ErrorContains(t, err, "requires")
+}
+
+func newUserCertificateTestSigner(t *testing.T) ssh.Signer {
+	t.Helper()
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	require.NoError(t, err)
+	return signer
+}
+
+func newUserCertificateTestCertificate(t *testing.T, authority ssh.Signer, subject ssh.PublicKey, now time.Time) *ssh.Certificate {
+	t.Helper()
+	return newUserCertificateTestCertificateWithMutation(t, authority, subject, now, nil)
+}
+
+func newUserCertificateTestCertificateWithMutation(t *testing.T, authority ssh.Signer, subject ssh.PublicKey, now time.Time, mutate func(*ssh.Certificate)) *ssh.Certificate {
+	t.Helper()
+	certificate := &ssh.Certificate{
+		Key:             subject,
+		CertType:        ssh.UserCert,
+		ValidPrincipals: []string{"alice"},
+		ValidAfter:      uint64(now.Add(-time.Minute).Unix()),
+		ValidBefore:     uint64(now.Add(time.Hour).Unix()),
+		Permissions: ssh.Permissions{
+			CriticalOptions: map[string]string{},
+			Extensions: map[string]string{
+				"permit-pty": "",
+			},
+		},
+	}
+	if mutate != nil {
+		mutate(certificate)
+	}
+	require.NoError(t, certificate.SignCert(rand.Reader, authority))
+	return certificate
+}
+
+func emptyAuthorizedKeySource(func(ssh.PublicKey, []crypto.AuthorizedKeyOption) (bool, error)) error {
+	return nil
+}
+
+func oneAuthorizedKeySource(key ssh.PublicKey, options []crypto.AuthorizedKeyOption) authorizedKeySource {
+	return func(consumer func(ssh.PublicKey, []crypto.AuthorizedKeyOption) (bool, error)) error {
+		_, err := consumer(key, options)
+		return err
+	}
+}

--- a/pkg/common/keyed-mutex.go
+++ b/pkg/common/keyed-mutex.go
@@ -16,57 +16,43 @@ type KeyedMutex[K comparable] struct {
 type Unlocker func()
 
 func (this *KeyedMutex[K]) Lock(key K) Unlocker {
-	return this.lockBy(key, func(instance *keyMutex[K]) Unlocker {
-		instance.numberOfHoldes.Add(1)
-		instance.mutex.Lock()
-		return instance.unlock
-	})
+	instance := this.acquire(key)
+	instance.mutex.Lock()
+	return instance.unlock
 }
 
 func (this *KeyedMutex[K]) RLock(key K) Unlocker {
-	return this.lockBy(key, func(instance *keyMutex[K]) Unlocker {
-		instance.numberOfHoldes.Add(1)
-		instance.mutex.RLock()
-		return instance.rUnlock
-	})
+	instance := this.acquire(key)
+	instance.mutex.RLock()
+	return instance.rUnlock
 }
 
-func (this *KeyedMutex[K]) lockBy(key K, instanceLocker func(*keyMutex[K]) Unlocker) Unlocker {
+func (this *KeyedMutex[K]) acquire(key K) *keyMutex[K] {
 	this.init.Do(func() {
 		this.keyToMutex = make(map[K]*keyMutex[K])
 	})
-	rLockActive := true
 	this.uberMutex.RLock()
-	uberRUnlock := func() {
-		if rLockActive {
-			this.uberMutex.RUnlock()
-		}
-		rLockActive = false
-	}
-	defer uberRUnlock()
-
 	instance, ok := this.keyToMutex[key]
 	if ok {
-		uberRUnlock()
-		return instanceLocker(instance)
+		instance.numberOfHoldes.Add(1)
+		this.uberMutex.RUnlock()
+		return instance
 	}
-	uberRUnlock()
+	this.uberMutex.RUnlock()
 
 	this.uberMutex.Lock()
 	defer this.uberMutex.Unlock()
 
 	instance, ok = this.keyToMutex[key]
-	if ok {
-		return instanceLocker(instance)
+	if !ok {
+		instance = &keyMutex[K]{
+			key:    key,
+			parent: this,
+		}
+		this.keyToMutex[key] = instance
 	}
-
-	instance = &keyMutex[K]{
-		key:    key,
-		parent: this,
-	}
-	this.keyToMutex[key] = instance
-
-	return instanceLocker(instance)
+	instance.numberOfHoldes.Add(1)
+	return instance
 }
 
 type keyMutex[K comparable] struct {
@@ -96,6 +82,7 @@ func (this *keyMutex[K]) afterUnlock() {
 	}
 	this.parent.uberMutex.Lock()
 	defer this.parent.uberMutex.Unlock()
-
-	delete(this.parent.keyToMutex, this.key)
+	if this.numberOfHoldes.Load() == 0 && this.parent.keyToMutex[this.key] == this {
+		delete(this.parent.keyToMutex, this.key)
+	}
 }

--- a/pkg/configuration/authorization-bifroest.go
+++ b/pkg/configuration/authorization-bifroest.go
@@ -1,0 +1,133 @@
+package configuration
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/engity-com/bifroest/pkg/common"
+)
+
+var (
+	_ = RegisterAuthorizationV(func() AuthorizationV {
+		return &AuthorizationBifroest{}
+	})
+
+	DefaultAuthorizationBifroestMaxCertificateValidity = common.DurationOf(15 * time.Minute)
+)
+
+type AuthorizationBifroest struct {
+	UserCertificateAuthorityProperties `yaml:",inline"`
+	Audiences                          BifroestAudiences `yaml:"audiences,omitempty"`
+	MaxCertificateValidity             common.Duration   `yaml:"maxCertificateValidity,omitempty"`
+}
+
+func (this *AuthorizationBifroest) SetDefaults() error {
+	return setDefaults(this,
+		func(v *AuthorizationBifroest) (string, defaulter) { return "", &v.UserCertificateAuthorityProperties },
+		func(v *AuthorizationBifroest) (string, defaulter) { return "audiences", &v.Audiences },
+		fixedDefault("maxCertificateValidity", func(v *AuthorizationBifroest) *common.Duration { return &v.MaxCertificateValidity }, DefaultAuthorizationBifroestMaxCertificateValidity),
+	)
+}
+
+func (this *AuthorizationBifroest) Trim() error {
+	return trim(this,
+		func(v *AuthorizationBifroest) (string, trimmer) { return "", &v.UserCertificateAuthorityProperties },
+		func(v *AuthorizationBifroest) (string, trimmer) { return "audiences", &v.Audiences },
+		noopTrim[AuthorizationBifroest]("maxCertificateValidity"),
+	)
+}
+
+func (this *AuthorizationBifroest) Validate() error {
+	if this.TrustedUserCAs.IsZero() && this.TrustedUserCAsFile.IsZero() {
+		return fmt.Errorf("[trustedUserCAs] or [trustedUserCAsFile] required")
+	}
+	if this.MaxCertificateValidity.Native() <= 0 {
+		return fmt.Errorf("[maxCertificateValidity] has to be positive")
+	}
+	return validate(this,
+		func(v *AuthorizationBifroest) (string, validator) { return "", &v.UserCertificateAuthorityProperties },
+		func(v *AuthorizationBifroest) (string, validator) { return "audiences", &v.Audiences },
+		func(v *AuthorizationBifroest) (string, validator) {
+			return "maxCertificateValidity", &v.MaxCertificateValidity
+		},
+	)
+}
+
+func (this *AuthorizationBifroest) UnmarshalYAML(node *yaml.Node) error {
+	return unmarshalYAML(this, node, func(target *AuthorizationBifroest, node *yaml.Node) error {
+		type raw AuthorizationBifroest
+		return node.Decode((*raw)(target))
+	})
+}
+
+func (this AuthorizationBifroest) IsEqualTo(other any) bool {
+	switch v := other.(type) {
+	case AuthorizationBifroest:
+		return this.isEqualTo(&v)
+	case *AuthorizationBifroest:
+		return v != nil && this.isEqualTo(v)
+	default:
+		return false
+	}
+}
+
+func (this AuthorizationBifroest) isEqualTo(other *AuthorizationBifroest) bool {
+	return isEqual(&this.UserCertificateAuthorityProperties, &other.UserCertificateAuthorityProperties) &&
+		isEqual(&this.Audiences, &other.Audiences) &&
+		isEqual(&this.MaxCertificateValidity, &other.MaxCertificateValidity)
+}
+
+func (AuthorizationBifroest) Types() []string        { return []string{"bifroest"} }
+func (AuthorizationBifroest) FeatureFlags() []string { return []string{"bifroest"} }
+
+type BifroestAudiences []string
+
+func (this *BifroestAudiences) SetDefaults() error {
+	return nil
+}
+
+func (this *BifroestAudiences) Trim() error {
+	for i := range *this {
+		(*this)[i] = strings.TrimSpace((*this)[i])
+	}
+	return this.Validate()
+}
+
+func (this BifroestAudiences) Validate() error {
+	if this != nil && len(this) == 0 {
+		return fmt.Errorf("must not be explicitly empty")
+	}
+	seen := make(map[string]int, len(this))
+	for i, value := range this {
+		if value == "" || strings.IndexByte(value, 0) >= 0 {
+			return fmt.Errorf("[%d] required but absent or illegal", i)
+		}
+		if previous, exists := seen[value]; exists {
+			return fmt.Errorf("[%d] duplicates [%d] %q", i, previous, value)
+		}
+		seen[value] = i
+	}
+	return nil
+}
+
+func (this *BifroestAudiences) UnmarshalYAML(node *yaml.Node) error {
+	return unmarshalYAML(this, node, func(target *BifroestAudiences, node *yaml.Node) error {
+		type raw BifroestAudiences
+		return node.Decode((*raw)(target))
+	})
+}
+
+func (this BifroestAudiences) IsEqualTo(other any) bool {
+	switch v := other.(type) {
+	case BifroestAudiences:
+		return slices.Equal(this, v)
+	case *BifroestAudiences:
+		return v != nil && slices.Equal(this, *v)
+	default:
+		return false
+	}
+}

--- a/pkg/configuration/authorization-bifroest_test.go
+++ b/pkg/configuration/authorization-bifroest_test.go
@@ -1,0 +1,63 @@
+package configuration
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+	"gopkg.in/yaml.v3"
+
+	"github.com/engity-com/bifroest/pkg/crypto"
+)
+
+func TestAuthorizationBifroestConfiguration(t *testing.T) {
+	public, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	key, err := ssh.NewPublicKey(public)
+	require.NoError(t, err)
+	plainKey := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(key)))
+
+	var authorization Authorization
+	require.NoError(t, yaml.Unmarshal([]byte("type: bifroest\ntrustedUserCAs: "+plainKey+"\naudiences: [production, replacement]\n"), &authorization))
+	actual, ok := authorization.V.(*AuthorizationBifroest)
+	require.True(t, ok)
+	require.Equal(t, BifroestAudiences{"production", "replacement"}, actual.Audiences)
+	require.Equal(t, 15*time.Minute, actual.MaxCertificateValidity.Native())
+	require.Equal(t, crypto.PublicKeys(plainKey), actual.TrustedUserCAs)
+
+	roundtrip, err := yaml.Marshal(&authorization)
+	require.NoError(t, err)
+	var restored Authorization
+	require.NoError(t, yaml.Unmarshal(roundtrip, &restored))
+	require.True(t, authorization.IsEqualTo(restored))
+}
+
+func TestAuthorizationBifroestRejectsInvalidConfiguration(t *testing.T) {
+	for _, plain := range []string{
+		"type: bifroest\n",
+		"type: bifroest\ntrustedUserCAs: invalid\n",
+		"type: bifroest\ntrustedUserCAs: ssh-ed25519 AAAA\naudiences: ['']\n",
+		"type: bifroest\ntrustedUserCAs: ssh-ed25519 AAAA\nmaxCertificateValidity: 0s\n",
+	} {
+		var authorization Authorization
+		require.Error(t, yaml.Unmarshal([]byte(plain), &authorization))
+	}
+}
+
+func TestAuthorizationBifroestRejectsExplicitlyEmptyAudiences(t *testing.T) {
+	public, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	key, err := ssh.NewPublicKey(public)
+	require.NoError(t, err)
+	plainKey := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(key)))
+
+	var absent Authorization
+	require.NoError(t, yaml.Unmarshal([]byte("type: bifroest\ntrustedUserCAs: "+plainKey+"\n"), &absent))
+	require.Nil(t, absent.V.(*AuthorizationBifroest).Audiences)
+	var empty Authorization
+	require.Error(t, yaml.Unmarshal([]byte("type: bifroest\ntrustedUserCAs: "+plainKey+"\naudiences: []\n"), &empty))
+}

--- a/pkg/configuration/authorization-local.go
+++ b/pkg/configuration/authorization-local.go
@@ -18,13 +18,15 @@ var (
 )
 
 type AuthorizationLocal struct {
-	AuthorizedKeys template.Strings   `yaml:"authorizedKeys,omitempty"`
-	Password       PasswordProperties `yaml:"password,omitempty"`
-	PamService     string             `yaml:"pamService,omitempty"`
+	UserCertificateAuthorityProperties `yaml:",inline"`
+	AuthorizedKeys                     template.Strings   `yaml:"authorizedKeys,omitempty"`
+	Password                           PasswordProperties `yaml:"password,omitempty"`
+	PamService                         string             `yaml:"pamService,omitempty"`
 }
 
 func (this *AuthorizationLocal) SetDefaults() error {
 	return setDefaults(this,
+		func(v *AuthorizationLocal) (string, defaulter) { return "", &v.UserCertificateAuthorityProperties },
 		fixedDefault("authorizedKeys", func(v *AuthorizationLocal) *template.Strings { return &v.AuthorizedKeys }, DefaultAuthorizationLocalAuthorizedKeys),
 		func(v *AuthorizationLocal) (string, defaulter) { return "password", &v.Password },
 		fixedDefault("pamService", func(v *AuthorizationLocal) *string { return &v.PamService }, DefaultAuthorizationLocalPamService),
@@ -33,6 +35,7 @@ func (this *AuthorizationLocal) SetDefaults() error {
 
 func (this *AuthorizationLocal) Trim() error {
 	return trim(this,
+		func(v *AuthorizationLocal) (string, trimmer) { return "", &v.UserCertificateAuthorityProperties },
 		noopTrim[AuthorizationLocal]("authorizedKeys"),
 		func(v *AuthorizationLocal) (string, trimmer) { return "password", &v.Password },
 		func(v *AuthorizationLocal) (string, trimmer) { return "pamService", &stringTrimmer{&v.PamService} },
@@ -41,6 +44,7 @@ func (this *AuthorizationLocal) Trim() error {
 
 func (this *AuthorizationLocal) Validate() error {
 	return validate(this,
+		func(v *AuthorizationLocal) (string, validator) { return "", &v.UserCertificateAuthorityProperties },
 		func(v *AuthorizationLocal) (string, validator) { return "authorizedKeys", &v.AuthorizedKeys },
 		func(v *AuthorizationLocal) (string, validator) { return "password", &v.Password },
 		noopValidate[AuthorizationLocal]("pamService"),
@@ -69,7 +73,8 @@ func (this AuthorizationLocal) IsEqualTo(other any) bool {
 }
 
 func (this AuthorizationLocal) isEqualTo(other *AuthorizationLocal) bool {
-	return isEqual(&this.AuthorizedKeys, &other.AuthorizedKeys) &&
+	return isEqual(&this.UserCertificateAuthorityProperties, &other.UserCertificateAuthorityProperties) &&
+		isEqual(&this.AuthorizedKeys, &other.AuthorizedKeys) &&
 		isEqual(&this.Password, &other.Password) &&
 		this.PamService == other.PamService
 }

--- a/pkg/configuration/authorization-simple.go
+++ b/pkg/configuration/authorization-simple.go
@@ -11,23 +11,27 @@ var (
 )
 
 type AuthorizationSimple struct {
-	Entries AuthorizationSimpleEntries `yaml:"entries,omitempty"`
+	UserCertificateAuthorityProperties `yaml:",inline"`
+	Entries                            AuthorizationSimpleEntries `yaml:"entries,omitempty"`
 }
 
 func (this *AuthorizationSimple) SetDefaults() error {
 	return setDefaults(this,
+		func(v *AuthorizationSimple) (string, defaulter) { return "", &v.UserCertificateAuthorityProperties },
 		func(v *AuthorizationSimple) (string, defaulter) { return "entries", &v.Entries },
 	)
 }
 
 func (this *AuthorizationSimple) Trim() error {
 	return trim(this,
+		func(v *AuthorizationSimple) (string, trimmer) { return "", &v.UserCertificateAuthorityProperties },
 		func(v *AuthorizationSimple) (string, trimmer) { return "entries", &v.Entries },
 	)
 }
 
 func (this *AuthorizationSimple) Validate() error {
 	return validate(this,
+		func(v *AuthorizationSimple) (string, validator) { return "", &v.UserCertificateAuthorityProperties },
 		func(v *AuthorizationSimple) (string, validator) { return "entries", &v.Entries },
 	)
 }
@@ -54,7 +58,8 @@ func (this AuthorizationSimple) IsEqualTo(other any) bool {
 }
 
 func (this AuthorizationSimple) isEqualTo(other *AuthorizationSimple) bool {
-	return isEqual(&this.Entries, &other.Entries)
+	return isEqual(&this.UserCertificateAuthorityProperties, &other.UserCertificateAuthorityProperties) &&
+		isEqual(&this.Entries, &other.Entries)
 }
 
 func (this AuthorizationSimple) Types() []string {

--- a/pkg/configuration/authorization.go
+++ b/pkg/configuration/authorization.go
@@ -93,19 +93,21 @@ func (this *Authorization) UnmarshalYAML(node *yaml.Node) error {
 }
 
 func (this *Authorization) MarshalYAML() (any, error) {
-	typeBuf := struct {
-		AuthorizationV `yaml:",inline"`
-		Type           string `yaml:"type,omitempty"`
-	}{
-		AuthorizationV: this.V,
+	if this.V == nil {
+		return struct{}{}, nil
 	}
-
-	if this.V != nil {
-		typeBuf.Type = this.V.Types()[0]
-		typeBuf.AuthorizationV = this.V
+	var result yaml.Node
+	if err := result.Encode(this.V); err != nil {
+		return nil, err
 	}
-
-	return typeBuf, nil
+	if result.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("authorization %T does not encode as a mapping", this.V)
+	}
+	result.Content = append([]*yaml.Node{
+		{Kind: yaml.ScalarNode, Tag: "!!str", Value: "type"},
+		{Kind: yaml.ScalarNode, Tag: "!!str", Value: this.V.Types()[0]},
+	}, result.Content...)
+	return &result, nil
 }
 
 func (this Authorization) IsEqualTo(other any) bool {

--- a/pkg/configuration/configuration_unix_test.go
+++ b/pkg/configuration/configuration_unix_test.go
@@ -105,7 +105,7 @@ func TestConfiguration_UnmarshalYAML(t *testing.T) {
 						RetrieveIdToken:  DefaultAuthorizationOidcRetrieveIdToken,
 						RetrieveUserInfo: DefaultAuthorizationOidcRetrieveUserInfo,
 					}},
-					Environment: Environment{&EnvironmentLocal{
+					Environment: Environment{V: &EnvironmentLocal{
 						User: UserRequirementTemplate{
 							Name:        template.MustNewString("foo"),
 							DisplayName: template.MustNewString(""),

--- a/pkg/configuration/configuration_unix_test.go
+++ b/pkg/configuration/configuration_unix_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/echocat/slf4g/sdk/testlog"
+	"github.com/stretchr/testify/require"
 
 	"github.com/engity-com/bifroest/pkg/common"
 	"github.com/engity-com/bifroest/pkg/crypto"
@@ -14,6 +15,8 @@ import (
 
 func TestConfiguration_UnmarshalYAML(t *testing.T) {
 	testlog.Hook(t)
+	require.Equal(t, "/etc/engity/bifroest/client-key", DefaultCertificateIdentityFile.String())
+	require.Equal(t, "/etc/engity/bifroest/ca", DefaultCertificateAuthorityFile.String())
 
 	runUnmarshalYamlTests(t,
 		unmarshalYamlTestCase[Configuration]{

--- a/pkg/configuration/configuration_windows_test.go
+++ b/pkg/configuration/configuration_windows_test.go
@@ -104,7 +104,7 @@ func TestConfiguration_UnmarshalYAML(t *testing.T) {
 						RetrieveIdToken:  DefaultAuthorizationOidcRetrieveIdToken,
 						RetrieveUserInfo: DefaultAuthorizationOidcRetrieveUserInfo,
 					}},
-					Environment: Environment{&EnvironmentLocal{
+					Environment: Environment{V: &EnvironmentLocal{
 						LoginAllowed:          DefaultEnvironmentLocalLoginAllowed,
 						Banner:                DefaultEnvironmentLocalBanner,
 						ShellCommand:          DefaultEnvironmentLocalShellCommand,

--- a/pkg/configuration/configuration_windows_test.go
+++ b/pkg/configuration/configuration_windows_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/echocat/slf4g/sdk/testlog"
+	"github.com/stretchr/testify/require"
 
 	"github.com/engity-com/bifroest/pkg/common"
 	"github.com/engity-com/bifroest/pkg/crypto"
@@ -14,6 +15,8 @@ import (
 
 func TestConfiguration_UnmarshalYAML(t *testing.T) {
 	testlog.Hook(t)
+	require.Equal(t, `C:\ProgramData\Engity\Bifroest\client-key`, DefaultCertificateIdentityFile.String())
+	require.Equal(t, `C:\ProgramData\Engity\Bifroest\ca`, DefaultCertificateAuthorityFile.String())
 
 	runUnmarshalYamlTests(t,
 		unmarshalYamlTestCase[Configuration]{

--- a/pkg/configuration/environment-docker.go
+++ b/pkg/configuration/environment-docker.go
@@ -241,3 +241,5 @@ func (this EnvironmentDocker) Types() []string {
 func (this EnvironmentDocker) FeatureFlags() []string {
 	return []string{"docker"}
 }
+
+func (this EnvironmentDocker) SupportsEnvironmentVariables() bool { return true }

--- a/pkg/configuration/environment-kubernetes.go
+++ b/pkg/configuration/environment-kubernetes.go
@@ -272,3 +272,5 @@ func (this EnvironmentKubernetes) Types() []string {
 func (this EnvironmentKubernetes) FeatureFlags() []string {
 	return []string{"kubernetes"}
 }
+
+func (this EnvironmentKubernetes) SupportsEnvironmentVariables() bool { return true }

--- a/pkg/configuration/environment-local_unix.go
+++ b/pkg/configuration/environment-local_unix.go
@@ -115,3 +115,5 @@ func (this EnvironmentLocal) Types() []string {
 func (this EnvironmentLocal) FeatureFlags() []string {
 	return []string{"local[pty,impersonate]"}
 }
+
+func (this EnvironmentLocal) SupportsEnvironmentVariables() bool { return true }

--- a/pkg/configuration/environment-local_windows.go
+++ b/pkg/configuration/environment-local_windows.go
@@ -114,3 +114,5 @@ func (this EnvironmentLocal) Types() []string {
 func (this EnvironmentLocal) FeatureFlags() []string {
 	return []string{"local"}
 }
+
+func (this EnvironmentLocal) SupportsEnvironmentVariables() bool { return true }

--- a/pkg/configuration/environment-ssh-certificate.go
+++ b/pkg/configuration/environment-ssh-certificate.go
@@ -11,23 +11,28 @@ import (
 	"github.com/engity-com/bifroest/pkg/template"
 )
 
-var DefaultEnvironmentSshCertificateValidAfterSkew = template.DurationOf(30 * time.Second)
+var (
+	DefaultEnvironmentSshCertificateValidity       = template.DurationOf(15 * time.Minute)
+	DefaultEnvironmentSshCertificateValidAfterSkew = template.DurationOf(30 * time.Second)
+)
 
 type EnvironmentSshCertificate struct {
-	IdentityFile          template.String                     `yaml:"identityFile"`
+	IdentityFile          template.String                     `yaml:"identityFile,omitempty"`
 	AuthorityIdentityFile template.String                     `yaml:"authorityIdentityFile,omitempty"`
 	Validity              template.Duration                   `yaml:"validity"`
 	ValidAfterSkew        template.Duration                   `yaml:"validAfterSkew,omitempty"`
+	Audience              template.String                     `yaml:"audience,omitempty"`
 	Principals            template.Strings                    `yaml:"principals,omitempty"`
 	Extensions            EnvironmentSshCertificateExtensions `yaml:"extensions,omitempty"`
 }
 
 func (this *EnvironmentSshCertificate) SetDefaults() error {
 	return setDefaults(this,
-		noopSetDefault[EnvironmentSshCertificate]("identityFile"),
-		noopSetDefault[EnvironmentSshCertificate]("authorityIdentityFile"),
-		noopSetDefault[EnvironmentSshCertificate]("validity"),
+		fixedDefault("identityFile", func(v *EnvironmentSshCertificate) *template.String { return &v.IdentityFile }, DefaultCertificateIdentityFile),
+		fixedDefault("authorityIdentityFile", func(v *EnvironmentSshCertificate) *template.String { return &v.AuthorityIdentityFile }, DefaultCertificateAuthorityFile),
+		fixedDefault("validity", func(v *EnvironmentSshCertificate) *template.Duration { return &v.Validity }, DefaultEnvironmentSshCertificateValidity),
 		fixedDefault("validAfterSkew", func(v *EnvironmentSshCertificate) *template.Duration { return &v.ValidAfterSkew }, DefaultEnvironmentSshCertificateValidAfterSkew),
+		noopSetDefault[EnvironmentSshCertificate]("audience"),
 		noopSetDefault[EnvironmentSshCertificate]("principals"),
 		noopSetDefault[EnvironmentSshCertificate]("extensions"),
 	)
@@ -39,23 +44,18 @@ func (this *EnvironmentSshCertificate) Trim() error {
 		noopTrim[EnvironmentSshCertificate]("authorityIdentityFile"),
 		noopTrim[EnvironmentSshCertificate]("validity"),
 		noopTrim[EnvironmentSshCertificate]("validAfterSkew"),
+		noopTrim[EnvironmentSshCertificate]("audience"),
 		noopTrim[EnvironmentSshCertificate]("principals"),
 		noopTrim[EnvironmentSshCertificate]("extensions"),
 	)
 }
 
 func (this *EnvironmentSshCertificate) Validate() error {
-	if this.IdentityFile.IsZero() {
-		return fmt.Errorf("[identityFile] required but absent")
+	if this.IdentityFile.IsZero() || !this.IdentityFile.IsHardCoded() {
+		return fmt.Errorf("[identityFile] has to be a static non-empty path")
 	}
-	if !this.IdentityFile.IsHardCoded() {
-		return fmt.Errorf("[identityFile] has to be a static path")
-	}
-	if !this.AuthorityIdentityFile.IsZero() && !this.AuthorityIdentityFile.IsHardCoded() {
-		return fmt.Errorf("[authorityIdentityFile] has to be a static path")
-	}
-	if this.Validity.IsZero() {
-		return fmt.Errorf("[validity] required but absent")
+	if this.AuthorityIdentityFile.IsZero() || !this.AuthorityIdentityFile.IsHardCoded() {
+		return fmt.Errorf("[authorityIdentityFile] has to be a static non-empty path")
 	}
 	if this.Validity.IsHardCoded() {
 		value, _ := this.Validity.Render(nil)
@@ -81,6 +81,7 @@ func (this *EnvironmentSshCertificate) Validate() error {
 		},
 		func(v *EnvironmentSshCertificate) (string, validator) { return "validity", &v.Validity },
 		func(v *EnvironmentSshCertificate) (string, validator) { return "validAfterSkew", &v.ValidAfterSkew },
+		func(v *EnvironmentSshCertificate) (string, validator) { return "audience", &v.Audience },
 		func(v *EnvironmentSshCertificate) (string, validator) { return "principals", &v.Principals },
 		func(v *EnvironmentSshCertificate) (string, validator) { return "extensions", &v.Extensions },
 	)
@@ -109,6 +110,7 @@ func (this EnvironmentSshCertificate) isEqualTo(other *EnvironmentSshCertificate
 		isEqual(&this.AuthorityIdentityFile, &other.AuthorityIdentityFile) &&
 		isEqual(&this.Validity, &other.Validity) &&
 		isEqual(&this.ValidAfterSkew, &other.ValidAfterSkew) &&
+		isEqual(&this.Audience, &other.Audience) &&
 		isEqual(&this.Principals, &other.Principals) &&
 		isEqual(&this.Extensions, &other.Extensions)
 }

--- a/pkg/configuration/environment-ssh-certificate.go
+++ b/pkg/configuration/environment-ssh-certificate.go
@@ -1,0 +1,186 @@
+package configuration
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/engity-com/bifroest/pkg/template"
+)
+
+var DefaultEnvironmentSshCertificateValidAfterSkew = template.DurationOf(30 * time.Second)
+
+type EnvironmentSshCertificate struct {
+	IdentityFile          template.String                     `yaml:"identityFile"`
+	AuthorityIdentityFile template.String                     `yaml:"authorityIdentityFile,omitempty"`
+	Validity              template.Duration                   `yaml:"validity"`
+	ValidAfterSkew        template.Duration                   `yaml:"validAfterSkew,omitempty"`
+	Principals            template.Strings                    `yaml:"principals,omitempty"`
+	Extensions            EnvironmentSshCertificateExtensions `yaml:"extensions,omitempty"`
+}
+
+func (this *EnvironmentSshCertificate) SetDefaults() error {
+	return setDefaults(this,
+		noopSetDefault[EnvironmentSshCertificate]("identityFile"),
+		noopSetDefault[EnvironmentSshCertificate]("authorityIdentityFile"),
+		noopSetDefault[EnvironmentSshCertificate]("validity"),
+		fixedDefault("validAfterSkew", func(v *EnvironmentSshCertificate) *template.Duration { return &v.ValidAfterSkew }, DefaultEnvironmentSshCertificateValidAfterSkew),
+		noopSetDefault[EnvironmentSshCertificate]("principals"),
+		noopSetDefault[EnvironmentSshCertificate]("extensions"),
+	)
+}
+
+func (this *EnvironmentSshCertificate) Trim() error {
+	return trim(this,
+		noopTrim[EnvironmentSshCertificate]("identityFile"),
+		noopTrim[EnvironmentSshCertificate]("authorityIdentityFile"),
+		noopTrim[EnvironmentSshCertificate]("validity"),
+		noopTrim[EnvironmentSshCertificate]("validAfterSkew"),
+		noopTrim[EnvironmentSshCertificate]("principals"),
+		noopTrim[EnvironmentSshCertificate]("extensions"),
+	)
+}
+
+func (this *EnvironmentSshCertificate) Validate() error {
+	if this.IdentityFile.IsZero() {
+		return fmt.Errorf("[identityFile] required but absent")
+	}
+	if !this.IdentityFile.IsHardCoded() {
+		return fmt.Errorf("[identityFile] has to be a static path")
+	}
+	if !this.AuthorityIdentityFile.IsZero() && !this.AuthorityIdentityFile.IsHardCoded() {
+		return fmt.Errorf("[authorityIdentityFile] has to be a static path")
+	}
+	if this.Validity.IsZero() {
+		return fmt.Errorf("[validity] required but absent")
+	}
+	if this.Validity.IsHardCoded() {
+		value, _ := this.Validity.Render(nil)
+		if value <= 0 {
+			return fmt.Errorf("[validity] has to be positive")
+		}
+	}
+	if this.ValidAfterSkew.IsHardCoded() {
+		value, _ := this.ValidAfterSkew.Render(nil)
+		if value < 0 {
+			return fmt.Errorf("[validAfterSkew] cannot be negative")
+		}
+	}
+	for i, principal := range this.Principals {
+		if principal.IsZero() {
+			return fmt.Errorf("[principals][%d] required but absent", i)
+		}
+	}
+	return validate(this,
+		func(v *EnvironmentSshCertificate) (string, validator) { return "identityFile", &v.IdentityFile },
+		func(v *EnvironmentSshCertificate) (string, validator) {
+			return "authorityIdentityFile", &v.AuthorityIdentityFile
+		},
+		func(v *EnvironmentSshCertificate) (string, validator) { return "validity", &v.Validity },
+		func(v *EnvironmentSshCertificate) (string, validator) { return "validAfterSkew", &v.ValidAfterSkew },
+		func(v *EnvironmentSshCertificate) (string, validator) { return "principals", &v.Principals },
+		func(v *EnvironmentSshCertificate) (string, validator) { return "extensions", &v.Extensions },
+	)
+}
+
+func (this *EnvironmentSshCertificate) UnmarshalYAML(node *yaml.Node) error {
+	return unmarshalYAML(this, node, func(target *EnvironmentSshCertificate, node *yaml.Node) error {
+		type raw EnvironmentSshCertificate
+		return node.Decode((*raw)(target))
+	})
+}
+
+func (this EnvironmentSshCertificate) IsEqualTo(other any) bool {
+	switch v := other.(type) {
+	case EnvironmentSshCertificate:
+		return this.isEqualTo(&v)
+	case *EnvironmentSshCertificate:
+		return v != nil && this.isEqualTo(v)
+	default:
+		return false
+	}
+}
+
+func (this EnvironmentSshCertificate) isEqualTo(other *EnvironmentSshCertificate) bool {
+	return isEqual(&this.IdentityFile, &other.IdentityFile) &&
+		isEqual(&this.AuthorityIdentityFile, &other.AuthorityIdentityFile) &&
+		isEqual(&this.Validity, &other.Validity) &&
+		isEqual(&this.ValidAfterSkew, &other.ValidAfterSkew) &&
+		isEqual(&this.Principals, &other.Principals) &&
+		isEqual(&this.Extensions, &other.Extensions)
+}
+
+type EnvironmentSshCertificateExtensions map[string]template.String
+
+func (this *EnvironmentSshCertificateExtensions) SetDefaults() error {
+	*this = EnvironmentSshCertificateExtensions{}
+	return nil
+}
+
+func (this *EnvironmentSshCertificateExtensions) Trim() error { return this.Validate() }
+
+func (this EnvironmentSshCertificateExtensions) Validate() error {
+	keys := make([]string, 0, len(this))
+	for key := range this {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if strings.TrimSpace(key) == "" || strings.IndexByte(key, 0) >= 0 || strings.ContainsAny(key, "=,") {
+			return fmt.Errorf("[%s] illegal SSH certificate extension name", key)
+		}
+		if strings.HasSuffix(key, "@bifroest.engity.org") {
+			return fmt.Errorf("[%s] reserved SSH certificate extension name", key)
+		}
+		value := this[key]
+		if err := value.Validate(); err != nil {
+			return fmt.Errorf("[%s] %w", key, err)
+		}
+	}
+	return nil
+}
+
+func (this EnvironmentSshCertificateExtensions) IsZero() bool { return len(this) == 0 }
+
+func (this EnvironmentSshCertificateExtensions) IsEqualTo(other any) bool {
+	var candidate EnvironmentSshCertificateExtensions
+	switch v := other.(type) {
+	case EnvironmentSshCertificateExtensions:
+		candidate = v
+	case *EnvironmentSshCertificateExtensions:
+		if v == nil {
+			return false
+		}
+		candidate = *v
+	default:
+		return false
+	}
+	if len(this) != len(candidate) {
+		return false
+	}
+	for key, value := range this {
+		otherValue, ok := candidate[key]
+		if !ok || !value.IsEqualTo(otherValue) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this EnvironmentSshCertificateExtensions) Render(data any) (map[string]string, error) {
+	result := make(map[string]string, len(this))
+	for key, value := range this {
+		rendered, err := value.Render(data)
+		if err != nil {
+			return nil, fmt.Errorf("[%s] %w", key, err)
+		}
+		if strings.IndexByte(rendered, 0) >= 0 {
+			return nil, fmt.Errorf("[%s] SSH certificate extension value contains NUL", key)
+		}
+		result[key] = rendered
+	}
+	return result, nil
+}

--- a/pkg/configuration/environment-ssh.go
+++ b/pkg/configuration/environment-ssh.go
@@ -8,7 +8,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/engity-com/bifroest/pkg/crypto"
-	"github.com/engity-com/bifroest/pkg/net"
+	"github.com/engity-com/bifroest/pkg/ssh"
 	"github.com/engity-com/bifroest/pkg/sys"
 	"github.com/engity-com/bifroest/pkg/template"
 )
@@ -91,11 +91,7 @@ func (this *EnvironmentSsh) Validate() error {
 		}
 	}
 	if this.Address.IsHardCoded() {
-		var address net.HostPort
-		if err := address.Set(this.Address.String()); err != nil {
-			return fmt.Errorf("[address] %w", err)
-		}
-		if err := address.Validate(); err != nil {
+		if _, err := ssh.ParseAddress(this.Address.String()); err != nil {
 			return fmt.Errorf("[address] %w", err)
 		}
 	}

--- a/pkg/configuration/environment-ssh.go
+++ b/pkg/configuration/environment-ssh.go
@@ -1,0 +1,155 @@
+package configuration
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/engity-com/bifroest/pkg/crypto"
+	"github.com/engity-com/bifroest/pkg/net"
+	"github.com/engity-com/bifroest/pkg/sys"
+	"github.com/engity-com/bifroest/pkg/template"
+)
+
+var (
+	DefaultEnvironmentSshConnectTimeout        = template.DurationOf(10 * time.Second)
+	DefaultEnvironmentSshOs                    = sys.OsLinux
+	DefaultEnvironmentSshLoginAllowed          = template.BoolOf(true)
+	DefaultEnvironmentSshBanner                = template.MustNewString("")
+	DefaultEnvironmentSshPortForwardingAllowed = template.BoolOf(true)
+
+	_ = RegisterEnvironmentV(func() EnvironmentV { return &EnvironmentSsh{} })
+)
+
+type EnvironmentSsh struct {
+	Address template.String `yaml:"address"`
+	User    template.String `yaml:"user"`
+	Os      sys.Os          `yaml:"os,omitempty"`
+
+	KnownHosts        crypto.KnownHosts     `yaml:"knownHosts,omitempty"`
+	KnownHostsFile    crypto.KnownHostsFile `yaml:"knownHostsFile,omitempty"`
+	AcceptAllHostKeys bool                  `yaml:"acceptAllHostKeys,omitempty"`
+
+	IdentityFiles  template.Strings  `yaml:"identityFiles,omitempty"`
+	ConnectTimeout template.Duration `yaml:"connectTimeout,omitempty"`
+
+	LoginAllowed          template.Bool   `yaml:"loginAllowed,omitempty"`
+	Banner                template.String `yaml:"banner,omitempty"`
+	PortForwardingAllowed template.Bool   `yaml:"portForwardingAllowed,omitempty"`
+}
+
+func (this *EnvironmentSsh) SetDefaults() error {
+	return setDefaults(this,
+		noopSetDefault[EnvironmentSsh]("address"),
+		noopSetDefault[EnvironmentSsh]("user"),
+		fixedDefault("os", func(v *EnvironmentSsh) *sys.Os { return &v.Os }, DefaultEnvironmentSshOs),
+		noopSetDefault[EnvironmentSsh]("knownHosts"),
+		noopSetDefault[EnvironmentSsh]("knownHostsFile"),
+		noopSetDefault[EnvironmentSsh]("acceptAllHostKeys"),
+		noopSetDefault[EnvironmentSsh]("identityFiles"),
+		fixedDefault("connectTimeout", func(v *EnvironmentSsh) *template.Duration { return &v.ConnectTimeout }, DefaultEnvironmentSshConnectTimeout),
+		fixedDefault("loginAllowed", func(v *EnvironmentSsh) *template.Bool { return &v.LoginAllowed }, DefaultEnvironmentSshLoginAllowed),
+		fixedDefault("banner", func(v *EnvironmentSsh) *template.String { return &v.Banner }, DefaultEnvironmentSshBanner),
+		fixedDefault("portForwardingAllowed", func(v *EnvironmentSsh) *template.Bool { return &v.PortForwardingAllowed }, DefaultEnvironmentSshPortForwardingAllowed),
+	)
+}
+
+func (this *EnvironmentSsh) Trim() error {
+	return trim(this,
+		noopTrim[EnvironmentSsh]("address"),
+		noopTrim[EnvironmentSsh]("user"),
+		noopTrim[EnvironmentSsh]("os"),
+		func(v *EnvironmentSsh) (string, trimmer) { return "knownHosts", &v.KnownHosts },
+		func(v *EnvironmentSsh) (string, trimmer) { return "knownHostsFile", &v.KnownHostsFile },
+		noopTrim[EnvironmentSsh]("acceptAllHostKeys"),
+		noopTrim[EnvironmentSsh]("identityFiles"),
+		noopTrim[EnvironmentSsh]("connectTimeout"),
+		noopTrim[EnvironmentSsh]("loginAllowed"),
+		noopTrim[EnvironmentSsh]("banner"),
+		noopTrim[EnvironmentSsh]("portForwardingAllowed"),
+	)
+}
+
+func (this *EnvironmentSsh) Validate() error {
+	if this.AcceptAllHostKeys && (!this.KnownHosts.IsZero() || !this.KnownHostsFile.IsZero()) {
+		return fmt.Errorf("[acceptAllHostKeys] cannot be combined with knownHosts or knownHostsFile")
+	}
+	if !this.AcceptAllHostKeys && this.KnownHosts.IsZero() && this.KnownHostsFile.IsZero() {
+		return fmt.Errorf("[knownHosts] or [knownHostsFile] required unless [acceptAllHostKeys] is true")
+	}
+	for i, identity := range this.IdentityFiles {
+		if identity.IsZero() {
+			return fmt.Errorf("[identityFiles][%d] required but absent", i)
+		}
+	}
+	if this.Address.IsHardCoded() {
+		var address net.HostPort
+		if err := address.Set(this.Address.String()); err != nil {
+			return fmt.Errorf("[address] %w", err)
+		}
+		if err := address.Validate(); err != nil {
+			return fmt.Errorf("[address] %w", err)
+		}
+	}
+	if this.User.IsHardCoded() && strings.TrimSpace(this.User.String()) == "" {
+		return fmt.Errorf("[user] required but absent")
+	}
+	if this.ConnectTimeout.IsHardCoded() {
+		value, _ := this.ConnectTimeout.Render(nil)
+		if value < 0 {
+			return fmt.Errorf("[connectTimeout] cannot be negative")
+		}
+	}
+	return validate(this,
+		notZeroValidate("address", func(v *EnvironmentSsh) *template.String { return &v.Address }),
+		notZeroValidate("user", func(v *EnvironmentSsh) *template.String { return &v.User }),
+		func(v *EnvironmentSsh) (string, validator) { return "os", &v.Os },
+		func(v *EnvironmentSsh) (string, validator) { return "knownHosts", &v.KnownHosts },
+		func(v *EnvironmentSsh) (string, validator) { return "knownHostsFile", &v.KnownHostsFile },
+		func(v *EnvironmentSsh) (string, validator) { return "identityFiles", &v.IdentityFiles },
+		func(v *EnvironmentSsh) (string, validator) { return "connectTimeout", &v.ConnectTimeout },
+		func(v *EnvironmentSsh) (string, validator) { return "loginAllowed", &v.LoginAllowed },
+		func(v *EnvironmentSsh) (string, validator) { return "banner", &v.Banner },
+		func(v *EnvironmentSsh) (string, validator) { return "portForwardingAllowed", &v.PortForwardingAllowed },
+	)
+}
+
+func (this *EnvironmentSsh) UnmarshalYAML(node *yaml.Node) error {
+	return unmarshalYAML(this, node, func(target *EnvironmentSsh, node *yaml.Node) error {
+		type raw EnvironmentSsh
+		return node.Decode((*raw)(target))
+	})
+}
+
+func (this EnvironmentSsh) IsEqualTo(other any) bool {
+	switch v := other.(type) {
+	case EnvironmentSsh:
+		return this.isEqualTo(&v)
+	case *EnvironmentSsh:
+		return v != nil && this.isEqualTo(v)
+	default:
+		return false
+	}
+}
+
+func (this EnvironmentSsh) isEqualTo(other *EnvironmentSsh) bool {
+	return isEqual(&this.Address, &other.Address) &&
+		isEqual(&this.User, &other.User) &&
+		isEqual(&this.Os, &other.Os) &&
+		isEqual(&this.KnownHosts, &other.KnownHosts) &&
+		isEqual(&this.KnownHostsFile, &other.KnownHostsFile) &&
+		this.AcceptAllHostKeys == other.AcceptAllHostKeys &&
+		isEqual(&this.IdentityFiles, &other.IdentityFiles) &&
+		isEqual(&this.ConnectTimeout, &other.ConnectTimeout) &&
+		isEqual(&this.LoginAllowed, &other.LoginAllowed) &&
+		isEqual(&this.Banner, &other.Banner) &&
+		isEqual(&this.PortForwardingAllowed, &other.PortForwardingAllowed)
+}
+
+func (this EnvironmentSsh) Types() []string { return []string{"ssh"} }
+
+func (this EnvironmentSsh) FeatureFlags() []string { return []string{"ssh"} }
+
+func (this EnvironmentSsh) SupportsEnvironmentVariables() bool { return true }

--- a/pkg/configuration/environment-ssh.go
+++ b/pkg/configuration/environment-ssh.go
@@ -32,8 +32,9 @@ type EnvironmentSsh struct {
 	KnownHostsFile    crypto.KnownHostsFile `yaml:"knownHostsFile,omitempty"`
 	AcceptAllHostKeys bool                  `yaml:"acceptAllHostKeys,omitempty"`
 
-	IdentityFiles  template.Strings  `yaml:"identityFiles,omitempty"`
-	ConnectTimeout template.Duration `yaml:"connectTimeout,omitempty"`
+	IdentityFiles  template.Strings           `yaml:"identityFiles,omitempty"`
+	Certificate    *EnvironmentSshCertificate `yaml:"certificate,omitempty"`
+	ConnectTimeout template.Duration          `yaml:"connectTimeout,omitempty"`
 
 	LoginAllowed          template.Bool   `yaml:"loginAllowed,omitempty"`
 	Banner                template.String `yaml:"banner,omitempty"`
@@ -49,6 +50,7 @@ func (this *EnvironmentSsh) SetDefaults() error {
 		noopSetDefault[EnvironmentSsh]("knownHostsFile"),
 		noopSetDefault[EnvironmentSsh]("acceptAllHostKeys"),
 		noopSetDefault[EnvironmentSsh]("identityFiles"),
+		noopSetDefault[EnvironmentSsh]("certificate"),
 		fixedDefault("connectTimeout", func(v *EnvironmentSsh) *template.Duration { return &v.ConnectTimeout }, DefaultEnvironmentSshConnectTimeout),
 		fixedDefault("loginAllowed", func(v *EnvironmentSsh) *template.Bool { return &v.LoginAllowed }, DefaultEnvironmentSshLoginAllowed),
 		fixedDefault("banner", func(v *EnvironmentSsh) *template.String { return &v.Banner }, DefaultEnvironmentSshBanner),
@@ -65,6 +67,7 @@ func (this *EnvironmentSsh) Trim() error {
 		func(v *EnvironmentSsh) (string, trimmer) { return "knownHostsFile", &v.KnownHostsFile },
 		noopTrim[EnvironmentSsh]("acceptAllHostKeys"),
 		noopTrim[EnvironmentSsh]("identityFiles"),
+		noopTrim[EnvironmentSsh]("certificate"),
 		noopTrim[EnvironmentSsh]("connectTimeout"),
 		noopTrim[EnvironmentSsh]("loginAllowed"),
 		noopTrim[EnvironmentSsh]("banner"),
@@ -73,6 +76,9 @@ func (this *EnvironmentSsh) Trim() error {
 }
 
 func (this *EnvironmentSsh) Validate() error {
+	if len(this.IdentityFiles) > 0 && this.Certificate != nil {
+		return fmt.Errorf("[identityFiles] cannot be combined with [certificate]")
+	}
 	if this.AcceptAllHostKeys && (!this.KnownHosts.IsZero() || !this.KnownHostsFile.IsZero()) {
 		return fmt.Errorf("[acceptAllHostKeys] cannot be combined with knownHosts or knownHostsFile")
 	}
@@ -109,6 +115,7 @@ func (this *EnvironmentSsh) Validate() error {
 		func(v *EnvironmentSsh) (string, validator) { return "knownHosts", &v.KnownHosts },
 		func(v *EnvironmentSsh) (string, validator) { return "knownHostsFile", &v.KnownHostsFile },
 		func(v *EnvironmentSsh) (string, validator) { return "identityFiles", &v.IdentityFiles },
+		func(v *EnvironmentSsh) (string, validator) { return "certificate", v.Certificate },
 		func(v *EnvironmentSsh) (string, validator) { return "connectTimeout", &v.ConnectTimeout },
 		func(v *EnvironmentSsh) (string, validator) { return "loginAllowed", &v.LoginAllowed },
 		func(v *EnvironmentSsh) (string, validator) { return "banner", &v.Banner },
@@ -142,6 +149,7 @@ func (this EnvironmentSsh) isEqualTo(other *EnvironmentSsh) bool {
 		isEqual(&this.KnownHostsFile, &other.KnownHostsFile) &&
 		this.AcceptAllHostKeys == other.AcceptAllHostKeys &&
 		isEqual(&this.IdentityFiles, &other.IdentityFiles) &&
+		isEqual(this.Certificate, other.Certificate) &&
 		isEqual(&this.ConnectTimeout, &other.ConnectTimeout) &&
 		isEqual(&this.LoginAllowed, &other.LoginAllowed) &&
 		isEqual(&this.Banner, &other.Banner) &&

--- a/pkg/configuration/environment-ssh_test.go
+++ b/pkg/configuration/environment-ssh_test.go
@@ -103,7 +103,7 @@ func TestEnvironmentSshRejectsInvalidStaticValues(t *testing.T) {
 		name string
 		yaml string
 	}{
-		{name: "address", yaml: "address: missing-port\nuser: alice"},
+		{name: "address", yaml: "address: missing-port:\nuser: alice"},
 		{name: "empty-address-host", yaml: "address: :22\nuser: alice"},
 		{name: "user", yaml: "address: target.example.org:22\nuser: ''"},
 		{name: "identity", yaml: "address: target.example.org:22\nuser: alice\nidentityFiles: ['']"},
@@ -153,10 +153,10 @@ func TestEnvironmentSshRejectsInvalidCertificateConfiguration(t *testing.T) {
 		certificate string
 		identity    string
 	}{
-		{name: "missing identity", certificate: "validity: 1h"},
+		{name: "empty identity", certificate: "identityFile: ''\nvalidity: 1h"},
+		{name: "empty authority", certificate: "identityFile: target-key\nauthorityIdentityFile: ''\nvalidity: 1h"},
 		{name: "templated identity", certificate: "identityFile: '{{ .session.id }}'\nvalidity: 1h"},
 		{name: "templated authority", certificate: "identityFile: target-key\nauthorityIdentityFile: '{{ .session.id }}'\nvalidity: 1h"},
-		{name: "missing validity", certificate: "identityFile: target-key"},
 		{name: "zero validity", certificate: "identityFile: target-key\nvalidity: 0s"},
 		{name: "negative skew", certificate: "identityFile: target-key\nvalidity: 1h\nvalidAfterSkew: -1s"},
 		{name: "empty principal", certificate: "identityFile: target-key\nvalidity: 1h\nprincipals: ['']"},
@@ -171,6 +171,21 @@ func TestEnvironmentSshRejectsInvalidCertificateConfiguration(t *testing.T) {
 			require.Error(t, yaml.Unmarshal([]byte(plain), &environment))
 		})
 	}
+}
+
+func TestEnvironmentSshCertificateKeyDefaults(t *testing.T) {
+	var environment Environment
+	require.NoError(t, yaml.Unmarshal([]byte(`
+type: ssh
+address: target.example.org
+user: alice
+acceptAllHostKeys: true
+certificate: {}
+`), &environment))
+
+	actual := environment.V.(*EnvironmentSsh).Certificate
+	require.Equal(t, DefaultCertificateIdentityFile, actual.IdentityFile)
+	require.Equal(t, DefaultCertificateAuthorityFile, actual.AuthorityIdentityFile)
 }
 
 func mustRenderDuration(t *testing.T, value interface {

--- a/pkg/configuration/environment-ssh_test.go
+++ b/pkg/configuration/environment-ssh_test.go
@@ -1,0 +1,135 @@
+package configuration
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+	"gopkg.in/yaml.v3"
+
+	"github.com/engity-com/bifroest/pkg/sys"
+	"github.com/engity-com/bifroest/pkg/template"
+)
+
+func environmentSshKnownHost(t *testing.T) string {
+	t.Helper()
+	public, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	key, err := ssh.NewPublicKey(public)
+	require.NoError(t, err)
+	return "target.example.org " + strings.TrimSpace(string(ssh.MarshalAuthorizedKey(key)))
+}
+
+func TestEnvironmentSshDefaults(t *testing.T) {
+	var environment Environment
+	require.NoError(t, yaml.Unmarshal([]byte(`
+type: ssh
+address: target.example.org:22
+user: alice
+acceptAllHostKeys: true
+`), &environment))
+
+	actual, ok := environment.V.(*EnvironmentSsh)
+	require.True(t, ok)
+	require.Equal(t, 10*time.Second, mustRenderDuration(t, actual.ConnectTimeout))
+	require.True(t, mustRenderBool(t, actual.LoginAllowed))
+	require.True(t, mustRenderBool(t, actual.PortForwardingAllowed))
+	require.Empty(t, actual.IdentityFiles)
+	require.Equal(t, sys.OsLinux, actual.Os)
+}
+
+func TestEnvironmentSshTargetOs(t *testing.T) {
+	var environment Environment
+	require.NoError(t, yaml.Unmarshal([]byte(`
+type: ssh
+address: target.example.org:22
+user: alice
+os: windows
+acceptAllHostKeys: true
+`), &environment))
+
+	actual := environment.V.(*EnvironmentSsh)
+	require.Equal(t, sys.OsWindows, actual.Os)
+}
+
+func TestEnvironmentVariablesBelongToEnvironment(t *testing.T) {
+	var environment Environment
+	require.NoError(t, yaml.Unmarshal([]byte(`
+type: ssh
+address: target.example.org:22
+user: alice
+acceptAllHostKeys: true
+variables:
+  TARGET_NAME: production
+`), &environment))
+
+	require.Equal(t, template.MustNewString("production"), environment.Variables["TARGET_NAME"])
+	marshaled, err := yaml.Marshal(environment)
+	require.NoError(t, err)
+	require.Contains(t, string(marshaled), "variables:")
+	require.Contains(t, string(marshaled), "TARGET_NAME: production")
+}
+
+func TestEnvironmentSshHostKeyValidationMatrix(t *testing.T) {
+	knownHost := environmentSshKnownHost(t)
+	for _, test := range []struct {
+		name    string
+		extra   string
+		wantErr bool
+	}{
+		{name: "missing", wantErr: true},
+		{name: "known-hosts", extra: "knownHosts: " + strings.TrimSpace(knownHost)},
+		{name: "accept-all", extra: "acceptAllHostKeys: true"},
+		{name: "conflicting", extra: "acceptAllHostKeys: true\nknownHosts: " + strings.TrimSpace(knownHost), wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var environment Environment
+			err := yaml.Unmarshal([]byte("type: ssh\naddress: target.example.org:22\nuser: alice\n"+test.extra+"\n"), &environment)
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestEnvironmentSshRejectsInvalidStaticValues(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		yaml string
+	}{
+		{name: "address", yaml: "address: missing-port\nuser: alice"},
+		{name: "empty-address-host", yaml: "address: :22\nuser: alice"},
+		{name: "user", yaml: "address: target.example.org:22\nuser: ''"},
+		{name: "identity", yaml: "address: target.example.org:22\nuser: alice\nidentityFiles: ['']"},
+		{name: "timeout", yaml: "address: target.example.org:22\nuser: alice\nconnectTimeout: -1s"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var environment Environment
+			require.Error(t, yaml.Unmarshal([]byte("type: ssh\nacceptAllHostKeys: true\n"+test.yaml+"\n"), &environment))
+		})
+	}
+}
+
+func mustRenderDuration(t *testing.T, value interface {
+	Render(any) (time.Duration, error)
+}) time.Duration {
+	t.Helper()
+	result, err := value.Render(nil)
+	require.NoError(t, err)
+	return result
+}
+
+func mustRenderBool(t *testing.T, value interface {
+	Render(any) (bool, error)
+}) bool {
+	t.Helper()
+	result, err := value.Render(nil)
+	require.NoError(t, err)
+	return result
+}

--- a/pkg/configuration/environment-ssh_test.go
+++ b/pkg/configuration/environment-ssh_test.go
@@ -116,6 +116,63 @@ func TestEnvironmentSshRejectsInvalidStaticValues(t *testing.T) {
 	}
 }
 
+func TestEnvironmentSshCertificateConfiguration(t *testing.T) {
+	var environment Environment
+	require.NoError(t, yaml.Unmarshal([]byte(`
+type: ssh
+address: target.example.org:22
+user: '{{ .session.created.remote.user }}'
+acceptAllHostKeys: true
+certificate:
+  identityFile: /var/lib/bifroest/target-key
+  authorityIdentityFile: /etc/bifroest/user-ca
+  validity: 24h
+  principals:
+    - '{{ .session.created.remote.user }}'
+  extensions:
+    permit-pty: ""
+    role@example.org: production
+`), &environment))
+
+	actual := environment.V.(*EnvironmentSsh)
+	require.NotNil(t, actual.Certificate)
+	require.Equal(t, 24*time.Hour, mustRenderDuration(t, actual.Certificate.Validity))
+	require.Equal(t, 30*time.Second, mustRenderDuration(t, actual.Certificate.ValidAfterSkew))
+	require.Equal(t, template.MustNewString("production"), actual.Certificate.Extensions["role@example.org"])
+
+	roundtrip, err := yaml.Marshal(actual)
+	require.NoError(t, err)
+	var restored EnvironmentSsh
+	require.NoError(t, yaml.Unmarshal(roundtrip, &restored))
+	require.True(t, actual.IsEqualTo(restored))
+}
+
+func TestEnvironmentSshRejectsInvalidCertificateConfiguration(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		certificate string
+		identity    string
+	}{
+		{name: "missing identity", certificate: "validity: 1h"},
+		{name: "templated identity", certificate: "identityFile: '{{ .session.id }}'\nvalidity: 1h"},
+		{name: "templated authority", certificate: "identityFile: target-key\nauthorityIdentityFile: '{{ .session.id }}'\nvalidity: 1h"},
+		{name: "missing validity", certificate: "identityFile: target-key"},
+		{name: "zero validity", certificate: "identityFile: target-key\nvalidity: 0s"},
+		{name: "negative skew", certificate: "identityFile: target-key\nvalidity: 1h\nvalidAfterSkew: -1s"},
+		{name: "empty principal", certificate: "identityFile: target-key\nvalidity: 1h\nprincipals: ['']"},
+		{name: "identity modes", identity: "identityFiles: [other-key]\n", certificate: "identityFile: target-key\nvalidity: 1h"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var environment Environment
+			plain := "type: ssh\naddress: target.example.org:22\nuser: alice\nacceptAllHostKeys: true\n" + test.identity + "certificate:\n"
+			for _, line := range strings.Split(test.certificate, "\n") {
+				plain += "  " + line + "\n"
+			}
+			require.Error(t, yaml.Unmarshal([]byte(plain), &environment))
+		})
+	}
+}
+
 func mustRenderDuration(t *testing.T, value interface {
 	Render(any) (time.Duration, error)
 }) time.Duration {

--- a/pkg/configuration/environment-variables.go
+++ b/pkg/configuration/environment-variables.go
@@ -1,0 +1,95 @@
+package configuration
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/engity-com/bifroest/pkg/sys"
+	"github.com/engity-com/bifroest/pkg/template"
+)
+
+type EnvironmentVariableName string
+
+func (this EnvironmentVariableName) Validate() error {
+	if this == "" {
+		return fmt.Errorf("required but absent")
+	}
+	for i, r := range this {
+		if r == '_' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' || i > 0 && r >= '0' && r <= '9' {
+			continue
+		}
+		return fmt.Errorf("illegal environment variable name")
+	}
+	return nil
+}
+
+type EnvironmentVariables map[EnvironmentVariableName]template.String
+
+func (this *EnvironmentVariables) SetDefaults() error {
+	*this = EnvironmentVariables{}
+	return nil
+}
+
+func (this *EnvironmentVariables) Trim() error {
+	return this.Validate()
+}
+
+func (this EnvironmentVariables) Validate() error {
+	keys := make([]EnvironmentVariableName, 0, len(this))
+	for key := range this {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	for _, key := range keys {
+		if err := key.Validate(); err != nil {
+			return fmt.Errorf("[%s] %w", key, err)
+		}
+		value := this[key]
+		if err := value.Validate(); err != nil {
+			return fmt.Errorf("[%s] %w", key, err)
+		}
+	}
+	return nil
+}
+
+func (this EnvironmentVariables) IsZero() bool { return len(this) == 0 }
+
+func (this EnvironmentVariables) IsEqualTo(other any) bool {
+	switch v := other.(type) {
+	case EnvironmentVariables:
+		return this.isEqualTo(v)
+	case *EnvironmentVariables:
+		return v != nil && this.isEqualTo(*v)
+	default:
+		return false
+	}
+}
+
+func (this EnvironmentVariables) isEqualTo(other EnvironmentVariables) bool {
+	if len(this) != len(other) {
+		return false
+	}
+	for key, value := range this {
+		candidate, ok := other[key]
+		if !ok || !value.IsEqualTo(candidate) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this EnvironmentVariables) Render(data any) (sys.EnvVars, error) {
+	result := make(sys.EnvVars, len(this))
+	for key, value := range this {
+		rendered, err := value.Render(data)
+		if err != nil {
+			return nil, fmt.Errorf("[%s] %w", key, err)
+		}
+		if strings.IndexByte(rendered, 0) >= 0 {
+			return nil, fmt.Errorf("[%s] environment variable value contains NUL", key)
+		}
+		result[string(key)] = rendered
+	}
+	return result, nil
+}

--- a/pkg/configuration/environment-variables_test.go
+++ b/pkg/configuration/environment-variables_test.go
@@ -1,0 +1,46 @@
+package configuration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestEnvironmentVariablesRender(t *testing.T) {
+	var actual struct {
+		Values EnvironmentVariables `yaml:"values"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte("values:\n  FIRST: one\n  SECOND: two\n"), &actual))
+	require.NoError(t, actual.Values.Validate())
+
+	rendered, err := actual.Values.Render(nil)
+	require.NoError(t, err)
+	require.Equal(t, "one", rendered["FIRST"])
+	require.Equal(t, "two", rendered["SECOND"])
+}
+
+func TestEnvironmentVariablesRejectInvalidName(t *testing.T) {
+	var actual struct {
+		Values EnvironmentVariables `yaml:"values"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte("values:\n  INVALID-NAME: value\n"), &actual))
+	require.Error(t, actual.Values.Validate())
+}
+
+func TestEnvironmentVariablesRejectNonAsciiName(t *testing.T) {
+	actual := EnvironmentVariables{"KEY": {}}
+	require.Error(t, actual.Validate())
+}
+
+func TestEnvironmentVariableName(t *testing.T) {
+	require.NoError(t, EnvironmentVariableName("VALID_NAME_2").Validate())
+	require.Error(t, EnvironmentVariableName("2_INVALID").Validate())
+	require.Error(t, EnvironmentVariableName("INVALID-NAME").Validate())
+}
+
+func TestDummyEnvironmentRejectsVariables(t *testing.T) {
+	var environment Environment
+	err := yaml.Unmarshal([]byte("type: dummy\nvariables:\n  UNUSED: value\n"), &environment)
+	require.ErrorContains(t, err, "not supported by environment type \"dummy\"")
+}

--- a/pkg/configuration/environment.go
+++ b/pkg/configuration/environment.go
@@ -9,7 +9,8 @@ import (
 )
 
 type Environment struct {
-	V EnvironmentV
+	Variables EnvironmentVariables `yaml:"variables,omitempty"`
+	V         EnvironmentV         `yaml:"-"`
 }
 
 type EnvironmentV interface {
@@ -19,6 +20,10 @@ type EnvironmentV interface {
 	equaler
 	Types() []string
 	FeatureFlags() []string
+}
+
+type EnvironmentVariablesAware interface {
+	SupportsEnvironmentVariables() bool
 }
 
 var (
@@ -43,7 +48,7 @@ func RegisterEnvironmentV(factory EnvironmentVFactory) EnvironmentVFactory {
 
 func (this *Environment) SetDefaults() error {
 	*this = Environment{}
-	return nil
+	return this.Variables.SetDefaults()
 }
 
 func (this *Environment) Trim() error {
@@ -52,11 +57,23 @@ func (this *Environment) Trim() error {
 			return err
 		}
 	}
+	if err := this.Variables.Trim(); err != nil {
+		return fmt.Errorf("[variables] %w", err)
+	}
 	return this.Validate()
 }
 
 func (this *Environment) Validate() error {
+	if err := this.Variables.Validate(); err != nil {
+		return fmt.Errorf("[variables] %w", err)
+	}
 	if v := this.V; v != nil {
+		if !this.Variables.IsZero() {
+			support, ok := v.(EnvironmentVariablesAware)
+			if !ok || !support.SupportsEnvironmentVariables() {
+				return fmt.Errorf("[variables] not supported by environment type %q", v.Types()[0])
+			}
+		}
 		return v.Validate()
 	}
 	return fmt.Errorf("required but absent")
@@ -88,6 +105,13 @@ func (this *Environment) UnmarshalYAML(node *yaml.Node) error {
 	if err := node.Decode(this.V); err != nil {
 		return reportYamlRelatedErr(node, err)
 	}
+	var common struct {
+		Variables EnvironmentVariables `yaml:"variables,omitempty"`
+	}
+	if err := node.Decode(&common); err != nil {
+		return reportYamlRelatedErr(node, err)
+	}
+	this.Variables = common.Variables
 
 	return this.Trim()
 }
@@ -95,8 +119,10 @@ func (this *Environment) UnmarshalYAML(node *yaml.Node) error {
 func (this *Environment) MarshalYAML() (any, error) {
 	typeBuf := struct {
 		EnvironmentV `yaml:",inline"`
-		Type         string `yaml:"type,omitempty"`
+		Type         string               `yaml:"type,omitempty"`
+		Variables    EnvironmentVariables `yaml:"variables,omitempty"`
 	}{}
+	typeBuf.Variables = this.Variables
 
 	if this.V != nil {
 		typeBuf.Type = this.V.Types()[0]
@@ -121,6 +147,9 @@ func (this Environment) IsEqualTo(other any) bool {
 }
 
 func (this Environment) isEqualTo(other *Environment) bool {
+	if !isEqual(&this.Variables, &other.Variables) {
+		return false
+	}
 	if other.V == nil {
 		return this.V == nil
 	}

--- a/pkg/configuration/flow-key.go
+++ b/pkg/configuration/flow-key.go
@@ -36,6 +36,9 @@ func (this FlowName) Validate() error {
 	if len(this) == 0 {
 		return fmt.Errorf("illegal flow key: empty")
 	}
+	if this == "." || this == ".." {
+		return fmt.Errorf("illegal flow key: %q", this)
+	}
 	for _, c := range string(this) {
 		if (c >= 'a' && 'z' >= c) ||
 			(c >= 'A' && 'Z' >= c) ||

--- a/pkg/configuration/flow.go
+++ b/pkg/configuration/flow.go
@@ -1,6 +1,8 @@
 package configuration
 
 import (
+	"fmt"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -100,11 +102,28 @@ func (this Flows) IsZero() bool {
 }
 
 func (this *Flows) Trim() error {
-	return trimSlice(this)
+	if err := trimSlice(this); err != nil {
+		return err
+	}
+	return this.validateUniqueNames()
 }
 
 func (this Flows) Validate() error {
+	if err := this.validateUniqueNames(); err != nil {
+		return err
+	}
 	return validateSlice(this)
+}
+
+func (this Flows) validateUniqueNames() error {
+	indices := make(map[FlowName]int, len(this))
+	for i, flow := range this {
+		if previous, exists := indices[flow.Name]; exists {
+			return fmt.Errorf("[%d][name] duplicates [%d][name] %q", i, previous, flow.Name)
+		}
+		indices[flow.Name] = i
+	}
+	return nil
 }
 
 func (this *Flows) UnmarshalYAML(node *yaml.Node) error {

--- a/pkg/configuration/flow_test.go
+++ b/pkg/configuration/flow_test.go
@@ -1,0 +1,38 @@
+package configuration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestFlowsRejectDuplicateNames(t *testing.T) {
+	flows := Flows{{Name: "duplicate"}, {Name: "duplicate"}}
+	require.ErrorContains(t, flows.Validate(), "duplicates")
+}
+
+func TestFlowsYamlRejectsDuplicateNames(t *testing.T) {
+	var flows Flows
+	err := yaml.Unmarshal([]byte(`
+- name: duplicate
+  authorization:
+    type: oidcDeviceAuth
+    issuer: https://example.org
+    clientId: client
+    clientSecret: secret
+  environment:
+    type: local
+    name: user
+- name: duplicate
+  authorization:
+    type: oidcDeviceAuth
+    issuer: https://example.org
+    clientId: client
+    clientSecret: secret
+  environment:
+    type: local
+    name: user
+`), &flows)
+	require.ErrorContains(t, err, "duplicates")
+}

--- a/pkg/configuration/keys.go
+++ b/pkg/configuration/keys.go
@@ -10,9 +10,11 @@ import (
 )
 
 var (
-	DefaultHostKeyLocations       = template.MustNewStrings(DefaultHostKeyLocation)
-	DefaultKeyExchanges           = ssh.DefaultKeyExchanges
-	DefaultRememberMeNotification = template.MustNewString("\nIf you return until {{.session.validUntil | format `dateTimeT`}} with the same public key ({{.key | fingerprint}}), you can seamlessly login again.\n\n")
+	DefaultHostKeyLocations         = template.MustNewStrings(DefaultHostKeyLocation)
+	DefaultCertificateIdentityFile  = template.MustNewString(DefaultCertificateIdentityFileLocation)
+	DefaultCertificateAuthorityFile = template.MustNewString(DefaultCertificateAuthorityFileLocation)
+	DefaultKeyExchanges             = ssh.DefaultKeyExchanges
+	DefaultRememberMeNotification   = template.MustNewString("\nIf you return until {{.session.validUntil | format `dateTimeT`}} with the same public key ({{.key | fingerprint}}), you can seamlessly login again.\n\n")
 )
 
 type Keys struct {

--- a/pkg/configuration/keys.go
+++ b/pkg/configuration/keys.go
@@ -1,6 +1,7 @@
 package configuration
 
 import (
+	gossh "golang.org/x/crypto/ssh"
 	"gopkg.in/yaml.v3"
 
 	"github.com/engity-com/bifroest/pkg/crypto"
@@ -94,6 +95,22 @@ func (this Keys) isEqualTo(other *Keys) bool {
 }
 
 func (this Keys) KeyAllowed(in any) (bool, error) {
+	if certificate, ok := in.(*gossh.Certificate); ok {
+		if certificate.Key == nil || certificate.SignatureKey == nil {
+			return false, nil
+		}
+		if _, nested := certificate.Key.(*gossh.Certificate); nested {
+			return false, nil
+		}
+		if _, nested := certificate.SignatureKey.(*gossh.Certificate); nested {
+			return false, nil
+		}
+		subjectAllowed, err := this.KeyAllowed(certificate.Key)
+		if err != nil || !subjectAllowed {
+			return subjectAllowed, err
+		}
+		return this.KeyAllowed(certificate.SignatureKey)
+	}
 	if ok, err := this.RsaRestriction.KeyAllowed(in); err != nil || ok {
 		return ok, err
 	}

--- a/pkg/configuration/keys_certificate_test.go
+++ b/pkg/configuration/keys_certificate_test.go
@@ -1,0 +1,44 @@
+package configuration
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/engity-com/bifroest/pkg/crypto"
+)
+
+func TestKeysAppliesRestrictionsToCertificateSubjectAndAuthority(t *testing.T) {
+	_, authorityPrivate, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	authority, err := gossh.NewSignerFromKey(authorityPrivate)
+	require.NoError(t, err)
+	subjectPrivate, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	subject, err := gossh.NewSignerFromKey(subjectPrivate)
+	require.NoError(t, err)
+	certificate := &gossh.Certificate{Key: subject.PublicKey()}
+	require.NoError(t, certificate.SignCert(rand.Reader, authority))
+
+	var keys Keys
+	require.NoError(t, keys.SetDefaults())
+	keys.RsaRestriction = crypto.RsaRestrictionAll
+	allowed, err := keys.KeyAllowed(certificate)
+	require.NoError(t, err)
+	require.True(t, allowed)
+
+	keys.RsaRestriction = crypto.RsaRestrictionNone
+	allowed, err = keys.KeyAllowed(certificate)
+	require.NoError(t, err)
+	require.False(t, allowed, "the certificate subject must satisfy the restrictions")
+
+	keys.RsaRestriction = crypto.RsaRestrictionAll
+	keys.Ed25519Restriction = crypto.Ed25519RestrictionNone
+	allowed, err = keys.KeyAllowed(certificate)
+	require.NoError(t, err)
+	require.False(t, allowed, "the certificate authority must satisfy the restrictions")
+}

--- a/pkg/configuration/keys_unix.go
+++ b/pkg/configuration/keys_unix.go
@@ -3,5 +3,7 @@
 package configuration
 
 const (
-	DefaultHostKeyLocation = "/etc/engity/bifroest/key"
+	DefaultHostKeyLocation                  = "/etc/engity/bifroest/key"
+	DefaultCertificateIdentityFileLocation  = "/etc/engity/bifroest/client-key"
+	DefaultCertificateAuthorityFileLocation = "/etc/engity/bifroest/ca"
 )

--- a/pkg/configuration/keys_windows.go
+++ b/pkg/configuration/keys_windows.go
@@ -3,5 +3,7 @@
 package configuration
 
 const (
-	DefaultHostKeyLocation = `C:\ProgramData\Engity\Bifroest\key`
+	DefaultHostKeyLocation                  = `C:\ProgramData\Engity\Bifroest\key`
+	DefaultCertificateIdentityFileLocation  = `C:\ProgramData\Engity\Bifroest\client-key`
+	DefaultCertificateAuthorityFileLocation = `C:\ProgramData\Engity\Bifroest\ca`
 )

--- a/pkg/configuration/user-certificate-authority-properties.go
+++ b/pkg/configuration/user-certificate-authority-properties.go
@@ -1,0 +1,53 @@
+package configuration
+
+import "github.com/engity-com/bifroest/pkg/crypto"
+
+type UserCertificateAuthorityProperties struct {
+	TrustedUserCAs     crypto.PublicKeys     `yaml:"trustedUserCAs,omitempty"`
+	TrustedUserCAsFile crypto.PublicKeysFile `yaml:"trustedUserCAsFile,omitempty"`
+}
+
+func (this *UserCertificateAuthorityProperties) SetDefaults() error {
+	return setDefaults(this,
+		noopSetDefault[UserCertificateAuthorityProperties]("trustedUserCAs"),
+		noopSetDefault[UserCertificateAuthorityProperties]("trustedUserCAsFile"),
+	)
+}
+
+func (this *UserCertificateAuthorityProperties) Trim() error {
+	return trim(this,
+		func(v *UserCertificateAuthorityProperties) (string, trimmer) {
+			return "trustedUserCAs", &v.TrustedUserCAs
+		},
+		func(v *UserCertificateAuthorityProperties) (string, trimmer) {
+			return "trustedUserCAsFile", &v.TrustedUserCAsFile
+		},
+	)
+}
+
+func (this *UserCertificateAuthorityProperties) Validate() error {
+	return validate(this,
+		func(v *UserCertificateAuthorityProperties) (string, validator) {
+			return "trustedUserCAs", &v.TrustedUserCAs
+		},
+		func(v *UserCertificateAuthorityProperties) (string, validator) {
+			return "trustedUserCAsFile", &v.TrustedUserCAsFile
+		},
+	)
+}
+
+func (this UserCertificateAuthorityProperties) IsEqualTo(other any) bool {
+	switch v := other.(type) {
+	case UserCertificateAuthorityProperties:
+		return this.isEqualTo(&v)
+	case *UserCertificateAuthorityProperties:
+		return v != nil && this.isEqualTo(v)
+	default:
+		return false
+	}
+}
+
+func (this UserCertificateAuthorityProperties) isEqualTo(other *UserCertificateAuthorityProperties) bool {
+	return isEqual(&this.TrustedUserCAs, &other.TrustedUserCAs) &&
+		isEqual(&this.TrustedUserCAsFile, &other.TrustedUserCAsFile)
+}

--- a/pkg/configuration/user-certificate-authority-properties_local_test.go
+++ b/pkg/configuration/user-certificate-authority-properties_local_test.go
@@ -1,0 +1,34 @@
+//go:build unix
+
+package configuration
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+	"gopkg.in/yaml.v3"
+)
+
+func TestLocalTrustedUserCAsConfiguration(t *testing.T) {
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	require.NoError(t, err)
+	publicKey := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(signer.PublicKey())))
+
+	var authorization Authorization
+	require.NoError(t, yaml.Unmarshal([]byte("type: local\ntrustedUserCAs: |\n  "+publicKey+"\nauthorizedKeys: [/tmp/authorized_keys]\npamService: test\n"), &authorization))
+	actual := authorization.V.(*AuthorizationLocal)
+	require.Equal(t, publicKey, string(actual.TrustedUserCAs))
+	require.Len(t, actual.AuthorizedKeys, 1)
+
+	roundtrip, err := yaml.Marshal(actual)
+	require.NoError(t, err)
+	var restored AuthorizationLocal
+	require.NoError(t, yaml.Unmarshal(roundtrip, &restored))
+	require.True(t, actual.IsEqualTo(restored))
+}

--- a/pkg/configuration/user-certificate-authority-properties_test.go
+++ b/pkg/configuration/user-certificate-authority-properties_test.go
@@ -1,0 +1,71 @@
+package configuration
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+	"gopkg.in/yaml.v3"
+)
+
+func TestSimpleTrustedUserCAsConfiguration(t *testing.T) {
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	require.NoError(t, err)
+	publicKey := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(signer.PublicKey())))
+
+	directory := t.TempDir()
+	var conf Configuration
+	require.NoError(t, conf.LoadFromYaml(strings.NewReader(fmt.Sprintf(`
+ssh:
+  addresses: ["127.0.0.1:0"]
+  keys:
+    hostKeys: ["%s"]
+session:
+  type: fs
+  storage: "%s"
+flows:
+  - name: certificate
+    authorization:
+      type: simple
+      trustedUserCAs: |
+        %s
+      entries:
+        - name: alice
+    environment:
+      type: dummy
+`, filepath.ToSlash(filepath.Join(directory, "host-key")), filepath.ToSlash(filepath.Join(directory, "sessions")), publicKey)), "certificate-test.yaml"))
+	actual := conf.Flows[0].Authorization.V.(*AuthorizationSimple)
+	require.Equal(t, publicKey, string(actual.TrustedUserCAs))
+	require.Len(t, actual.Entries, 1)
+
+	roundtrip, err := yaml.Marshal(actual)
+	require.NoError(t, err)
+	var restored AuthorizationSimple
+	require.NoError(t, yaml.Unmarshal(roundtrip, &restored), string(roundtrip))
+	require.True(t, actual.IsEqualTo(restored))
+}
+
+func TestTrustedUserCAsFileValidation(t *testing.T) {
+	directory := t.TempDir()
+	empty := filepath.Join(directory, "empty")
+	require.NoError(t, os.WriteFile(empty, nil, 0600))
+
+	for name, file := range map[string]string{
+		"missing": filepath.Join(directory, "missing"),
+		"empty":   empty,
+	} {
+		t.Run(name, func(t *testing.T) {
+			var authorization Authorization
+			err := yaml.Unmarshal([]byte("type: simple\ntrustedUserCAsFile: '"+file+"'\nentries:\n  - name: alice\n"), &authorization)
+			require.Error(t, err)
+		})
+	}
+}

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -1,6 +1,8 @@
 package connection
 
 import (
+	"context"
+
 	log "github.com/echocat/slf4g"
 
 	"github.com/engity-com/bifroest/pkg/errors"
@@ -19,4 +21,11 @@ type Connection interface {
 	Id() Id
 	Remote() net.Remote
 	Logger() log.Logger
+}
+
+// LifetimeAware is implemented by connections that expose their complete
+// lifetime independently of individual channel or session contexts.
+type LifetimeAware interface {
+	Connection
+	Lifetime() context.Context
 }

--- a/pkg/crypto/bootstrap-file_linux.go
+++ b/pkg/crypto/bootstrap-file_linux.go
@@ -1,0 +1,34 @@
+//go:build linux
+
+package crypto
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func installBootstrapFile(temporary, target string, force bool) error {
+	var err error
+	if force {
+		err = os.Rename(temporary, target)
+	} else {
+		err = unix.Renameat2(unix.AT_FDCWD, temporary, unix.AT_FDCWD, target, unix.RENAME_NOREPLACE)
+		if errors.Is(err, unix.ENOSYS) || errors.Is(err, unix.EINVAL) || errors.Is(err, unix.EOPNOTSUPP) {
+			if err = os.Link(temporary, target); err == nil {
+				err = os.Remove(temporary)
+			}
+		}
+	}
+	if err != nil {
+		return err
+	}
+	directory, err := os.Open(filepath.Dir(target))
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	return directory.Sync()
+}

--- a/pkg/crypto/bootstrap-file_unix.go
+++ b/pkg/crypto/bootstrap-file_unix.go
@@ -1,0 +1,26 @@
+//go:build unix && !linux
+
+package crypto
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func installBootstrapFile(temporary, target string, force bool) error {
+	var err error
+	if force {
+		err = os.Rename(temporary, target)
+	} else if err = os.Link(temporary, target); err == nil {
+		err = os.Remove(temporary)
+	}
+	if err != nil {
+		return err
+	}
+	directory, err := os.Open(filepath.Dir(target))
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	return directory.Sync()
+}

--- a/pkg/crypto/bootstrap-file_windows.go
+++ b/pkg/crypto/bootstrap-file_windows.go
@@ -5,11 +5,11 @@ package crypto
 import "golang.org/x/sys/windows"
 
 func installBootstrapFile(temporary, target string, force bool) error {
-	from, err := windows.UTF16PtrFromString(temporary)
+	from, err := windowsPathPointer(temporary)
 	if err != nil {
 		return err
 	}
-	to, err := windows.UTF16PtrFromString(target)
+	to, err := windowsPathPointer(target)
 	if err != nil {
 		return err
 	}

--- a/pkg/crypto/bootstrap-file_windows.go
+++ b/pkg/crypto/bootstrap-file_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package crypto
+
+import "golang.org/x/sys/windows"
+
+func installBootstrapFile(temporary, target string, force bool) error {
+	from, err := windows.UTF16PtrFromString(temporary)
+	if err != nil {
+		return err
+	}
+	to, err := windows.UTF16PtrFromString(target)
+	if err != nil {
+		return err
+	}
+	flags := uint32(windows.MOVEFILE_WRITE_THROUGH)
+	if force {
+		flags |= windows.MOVEFILE_REPLACE_EXISTING
+	}
+	return windows.MoveFileEx(from, to, flags)
+}

--- a/pkg/crypto/bootstrap-host-key.go
+++ b/pkg/crypto/bootstrap-host-key.go
@@ -1,0 +1,70 @@
+package crypto
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+
+	bfssh "github.com/engity-com/bifroest/pkg/ssh"
+)
+
+var errHostKeyCaptured = errors.New("SSH host key captured")
+
+var hostKeyScanAlgorithms = []string{
+	ssh.KeyAlgoED25519,
+	ssh.KeyAlgoECDSA256,
+	ssh.KeyAlgoECDSA384,
+	ssh.KeyAlgoECDSA521,
+	ssh.KeyAlgoRSASHA512,
+	ssh.KeyAlgoRSASHA256,
+}
+
+func FetchKnownHostKey(ctx context.Context, address string) ([]byte, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	resolvedAddress, err := bfssh.ParseAddress(address)
+	if err != nil {
+		return nil, err
+	}
+	connection, err := (&net.Dialer{}).DialContext(ctx, "tcp", resolvedAddress.String())
+	if err != nil {
+		return nil, fmt.Errorf("cannot connect to SSH server %q: %w", resolvedAddress, err)
+	}
+	defer connection.Close()
+	if deadline, ok := ctx.Deadline(); ok {
+		if err := connection.SetDeadline(deadline); err != nil {
+			return nil, fmt.Errorf("cannot set SSH handshake deadline: %w", err)
+		}
+	}
+	stopClose := context.AfterFunc(ctx, func() { _ = connection.Close() })
+	defer stopClose()
+
+	var captured ssh.PublicKey
+	config := &ssh.ClientConfig{
+		User:              "bifroest-host-key-scan",
+		HostKeyAlgorithms: hostKeyScanAlgorithms,
+		HostKeyCallback: func(_ string, _ net.Addr, key ssh.PublicKey) error {
+			captured = key
+			return errHostKeyCaptured
+		},
+	}
+	_, _, _, handshakeErr := ssh.NewClientConn(connection, resolvedAddress.String(), config)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	var networkErr net.Error
+	if deadline, hasDeadline := ctx.Deadline(); hasDeadline && !time.Now().Before(deadline) && errors.As(handshakeErr, &networkErr) && networkErr.Timeout() {
+		return nil, context.DeadlineExceeded
+	}
+	if !errors.Is(handshakeErr, errHostKeyCaptured) || captured == nil {
+		return nil, fmt.Errorf("cannot retrieve SSH host key from %q: %w", resolvedAddress, handshakeErr)
+	}
+	host := knownhosts.Normalize(resolvedAddress.String())
+	return []byte(knownhosts.Line([]string{host}, captured) + "\n"), nil
+}

--- a/pkg/crypto/bootstrap-host-key_test.go
+++ b/pkg/crypto/bootstrap-host-key_test.go
@@ -1,0 +1,107 @@
+package crypto
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+func TestFetchKnownHostKeyStopsBeforeAuthentication(t *testing.T) {
+	address, expected, authenticationCalls, serverDone := startHostKeyScanTestServer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	raw, err := FetchKnownHostKey(ctx, address)
+	require.NoError(t, err)
+
+	marker, hosts, actual, _, rest, err := ssh.ParseKnownHosts(raw)
+	require.NoError(t, err)
+	require.Empty(t, marker)
+	require.Equal(t, []string{knownhosts.Normalize(address)}, hosts)
+	require.Equal(t, expected.Marshal(), actual.Marshal())
+	require.Empty(t, rest)
+	require.Zero(t, authenticationCalls.Load())
+	require.Error(t, <-serverDone)
+}
+
+func TestFetchKnownHostKeyHonorsContextDeadline(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr == nil {
+			accepted <- connection
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err = FetchKnownHostKey(ctx, listener.Addr().String())
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	connection := <-accepted
+	require.NoError(t, connection.Close())
+}
+
+func TestFetchKnownHostKeyRejectsNonSshPeer(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr == nil {
+			_ = connection.Close()
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err = FetchKnownHostKey(ctx, listener.Addr().String())
+	require.Error(t, err)
+	require.False(t, errors.Is(err, errHostKeyCaptured))
+}
+
+func startHostKeyScanTestServer(t *testing.T) (string, ssh.PublicKey, *atomic.Int32, <-chan error) {
+	t.Helper()
+	_, private, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(private)
+	require.NoError(t, err)
+	var authenticationCalls atomic.Int32
+	config := &ssh.ServerConfig{
+		NoClientAuth: true,
+		NoClientAuthCallback: func(ssh.ConnMetadata) (*ssh.Permissions, error) {
+			authenticationCalls.Add(1)
+			return nil, nil
+		},
+	}
+	config.AddHostKey(signer)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+	serverDone := make(chan error, 1)
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			serverDone <- acceptErr
+			return
+		}
+		defer connection.Close()
+		server, _, _, serverErr := ssh.NewServerConn(connection, config)
+		if server != nil {
+			_ = server.Close()
+		}
+		serverDone <- serverErr
+	}()
+	return listener.Addr().String(), signer.PublicKey(), &authenticationCalls, serverDone
+}

--- a/pkg/crypto/bootstrap-lock_unix.go
+++ b/pkg/crypto/bootstrap-lock_unix.go
@@ -1,0 +1,32 @@
+//go:build unix
+
+package crypto
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+type bootstrapFileLock struct{ file *os.File }
+
+func acquireBootstrapFileLock(path string) (*bootstrapFileLock, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open trust file lock %q: %w", path, err)
+	}
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("cannot lock trust file %q: %w", path, err)
+	}
+	return &bootstrapFileLock{file: file}, nil
+}
+
+func (this *bootstrapFileLock) Close() error {
+	if err := unix.Flock(int(this.file.Fd()), unix.LOCK_UN); err != nil {
+		_ = this.file.Close()
+		return err
+	}
+	return this.file.Close()
+}

--- a/pkg/crypto/bootstrap-lock_windows.go
+++ b/pkg/crypto/bootstrap-lock_windows.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package crypto
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+type bootstrapFileLock struct {
+	file       *os.File
+	overlapped windows.Overlapped
+}
+
+func acquireBootstrapFileLock(path string) (*bootstrapFileLock, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open trust file lock %q: %w", path, err)
+	}
+	result := &bootstrapFileLock{file: file}
+	if err := windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &result.overlapped); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("cannot lock trust file %q: %w", path, err)
+	}
+	return result, nil
+}
+
+func (this *bootstrapFileLock) Close() error {
+	if err := windows.UnlockFileEx(windows.Handle(this.file.Fd()), 0, 1, 0, &this.overlapped); err != nil {
+		_ = this.file.Close()
+		return err
+	}
+	return this.file.Close()
+}

--- a/pkg/crypto/bootstrap.go
+++ b/pkg/crypto/bootstrap.go
@@ -281,7 +281,7 @@ func WriteBootstrapFile(path string, data []byte, force bool) (rErr error) {
 	if err := os.MkdirAll(parent, 0700); err != nil {
 		return fmt.Errorf("cannot create parent directory for %q: %w", path, err)
 	}
-	temporary, err := os.CreateTemp(parent, "."+filepath.Base(path)+".tmp-*")
+	temporary, err := createProtectedTempFile(parent, ".bifroest-bootstrap-*", 0600)
 	if err != nil {
 		return fmt.Errorf("cannot create temporary file for %q: %w", path, err)
 	}
@@ -294,9 +294,6 @@ func WriteBootstrapFile(path string, data []byte, force bool) (rErr error) {
 		}
 		_ = os.Remove(temporaryPath)
 	}()
-	if err := temporary.Chmod(0600); err != nil {
-		return fmt.Errorf("cannot set mode of temporary file for %q: %w", path, err)
-	}
 	if _, err := temporary.Write(data); err != nil {
 		return fmt.Errorf("cannot write temporary file for %q: %w", path, err)
 	}

--- a/pkg/crypto/bootstrap.go
+++ b/pkg/crypto/bootstrap.go
@@ -1,0 +1,314 @@
+package crypto
+
+import (
+	"bytes"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+
+	bfssh "github.com/engity-com/bifroest/pkg/ssh"
+)
+
+const MaxBootstrapInputSize = 4 * 1024 * 1024
+
+func ExportPublicKey(identityFile, comment string) ([]byte, error) {
+	if strings.ContainsAny(comment, "\r\n") {
+		return nil, fmt.Errorf("comment must not contain a line break")
+	}
+	key, err := EnsureKeyFile(identityFile, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	line := bytes.TrimSpace(MarshalPublicKey(key.PublicKey()))
+	if comment != "" {
+		line = append(append(line, ' '), comment...)
+	}
+	return append(line, '\n'), nil
+}
+
+func MarshalPublicKey(key PublicKey) []byte {
+	return append(bytes.TrimSpace(ssh.MarshalAuthorizedKey(key.ToSsh())), '\n')
+}
+
+func ExportKnownHostKey(identityFile, address string) ([]byte, error) {
+	key, err := EnsureKeyFile(identityFile, &KeyRequirement{Type: KeyTypeEd25519}, nil)
+	if err != nil {
+		return nil, err
+	}
+	return ExportKnownHostKeys([]PrivateKey{key}, address)
+}
+
+func ExportKnownHostKeys(keys []PrivateKey, address string) ([]byte, error) {
+	resolvedAddress, err := bfssh.ParseAddress(address)
+	if err != nil {
+		return nil, fmt.Errorf("illegal host address %q: %w", address, err)
+	}
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("no SSH host key is available")
+	}
+	host := knownhosts.Normalize(resolvedAddress.String())
+	var result []byte
+	for i, key := range keys {
+		if key == nil {
+			return nil, fmt.Errorf("nil SSH host key at index %d", i)
+		}
+		result = append(result, knownhosts.Line([]string{host}, key.PublicKey().ToSsh())...)
+		result = append(result, '\n')
+	}
+	return result, nil
+}
+
+func ImportKnownHostsFile(path string, imported []byte, expectedFingerprint string) (int, error) {
+	entries, err := parseImportedKnownHosts(imported)
+	if err != nil {
+		return 0, err
+	}
+	return mergeBootstrapTrustFile(path, entries, expectedFingerprint, parseExistingKnownHosts)
+}
+
+func ImportCertificateAuthoritiesFile(path string, imported []byte, expectedFingerprint string) (int, error) {
+	entries, err := parseImportedCertificateAuthorities(imported)
+	if err != nil {
+		return 0, err
+	}
+	return mergeBootstrapTrustFile(path, entries, expectedFingerprint, parseExistingCertificateAuthorities)
+}
+
+type bootstrapTrustEntry struct {
+	key        ssh.PublicKey
+	line       []byte
+	identities []string
+}
+
+type bootstrapTrustParser func([]byte) ([]bootstrapTrustEntry, error)
+
+func mergeBootstrapTrustFile(path string, imported []bootstrapTrustEntry, expectedFingerprint string, parseExisting bootstrapTrustParser) (result int, rErr error) {
+	if path == "" {
+		return 0, fmt.Errorf("trust file path is empty")
+	}
+	if err := validateExpectedFingerprint(expectedFingerprint); err != nil {
+		return 0, err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return 0, fmt.Errorf("cannot create parent directory for trust file %q: %w", path, err)
+	}
+	lock, err := acquireBootstrapFileLock(path + ".lock")
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		if err := lock.Close(); err != nil && rErr == nil {
+			rErr = err
+		}
+	}()
+
+	existingRaw, err := os.ReadFile(path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return 0, fmt.Errorf("cannot read trust file %q: %w", path, err)
+	}
+	existing, err := parseExisting(existingRaw)
+	if err != nil {
+		return 0, fmt.Errorf("illegal existing trust file %q: %w", path, err)
+	}
+	known := make(map[string]struct{}, len(existing)+len(imported))
+	for _, entry := range existing {
+		for _, identity := range entry.identities {
+			known[identity] = struct{}{}
+		}
+	}
+	var additions []byte
+	for _, entry := range imported {
+		if expectedFingerprint != "" && ssh.FingerprintSHA256(entry.key) != expectedFingerprint {
+			return 0, fmt.Errorf("public key fingerprint %s does not match expected fingerprint", ssh.FingerprintSHA256(entry.key))
+		}
+		allKnown := len(entry.identities) > 0
+		for _, identity := range entry.identities {
+			if _, found := known[identity]; !found {
+				allKnown = false
+				break
+			}
+		}
+		if allKnown {
+			continue
+		}
+		for _, identity := range entry.identities {
+			known[identity] = struct{}{}
+		}
+		additions = append(additions, entry.line...)
+		result++
+	}
+	if result == 0 {
+		return 0, nil
+	}
+	merged := append([]byte(nil), existingRaw...)
+	if len(merged) > 0 && merged[len(merged)-1] != '\n' {
+		merged = append(merged, '\n')
+	}
+	merged = append(merged, additions...)
+	if _, err := parseExisting(merged); err != nil {
+		return 0, fmt.Errorf("cannot produce valid trust file %q: %w", path, err)
+	}
+	if err := WriteBootstrapFile(path, merged, true); err != nil {
+		return 0, err
+	}
+	return result, nil
+}
+
+func parseImportedCertificateAuthorities(raw []byte) ([]bootstrapTrustEntry, error) {
+	if len(raw) > MaxBootstrapInputSize {
+		return nil, fmt.Errorf("certificate authority input exceeds %d bytes", MaxBootstrapInputSize)
+	}
+	return parseCertificateAuthorities(raw)
+}
+
+func parseExistingCertificateAuthorities(raw []byte) ([]bootstrapTrustEntry, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil, nil
+	}
+	return parseCertificateAuthorities(raw)
+}
+
+func parseCertificateAuthorities(raw []byte) ([]bootstrapTrustEntry, error) {
+	var result []bootstrapTrustEntry
+	err := PublicKeys(raw).ForEach(func(_ int, key ssh.PublicKey, comment string) (bool, error) {
+		line := bytes.TrimSpace(ssh.MarshalAuthorizedKey(key))
+		if comment != "" {
+			line = append(append(line, ' '), comment...)
+		}
+		result = append(result, bootstrapTrustEntry{
+			key: key, line: append(line, '\n'), identities: []string{bootstrapPublicKeyIdentity(key)},
+		})
+		return true, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("illegal certificate authority input: %w", err)
+	}
+	if len(result) == 0 {
+		return nil, fmt.Errorf("certificate authority input contains no public key")
+	}
+	return result, nil
+}
+
+func parseImportedKnownHosts(raw []byte) ([]bootstrapTrustEntry, error) {
+	if len(raw) > MaxBootstrapInputSize {
+		return nil, fmt.Errorf("known hosts input exceeds %d bytes", MaxBootstrapInputSize)
+	}
+	entries, err := parseKnownHostEntries(raw, true)
+	if err != nil {
+		return nil, err
+	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("known hosts input contains no host key")
+	}
+	return entries, nil
+}
+
+func parseExistingKnownHosts(raw []byte) ([]bootstrapTrustEntry, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil, nil
+	}
+	if err := validateKnownHosts(raw); err != nil {
+		return nil, err
+	}
+	return parseKnownHostEntries(raw, false)
+}
+
+func parseKnownHostEntries(raw []byte, rejectMarkers bool) ([]bootstrapTrustEntry, error) {
+	var result []bootstrapTrustEntry
+	remaining := raw
+	for len(bytes.TrimSpace(remaining)) > 0 {
+		marker, hosts, key, _, rest, err := ssh.ParseKnownHosts(remaining)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("illegal known hosts input: %w", err)
+		}
+		if rejectMarkers && marker != "" {
+			return nil, fmt.Errorf("known hosts marker @%s is not accepted", marker)
+		}
+		if _, certificate := key.(*ssh.Certificate); rejectMarkers && certificate {
+			return nil, fmt.Errorf("SSH certificates are not accepted as host keys")
+		}
+		if key != nil {
+			line := knownhosts.Line(hosts, key)
+			if marker != "" {
+				line = "@" + marker + " " + line
+			}
+			identities := make([]string, len(hosts))
+			for i, host := range hosts {
+				identities[i] = marker + "\x00" + knownhosts.Normalize(host) + "\x00" + bootstrapPublicKeyIdentity(key)
+			}
+			result = append(result, bootstrapTrustEntry{key: key, line: []byte(line + "\n"), identities: identities})
+		}
+		if len(rest) >= len(remaining) {
+			return nil, fmt.Errorf("illegal known hosts input: parser made no progress")
+		}
+		remaining = rest
+	}
+	return result, nil
+}
+
+func validateExpectedFingerprint(value string) error {
+	if value == "" {
+		return nil
+	}
+	const prefix = "SHA256:"
+	raw, err := base64.RawStdEncoding.DecodeString(strings.TrimPrefix(value, prefix))
+	if !strings.HasPrefix(value, prefix) || err != nil || len(raw) != 32 {
+		return fmt.Errorf("illegal expected fingerprint %q", value)
+	}
+	return nil
+}
+
+func bootstrapPublicKeyIdentity(key ssh.PublicKey) string {
+	return key.Type() + "\x00" + string(key.Marshal())
+}
+
+func WriteBootstrapFile(path string, data []byte, force bool) (rErr error) {
+	if path == "" {
+		return fmt.Errorf("output path is empty")
+	}
+	parent := filepath.Dir(path)
+	if err := os.MkdirAll(parent, 0700); err != nil {
+		return fmt.Errorf("cannot create parent directory for %q: %w", path, err)
+	}
+	temporary, err := os.CreateTemp(parent, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("cannot create temporary file for %q: %w", path, err)
+	}
+	temporaryPath := temporary.Name()
+	defer func() {
+		if temporary != nil {
+			if err := temporary.Close(); err != nil && rErr == nil {
+				rErr = err
+			}
+		}
+		_ = os.Remove(temporaryPath)
+	}()
+	if err := temporary.Chmod(0600); err != nil {
+		return fmt.Errorf("cannot set mode of temporary file for %q: %w", path, err)
+	}
+	if _, err := temporary.Write(data); err != nil {
+		return fmt.Errorf("cannot write temporary file for %q: %w", path, err)
+	}
+	if err := temporary.Sync(); err != nil {
+		return fmt.Errorf("cannot flush temporary file for %q: %w", path, err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("cannot close temporary file for %q: %w", path, err)
+	}
+	temporary = nil
+	if err := installBootstrapFile(temporaryPath, path, force); err != nil {
+		return fmt.Errorf("cannot install file at %q: %w", path, err)
+	}
+	return nil
+}

--- a/pkg/crypto/bootstrap_test.go
+++ b/pkg/crypto/bootstrap_test.go
@@ -1,0 +1,146 @@
+package crypto
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+
+	bfssh "github.com/engity-com/bifroest/pkg/ssh"
+)
+
+func TestBootstrapKeyExportAndNoClobber(t *testing.T) {
+	directory := t.TempDir()
+	identityFile := filepath.Join(directory, "identity")
+	_, err := (KeyRequirement{Type: KeyTypeEd25519}).CreateFile(nil, identityFile)
+	require.NoError(t, err)
+
+	public, err := ExportPublicKey(identityFile, "bootstrap-test")
+	require.NoError(t, err)
+	require.True(t, bytes.HasSuffix(public, []byte(" bootstrap-test\n")))
+	key, comment, options, rest, err := ssh.ParseAuthorizedKey(public)
+	require.NoError(t, err)
+	require.NotNil(t, key)
+	require.Equal(t, "bootstrap-test", comment)
+	require.Empty(t, options)
+	require.Empty(t, bytes.TrimSpace(rest))
+
+	output := filepath.Join(directory, "public")
+	require.NoError(t, WriteBootstrapFile(output, public, false))
+	require.Error(t, WriteBootstrapFile(output, []byte("replacement"), false))
+	actual, err := os.ReadFile(output)
+	require.NoError(t, err)
+	require.Equal(t, public, actual)
+	require.NoError(t, WriteBootstrapFile(output, []byte("replacement\n"), true))
+}
+
+func TestExportKnownHostKeyAddresses(t *testing.T) {
+	identityFile := filepath.Join(t.TempDir(), "identity")
+	private, err := (KeyRequirement{Type: KeyTypeEd25519}).CreateFile(nil, identityFile)
+	require.NoError(t, err)
+
+	for _, address := range []string{"host.example", "host.example:22", "host.example:2222", "2001:db8::1", "[2001:db8::1]", "[2001:db8::1]:22", "[2001:db8::1]:2222"} {
+		t.Run(address, func(t *testing.T) {
+			actual, err := ExportKnownHostKey(identityFile, address)
+			require.NoError(t, err)
+			resolved, err := bfssh.ParseAddress(address)
+			require.NoError(t, err)
+			marker, hosts, key, _, rest, err := ssh.ParseKnownHosts(actual)
+			require.NoError(t, err)
+			require.Empty(t, marker)
+			require.Equal(t, []string{knownhosts.Normalize(resolved.String())}, hosts)
+			require.Equal(t, private.PublicKey().Marshal(), key.Marshal())
+			require.Empty(t, bytes.TrimSpace(rest))
+		})
+	}
+	implicit, err := ExportKnownHostKey(identityFile, "host.example")
+	require.NoError(t, err)
+	explicit, err := ExportKnownHostKey(identityFile, "host.example:22")
+	require.NoError(t, err)
+	require.Equal(t, implicit, explicit)
+}
+
+func TestImportCertificateAuthoritiesIsValidatedAndIdempotent(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "trusted-user-cas")
+	input := append(bytes.TrimSpace(ssh.MarshalAuthorizedKey(ed255191Pub)), []byte(" first\n")...)
+	added, err := ImportCertificateAuthoritiesFile(target, input, ssh.FingerprintSHA256(ed255191Pub))
+	require.NoError(t, err)
+	require.Equal(t, 1, added)
+	original, err := os.ReadFile(target)
+	require.NoError(t, err)
+
+	added, err = ImportCertificateAuthoritiesFile(target, input, ssh.FingerprintSHA256(ed255191Pub))
+	require.NoError(t, err)
+	require.Zero(t, added)
+	afterIdempotentImport, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, original, afterIdempotentImport)
+
+	second := ssh.MarshalAuthorizedKey(ed255192Pub)
+	_, err = ImportCertificateAuthoritiesFile(target, second, ssh.FingerprintSHA256(ed255191Pub))
+	require.Error(t, err)
+	afterMismatch, readErr := os.ReadFile(target)
+	require.NoError(t, readErr)
+	require.Equal(t, original, afterMismatch)
+
+	_, err = ImportCertificateAuthoritiesFile(target, append([]byte("restrict "), second...), "")
+	require.Error(t, err)
+}
+
+func TestImportKnownHostsRejectsSpecialEntries(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "known-hosts")
+	line := []byte(knownhosts.Line([]string{"host.example"}, ed255191Pub) + "\n")
+	added, err := ImportKnownHostsFile(target, line, ssh.FingerprintSHA256(ed255191Pub))
+	require.NoError(t, err)
+	require.Equal(t, 1, added)
+
+	added, err = ImportKnownHostsFile(target, line, ssh.FingerprintSHA256(ed255191Pub))
+	require.NoError(t, err)
+	require.Zero(t, added)
+
+	_, err = ImportKnownHostsFile(target, line, ssh.FingerprintSHA256(ed255192Pub))
+	require.Error(t, err)
+
+	_, err = ImportKnownHostsFile(target, append([]byte("@revoked "), line...), "")
+	require.Error(t, err)
+
+	secondAddress := []byte(knownhosts.Line([]string{"another.example"}, ed255191Pub) + "\n")
+	added, err = ImportKnownHostsFile(target, secondAddress, ssh.FingerprintSHA256(ed255191Pub))
+	require.NoError(t, err)
+	require.Equal(t, 1, added)
+	actual, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Contains(t, string(actual), "host.example")
+	require.Contains(t, string(actual), "another.example")
+}
+
+func TestConcurrentTrustImportsDoNotLoseUpdates(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "trusted-user-cas")
+	inputs := [][]byte{ssh.MarshalAuthorizedKey(ed255191Pub), ssh.MarshalAuthorizedKey(ed255192Pub)}
+	errors := make(chan error, len(inputs))
+	var wait sync.WaitGroup
+	for _, input := range inputs {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			_, err := ImportCertificateAuthoritiesFile(target, input, "")
+			errors <- err
+		}()
+	}
+	wait.Wait()
+	close(errors)
+	for err := range errors {
+		require.NoError(t, err)
+	}
+
+	actual, err := os.ReadFile(target)
+	require.NoError(t, err)
+	entries, err := parseExistingCertificateAuthorities(actual)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+}

--- a/pkg/crypto/bootstrap_unix_test.go
+++ b/pkg/crypto/bootstrap_unix_test.go
@@ -1,0 +1,20 @@
+//go:build unix
+
+package crypto
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedPrivateKeyHasRestrictiveMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "identity")
+	_, err := (KeyRequirement{Type: KeyTypeEd25519}).CreateFile(nil, path)
+	require.NoError(t, err)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0400), info.Mode().Perm())
+}

--- a/pkg/crypto/bootstrap_windows_test.go
+++ b/pkg/crypto/bootstrap_windows_test.go
@@ -3,8 +3,11 @@
 package crypto
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows"
@@ -14,9 +17,62 @@ func TestGeneratedPrivateKeyHasProtectedDACL(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "identity")
 	_, err := (KeyRequirement{Type: KeyTypeEd25519}).CreateFile(nil, path)
 	require.NoError(t, err)
-	descriptor, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	requireProtectedDACL(t, path)
+}
+
+func TestBootstrapFileHasProtectedDACL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "known-hosts")
+	require.NoError(t, WriteBootstrapFile(path, []byte("first\n"), false))
+	requireProtectedDACL(t, path)
+
+	require.NoError(t, WriteBootstrapFile(path, []byte("replacement\n"), true))
+	requireProtectedDACL(t, path)
+}
+
+func TestProtectedTempFileHasProtectedDACLWhileOpen(t *testing.T) {
+	file, err := createProtectedTempFile(t.TempDir(), ".protected-*", 0600)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, file.Close())
+		require.NoError(t, os.Remove(file.Name()))
+	})
+	requireProtectedDACL(t, file.Name())
+}
+
+func TestBootstrapFileSupportsLongWindowsPath(t *testing.T) {
+	directory := t.TempDir()
+	for len(directory) < 280 {
+		directory = filepath.Join(directory, strings.Repeat("a", 40))
+	}
+	require.NoError(t, os.MkdirAll(directory, 0700))
+	path := filepath.Join(directory, "known-hosts")
+	require.NoError(t, WriteBootstrapFile(path, []byte("content\n"), false))
+	requireProtectedDACL(t, path)
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, []byte("content\n"), raw)
+}
+
+func requireProtectedDACL(t *testing.T, path string) {
+	t.Helper()
+	extended, err := windowsExtendedPath(path)
+	require.NoError(t, err)
+	descriptor, err := windows.GetNamedSecurityInfo(extended, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
 	require.NoError(t, err)
 	control, _, err := descriptor.Control()
 	require.NoError(t, err)
 	require.NotZero(t, control&windows.SE_DACL_PROTECTED)
+	dacl, _, err := descriptor.DACL()
+	require.NoError(t, err)
+	require.NotNil(t, dacl)
+	require.Equal(t, uint16(2), dacl.AceCount)
+	actualSIDs := make([]string, 0, dacl.AceCount)
+	for i := uint32(0); i < uint32(dacl.AceCount); i++ {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		require.NoError(t, windows.GetAce(dacl, i, &ace))
+		require.Equal(t, uint8(windows.ACCESS_ALLOWED_ACE_TYPE), ace.Header.AceType)
+		require.Equal(t, windows.ACCESS_MASK(0x001f01ff), ace.Mask)
+		actualSIDs = append(actualSIDs, (*windows.SID)(unsafe.Pointer(&ace.SidStart)).String())
+	}
+	require.ElementsMatch(t, []string{"S-1-5-18", "S-1-3-4"}, actualSIDs)
 }

--- a/pkg/crypto/bootstrap_windows_test.go
+++ b/pkg/crypto/bootstrap_windows_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/stretchr/testify/require"
@@ -51,6 +52,41 @@ func TestBootstrapFileSupportsLongWindowsPath(t *testing.T) {
 	raw, err := os.ReadFile(path)
 	require.NoError(t, err)
 	require.Equal(t, []byte("content\n"), raw)
+}
+
+func TestReadPrivateKeyFileRetriesTransientWindowsErrors(t *testing.T) {
+	for _, transient := range []error{windows.ERROR_SHARING_VIOLATION, windows.ERROR_LOCK_VIOLATION} {
+		attempts := 0
+		raw, err := readPrivateKeyFileUsing("identity", func(path string) ([]byte, error) {
+			require.Equal(t, "identity", path)
+			attempts++
+			if attempts == 1 {
+				return nil, transient
+			}
+			return []byte("private key"), nil
+		}, func(_ time.Duration) {})
+		require.NoError(t, err)
+		require.Equal(t, []byte("private key"), raw)
+		require.Equal(t, 2, attempts)
+	}
+}
+
+func TestReadPrivateKeyFileBoundsRetriesAndReturnsOtherErrorsImmediately(t *testing.T) {
+	attempts := 0
+	_, err := readPrivateKeyFileUsing("identity", func(string) ([]byte, error) {
+		attempts++
+		return nil, windows.ERROR_SHARING_VIOLATION
+	}, func(_ time.Duration) {})
+	require.ErrorIs(t, err, windows.ERROR_SHARING_VIOLATION)
+	require.Equal(t, 100, attempts)
+
+	attempts = 0
+	_, err = readPrivateKeyFileUsing("identity", func(string) ([]byte, error) {
+		attempts++
+		return nil, windows.ERROR_ACCESS_DENIED
+	}, func(_ time.Duration) {})
+	require.ErrorIs(t, err, windows.ERROR_ACCESS_DENIED)
+	require.Equal(t, 1, attempts)
 }
 
 func requireProtectedDACL(t *testing.T, path string) {

--- a/pkg/crypto/bootstrap_windows_test.go
+++ b/pkg/crypto/bootstrap_windows_test.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package crypto
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+func TestGeneratedPrivateKeyHasProtectedDACL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "identity")
+	_, err := (KeyRequirement{Type: KeyTypeEd25519}).CreateFile(nil, path)
+	require.NoError(t, err)
+	descriptor, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	require.NoError(t, err)
+	control, _, err := descriptor.Control()
+	require.NoError(t, err)
+	require.NotZero(t, control&windows.SE_DACL_PROTECTED)
+}

--- a/pkg/crypto/key-file_linux.go
+++ b/pkg/crypto/key-file_linux.go
@@ -23,8 +23,6 @@ func installPrivateKeyFile(temporary, target string) error {
 	return syncPrivateKeyDirectory(filepath.Dir(target))
 }
 
-func preparePrivateKeyFile(file *os.File, _ string) error { return file.Chmod(0400) }
-
 func syncPrivateKeyDirectory(path string) error {
 	directory, err := os.Open(path)
 	if err != nil {

--- a/pkg/crypto/key-file_linux.go
+++ b/pkg/crypto/key-file_linux.go
@@ -23,6 +23,8 @@ func installPrivateKeyFile(temporary, target string) error {
 	return syncPrivateKeyDirectory(filepath.Dir(target))
 }
 
+func preparePrivateKeyFile(file *os.File, _ string) error { return file.Chmod(0400) }
+
 func syncPrivateKeyDirectory(path string) error {
 	directory, err := os.Open(path)
 	if err != nil {

--- a/pkg/crypto/key-file_linux.go
+++ b/pkg/crypto/key-file_linux.go
@@ -1,0 +1,33 @@
+//go:build linux
+
+package crypto
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func installPrivateKeyFile(temporary, target string) error {
+	err := unix.Renameat2(unix.AT_FDCWD, temporary, unix.AT_FDCWD, target, unix.RENAME_NOREPLACE)
+	if errors.Is(err, unix.ENOSYS) || errors.Is(err, unix.EINVAL) || errors.Is(err, unix.EOPNOTSUPP) {
+		if err = os.Link(temporary, target); err == nil {
+			err = os.Remove(temporary)
+		}
+	}
+	if err != nil {
+		return err
+	}
+	return syncPrivateKeyDirectory(filepath.Dir(target))
+}
+
+func syncPrivateKeyDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	return directory.Sync()
+}

--- a/pkg/crypto/key-file_unix.go
+++ b/pkg/crypto/key-file_unix.go
@@ -1,0 +1,23 @@
+//go:build unix && !linux
+
+package crypto
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func installPrivateKeyFile(temporary, target string) error {
+	if err := os.Link(temporary, target); err != nil {
+		return err
+	}
+	if err := os.Remove(temporary); err != nil {
+		return err
+	}
+	directory, err := os.Open(filepath.Dir(target))
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	return directory.Sync()
+}

--- a/pkg/crypto/key-file_unix.go
+++ b/pkg/crypto/key-file_unix.go
@@ -21,5 +21,3 @@ func installPrivateKeyFile(temporary, target string) error {
 	defer directory.Close()
 	return directory.Sync()
 }
-
-func preparePrivateKeyFile(file *os.File, _ string) error { return file.Chmod(0400) }

--- a/pkg/crypto/key-file_unix.go
+++ b/pkg/crypto/key-file_unix.go
@@ -21,3 +21,5 @@ func installPrivateKeyFile(temporary, target string) error {
 	defer directory.Close()
 	return directory.Sync()
 }
+
+func preparePrivateKeyFile(file *os.File, _ string) error { return file.Chmod(0400) }

--- a/pkg/crypto/key-file_windows.go
+++ b/pkg/crypto/key-file_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package crypto
+
+import "golang.org/x/sys/windows"
+
+func installPrivateKeyFile(temporary, target string) error {
+	from, err := windows.UTF16PtrFromString(temporary)
+	if err != nil {
+		return err
+	}
+	to, err := windows.UTF16PtrFromString(target)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(from, to, windows.MOVEFILE_WRITE_THROUGH)
+}

--- a/pkg/crypto/key-file_windows.go
+++ b/pkg/crypto/key-file_windows.go
@@ -2,34 +2,16 @@
 
 package crypto
 
-import (
-	"os"
-
-	"golang.org/x/sys/windows"
-)
+import "golang.org/x/sys/windows"
 
 func installPrivateKeyFile(temporary, target string) error {
-	from, err := windows.UTF16PtrFromString(temporary)
+	from, err := windowsPathPointer(temporary)
 	if err != nil {
 		return err
 	}
-	to, err := windows.UTF16PtrFromString(target)
+	to, err := windowsPathPointer(target)
 	if err != nil {
 		return err
 	}
 	return windows.MoveFileEx(from, to, windows.MOVEFILE_WRITE_THROUGH)
-}
-
-func preparePrivateKeyFile(_ *os.File, path string) error {
-	descriptor, err := windows.SecurityDescriptorFromString("D:P(A;;FA;;;SY)(A;;FA;;;OW)")
-	if err != nil {
-		return err
-	}
-	dacl, _, err := descriptor.DACL()
-	if err != nil {
-		return err
-	}
-	return windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT,
-		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
-		nil, nil, dacl, nil)
 }

--- a/pkg/crypto/key-file_windows.go
+++ b/pkg/crypto/key-file_windows.go
@@ -2,7 +2,11 @@
 
 package crypto
 
-import "golang.org/x/sys/windows"
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
 
 func installPrivateKeyFile(temporary, target string) error {
 	from, err := windows.UTF16PtrFromString(temporary)
@@ -14,4 +18,18 @@ func installPrivateKeyFile(temporary, target string) error {
 		return err
 	}
 	return windows.MoveFileEx(from, to, windows.MOVEFILE_WRITE_THROUGH)
+}
+
+func preparePrivateKeyFile(_ *os.File, path string) error {
+	descriptor, err := windows.SecurityDescriptorFromString("D:P(A;;FA;;;SY)(A;;FA;;;OW)")
+	if err != nil {
+		return err
+	}
+	dacl, _, err := descriptor.DACL()
+	if err != nil {
+		return err
+	}
+	return windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil, nil, dacl, nil)
 }

--- a/pkg/crypto/key-read_unix.go
+++ b/pkg/crypto/key-read_unix.go
@@ -1,0 +1,9 @@
+//go:build unix
+
+package crypto
+
+import "os"
+
+func readPrivateKeyFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}

--- a/pkg/crypto/key-read_windows.go
+++ b/pkg/crypto/key-read_windows.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package crypto
+
+import (
+	"errors"
+	"os"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+func readPrivateKeyFile(path string) ([]byte, error) {
+	return readPrivateKeyFileUsing(path, os.ReadFile, time.Sleep)
+}
+
+func readPrivateKeyFileUsing(path string, read func(string) ([]byte, error), sleep func(time.Duration)) ([]byte, error) {
+	const (
+		attempts     = 100
+		initialDelay = time.Millisecond
+		maximumDelay = 50 * time.Millisecond
+	)
+	delay := initialDelay
+	for attempt := range attempts {
+		raw, err := read(path)
+		if !errors.Is(err, windows.ERROR_SHARING_VIOLATION) && !errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+			return raw, err
+		}
+		if attempt == attempts-1 {
+			return nil, err
+		}
+		sleep(delay)
+		delay = min(delay*2, maximumDelay)
+	}
+	panic("unreachable")
+}

--- a/pkg/crypto/key-requirement.go
+++ b/pkg/crypto/key-requirement.go
@@ -46,16 +46,12 @@ func (this KeyRequirement) CreateFile(rand io.Reader, fn string) (PrivateKey, er
 	if err := os.MkdirAll(parent, 0700); err != nil {
 		return nil, fmt.Errorf("cannot create parent directory for private key %q: %w", fn, err)
 	}
-	f, err := os.CreateTemp(parent, "."+filepath.Base(fn)+".tmp-*")
+	f, err := createProtectedTempFile(parent, ".bifroest-key-*", 0400)
 	if err != nil {
 		return nil, err
 	}
 	temporary := f.Name()
 	defer os.Remove(temporary)
-	if err := preparePrivateKeyFile(f, temporary); err != nil {
-		_ = f.Close()
-		return nil, fmt.Errorf("cannot protect new private key %q: %w", fn, err)
-	}
 	if _, err := f.Write(content.Bytes()); err != nil {
 		_ = f.Close()
 		return nil, fmt.Errorf("cannot write new private key to %q: %w", fn, err)

--- a/pkg/crypto/key-requirement.go
+++ b/pkg/crypto/key-requirement.go
@@ -52,9 +52,9 @@ func (this KeyRequirement) CreateFile(rand io.Reader, fn string) (PrivateKey, er
 	}
 	temporary := f.Name()
 	defer os.Remove(temporary)
-	if err := f.Chmod(0400); err != nil {
+	if err := preparePrivateKeyFile(f, temporary); err != nil {
 		_ = f.Close()
-		return nil, fmt.Errorf("cannot set mode of new private key %q: %w", fn, err)
+		return nil, fmt.Errorf("cannot protect new private key %q: %w", fn, err)
 	}
 	if _, err := f.Write(content.Bytes()); err != nil {
 		_ = f.Close()

--- a/pkg/crypto/key-requirement.go
+++ b/pkg/crypto/key-requirement.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"bytes"
 	"crypto/dsa"
 	"crypto/ecdsa"
 	"crypto/ed25519"
@@ -10,8 +11,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-
-	"github.com/engity-com/bifroest/pkg/common"
 )
 
 const (
@@ -39,15 +38,37 @@ func (this KeyRequirement) CreateFile(rand io.Reader, fn string) (PrivateKey, er
 		return nil, err
 	}
 
-	_ = os.MkdirAll(filepath.Dir(fn), 0700)
-	f, err := os.OpenFile(fn, os.O_CREATE|os.O_WRONLY, 0400)
+	var content bytes.Buffer
+	if err := WriteSshPrivateKey(pk, &content); err != nil {
+		return nil, fmt.Errorf("cannot encode new private key for %q: %w", fn, err)
+	}
+	parent := filepath.Dir(fn)
+	if err := os.MkdirAll(parent, 0700); err != nil {
+		return nil, fmt.Errorf("cannot create parent directory for private key %q: %w", fn, err)
+	}
+	f, err := os.CreateTemp(parent, "."+filepath.Base(fn)+".tmp-*")
 	if err != nil {
 		return nil, err
 	}
-	defer common.IgnoreCloseError(f)
-
-	if err := WriteSshPrivateKey(pk, f); err != nil {
+	temporary := f.Name()
+	defer os.Remove(temporary)
+	if err := f.Chmod(0400); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("cannot set mode of new private key %q: %w", fn, err)
+	}
+	if _, err := f.Write(content.Bytes()); err != nil {
+		_ = f.Close()
 		return nil, fmt.Errorf("cannot write new private key to %q: %w", fn, err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("cannot flush new private key for %q: %w", fn, err)
+	}
+	if err := f.Close(); err != nil {
+		return nil, fmt.Errorf("cannot close new private key for %q: %w", fn, err)
+	}
+	if err := installPrivateKeyFile(temporary, fn); err != nil {
+		return nil, fmt.Errorf("cannot install new private key at %q: %w", fn, err)
 	}
 
 	return pk, nil

--- a/pkg/crypto/key.go
+++ b/pkg/crypto/key.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"os"
 
 	"github.com/mikesmitty/edkey"
 	"golang.org/x/crypto/ssh"
@@ -146,7 +145,7 @@ func (this *privateKeyWrapper) String() string {
 }
 
 func EnsureKeyFile(fn string, reqOnAbsence *KeyRequirement, rand io.Reader) (PrivateKey, error) {
-	raw, err := os.ReadFile(fn)
+	raw, err := readPrivateKeyFile(fn)
 	if sys.IsNotExist(err) {
 		if reqOnAbsence == nil {
 			return nil, fmt.Errorf("private key %q does not exist", fn)

--- a/pkg/crypto/key.go
+++ b/pkg/crypto/key.go
@@ -164,8 +164,14 @@ func EnsureKeyFile(fn string, reqOnAbsence *KeyRequirement, rand io.Reader) (Pri
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse private key %q: %w", fn, err)
 	}
-
-	return PrivateKeyFromSdk(pk.(gocrypto.Signer))
+	switch value := pk.(type) {
+	case *dsa.PrivateKey:
+		return PrivateKeyFromSdk(&dsaPrivateKey{value})
+	case gocrypto.Signer:
+		return PrivateKeyFromSdk(value)
+	default:
+		return nil, fmt.Errorf("private key %q of type %T cannot be used as signer", fn, pk)
+	}
 }
 
 func WriteSshPrivateKey(pk PrivateKey, to io.Writer) error {

--- a/pkg/crypto/key.go
+++ b/pkg/crypto/key.go
@@ -7,8 +7,10 @@ import (
 	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 
 	"github.com/mikesmitty/edkey"
@@ -146,7 +148,14 @@ func (this *privateKeyWrapper) String() string {
 func EnsureKeyFile(fn string, reqOnAbsence *KeyRequirement, rand io.Reader) (PrivateKey, error) {
 	raw, err := os.ReadFile(fn)
 	if sys.IsNotExist(err) {
-		return reqOnAbsence.CreateFile(rand, fn)
+		if reqOnAbsence == nil {
+			return nil, fmt.Errorf("private key %q does not exist", fn)
+		}
+		created, createErr := reqOnAbsence.CreateFile(rand, fn)
+		if errors.Is(createErr, fs.ErrExist) {
+			return EnsureKeyFile(fn, nil, rand)
+		}
+		return created, createErr
 	} else if err != nil {
 		return nil, fmt.Errorf("cannot read %q: %w", fn, err)
 	}

--- a/pkg/crypto/key_test.go
+++ b/pkg/crypto/key_test.go
@@ -1,0 +1,47 @@
+package crypto
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestEnsureKeyFileCreatesOneCompleteKeyConcurrently(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "identity")
+	requirement := &KeyRequirement{Type: KeyTypeEd25519}
+	const workers = 16
+	fingerprints := make(chan string, workers)
+	errors := make(chan error, workers)
+	var wait sync.WaitGroup
+	for range workers {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			key, err := EnsureKeyFile(path, requirement, nil)
+			if err != nil {
+				errors <- err
+				return
+			}
+			fingerprints <- ssh.FingerprintSHA256(key.ToSsh().PublicKey())
+		}()
+	}
+	wait.Wait()
+	close(fingerprints)
+	close(errors)
+	for err := range errors {
+		require.NoError(t, err)
+	}
+	var expected string
+	for fingerprint := range fingerprints {
+		if expected == "" {
+			expected = fingerprint
+		}
+		require.Equal(t, expected, fingerprint)
+	}
+	require.NotEmpty(t, expected)
+	_, err := EnsureKeyFile(path, nil, nil)
+	require.NoError(t, err)
+}

--- a/pkg/crypto/key_test.go
+++ b/pkg/crypto/key_test.go
@@ -1,6 +1,12 @@
 package crypto
 
 import (
+	"crypto/dsa"
+	"crypto/rand"
+	"encoding/asn1"
+	"encoding/pem"
+	"math/big"
+	goos "os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -44,4 +50,20 @@ func TestEnsureKeyFileCreatesOneCompleteKeyConcurrently(t *testing.T) {
 	require.NotEmpty(t, expected)
 	_, err := EnsureKeyFile(path, nil, nil)
 	require.NoError(t, err)
+}
+
+func TestEnsureKeyFileRejectsUnsupportedDsaWithoutPanic(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "identity")
+	private := &dsa.PrivateKey{}
+	require.NoError(t, dsa.GenerateParameters(&private.Parameters, rand.Reader, dsa.L1024N160))
+	require.NoError(t, dsa.GenerateKey(private, rand.Reader))
+	der, err := asn1.Marshal(struct {
+		Version       int
+		P, Q, G, Y, X *big.Int
+	}{0, private.P, private.Q, private.G, private.Y, private.X})
+	require.NoError(t, err)
+	require.NoError(t, goos.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "DSA PRIVATE KEY", Bytes: der}), 0400))
+
+	_, err = EnsureKeyFile(path, nil, nil)
+	require.ErrorContains(t, err, "unsupported key type")
 }

--- a/pkg/crypto/known-hosts.go
+++ b/pkg/crypto/known-hosts.go
@@ -1,0 +1,156 @@
+package crypto
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+type KnownHosts string
+
+func (this KnownHosts) Validate() error {
+	if this.IsZero() {
+		return nil
+	}
+	return validateKnownHosts([]byte(this))
+}
+
+func (this KnownHosts) IsZero() bool {
+	return strings.TrimSpace(string(this)) == ""
+}
+
+func (this *KnownHosts) Trim() error {
+	*this = KnownHosts(strings.TrimSpace(string(*this)))
+	return nil
+}
+
+func (this KnownHosts) IsEqualTo(other any) bool {
+	switch v := other.(type) {
+	case KnownHosts:
+		return this == v
+	case *KnownHosts:
+		return v != nil && this == *v
+	default:
+		return false
+	}
+}
+
+type KnownHostsFile string
+
+func (this KnownHostsFile) Validate() error {
+	if this.IsZero() {
+		return nil
+	}
+	raw, err := os.ReadFile(string(this))
+	if err != nil {
+		return fmt.Errorf("cannot read known hosts file %q: %w", this, err)
+	}
+	return validateKnownHosts(raw)
+}
+
+func (this KnownHostsFile) IsZero() bool {
+	return strings.TrimSpace(string(this)) == ""
+}
+
+func (this *KnownHostsFile) Trim() error {
+	*this = KnownHostsFile(strings.TrimSpace(string(*this)))
+	return nil
+}
+
+func (this KnownHostsFile) IsEqualTo(other any) bool {
+	switch v := other.(type) {
+	case KnownHostsFile:
+		return this == v
+	case *KnownHostsFile:
+		return v != nil && this == *v
+	default:
+		return false
+	}
+}
+
+func validateKnownHosts(raw []byte) error {
+	remaining := raw
+	found := false
+	for len(remaining) > 0 {
+		marker, _, key, _, rest, err := ssh.ParseKnownHosts(remaining)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("illegal known hosts: %w", err)
+		}
+		if marker != "" && marker != "revoked" && marker != "cert-authority" {
+			return fmt.Errorf("illegal known hosts marker @%s", marker)
+		}
+		if key != nil {
+			found = true
+		}
+		if len(rest) >= len(remaining) {
+			return fmt.Errorf("illegal known hosts: parser made no progress")
+		}
+		remaining = rest
+	}
+	if !found {
+		return fmt.Errorf("illegal or non-existent known hosts")
+	}
+	f, err := os.CreateTemp("", "bifroest-known-hosts-validation-*")
+	if err != nil {
+		return fmt.Errorf("cannot create temporary known hosts validation file: %w", err)
+	}
+	name := f.Name()
+	defer func() { _ = os.Remove(name) }()
+	if _, err := f.Write(raw); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("cannot write temporary known hosts validation file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("cannot close temporary known hosts validation file: %w", err)
+	}
+	if _, err := knownhosts.New(name); err != nil {
+		return fmt.Errorf("illegal known hosts: %w", err)
+	}
+	return nil
+}
+
+func NewKnownHostsCallback(inline KnownHosts, file KnownHostsFile) (ssh.HostKeyCallback, error) {
+	if err := inline.Validate(); err != nil {
+		return nil, err
+	}
+	if err := file.Validate(); err != nil {
+		return nil, err
+	}
+
+	var files []string
+	if !inline.IsZero() {
+		f, err := os.CreateTemp("", "bifroest-known-hosts-*")
+		if err != nil {
+			return nil, fmt.Errorf("cannot create temporary known hosts file: %w", err)
+		}
+		name := f.Name()
+		defer func() { _ = os.Remove(name) }()
+		if _, err := f.WriteString(string(inline)); err != nil {
+			_ = f.Close()
+			return nil, fmt.Errorf("cannot write temporary known hosts file: %w", err)
+		}
+		if err := f.Close(); err != nil {
+			return nil, fmt.Errorf("cannot close temporary known hosts file: %w", err)
+		}
+		files = append(files, name)
+	}
+	if !file.IsZero() {
+		files = append(files, string(file))
+	}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no known hosts configured")
+	}
+	callback, err := knownhosts.New(files...)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load known hosts: %w", err)
+	}
+	return callback, nil
+}

--- a/pkg/crypto/known-hosts_test.go
+++ b/pkg/crypto/known-hosts_test.go
@@ -1,0 +1,73 @@
+package crypto
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"fmt"
+	gonet "net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+func newKnownHostsTestKey(t *testing.T) ssh.PublicKey {
+	t.Helper()
+	public, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	result, err := ssh.NewPublicKey(public)
+	require.NoError(t, err)
+	return result
+}
+
+func knownHostsTestLine(marker, host string, key ssh.PublicKey) string {
+	prefix := ""
+	if marker != "" {
+		prefix = "@" + marker + " "
+	}
+	return fmt.Sprintf("%s%s %s", prefix, host, strings.TrimSpace(string(ssh.MarshalAuthorizedKey(key))))
+}
+
+func TestNewKnownHostsCallbackAcceptsInlineAndFileEntries(t *testing.T) {
+	inlineKey := newKnownHostsTestKey(t)
+	fileKey := newKnownHostsTestKey(t)
+	file := filepath.Join(t.TempDir(), "known_hosts")
+	require.NoError(t, os.WriteFile(file, []byte(knownHostsTestLine("", "file.example.org", fileKey)), 0600))
+
+	callback, err := NewKnownHostsCallback(
+		KnownHosts(knownHostsTestLine("", "inline.example.org", inlineKey)),
+		KnownHostsFile(file),
+	)
+	require.NoError(t, err)
+
+	address := &gonet.TCPAddr{IP: gonet.ParseIP("127.0.0.1"), Port: 22}
+	require.NoError(t, callback("inline.example.org:22", address, inlineKey))
+	require.NoError(t, callback("file.example.org:22", address, fileKey))
+}
+
+func TestNewKnownHostsCallbackHonorsRevocationAcrossSources(t *testing.T) {
+	key := newKnownHostsTestKey(t)
+	file := filepath.Join(t.TempDir(), "known_hosts")
+	require.NoError(t, os.WriteFile(file, []byte(knownHostsTestLine("revoked", "target.example.org", key)), 0600))
+
+	callback, err := NewKnownHostsCallback(
+		KnownHosts(knownHostsTestLine("", "target.example.org", key)),
+		KnownHostsFile(file),
+	)
+	require.NoError(t, err)
+
+	err = callback("target.example.org:22", &gonet.TCPAddr{IP: gonet.ParseIP("127.0.0.1"), Port: 22}, key)
+	var revoked *knownhosts.RevokedError
+	require.ErrorAs(t, err, &revoked)
+}
+
+func TestKnownHostsRejectsCommentOnlyAndMalformedInput(t *testing.T) {
+	require.Error(t, KnownHosts("# only a comment").Validate())
+	require.Error(t, KnownHosts("target.example.org not-a-key").Validate())
+	require.Error(t, KnownHosts(knownHostsTestLine("unknown", "target.example.org", newKnownHostsTestKey(t))).Validate())
+	require.Error(t, KnownHosts(knownHostsTestLine("", "!", newKnownHostsTestKey(t))).Validate())
+}

--- a/pkg/crypto/protected-temp-file_unix.go
+++ b/pkg/crypto/protected-temp-file_unix.go
@@ -1,0 +1,20 @@
+//go:build unix
+
+package crypto
+
+import (
+	"os"
+)
+
+func createProtectedTempFile(parent, pattern string, mode os.FileMode) (*os.File, error) {
+	file, err := os.CreateTemp(parent, pattern)
+	if err != nil {
+		return nil, err
+	}
+	if err := file.Chmod(mode); err != nil {
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+		return nil, err
+	}
+	return file, nil
+}

--- a/pkg/crypto/protected-temp-file_windows.go
+++ b/pkg/crypto/protected-temp-file_windows.go
@@ -1,0 +1,75 @@
+//go:build windows
+
+package crypto
+
+import (
+	crand "crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func createProtectedTempFile(parent, pattern string, _ os.FileMode) (*os.File, error) {
+	if !strings.HasSuffix(pattern, "*") {
+		return nil, fmt.Errorf("temporary file pattern %q does not end in *", pattern)
+	}
+	descriptor, err := windows.SecurityDescriptorFromString("D:P(A;;FA;;;SY)(A;;FA;;;OW)")
+	if err != nil {
+		return nil, err
+	}
+	attributes := &windows.SecurityAttributes{
+		Length:             uint32(unsafe.Sizeof(windows.SecurityAttributes{})),
+		SecurityDescriptor: descriptor,
+	}
+	prefix := strings.TrimSuffix(pattern, "*")
+	for range 100 {
+		var random [16]byte
+		if _, err := crand.Read(random[:]); err != nil {
+			return nil, err
+		}
+		path := filepath.Join(parent, prefix+hex.EncodeToString(random[:]))
+		name, err := windowsPathPointer(path)
+		if err != nil {
+			return nil, err
+		}
+		handle, err := windows.CreateFile(name, windows.GENERIC_READ|windows.GENERIC_WRITE,
+			windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+			attributes, windows.CREATE_NEW, windows.FILE_ATTRIBUTE_NORMAL, 0)
+		if errors.Is(err, windows.ERROR_FILE_EXISTS) || errors.Is(err, windows.ERROR_ALREADY_EXISTS) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		return os.NewFile(uintptr(handle), path), nil
+	}
+	return nil, fmt.Errorf("cannot create a unique temporary file in %q", parent)
+}
+
+func windowsPathPointer(path string) (*uint16, error) {
+	extended, err := windowsExtendedPath(path)
+	if err != nil {
+		return nil, err
+	}
+	return windows.UTF16PtrFromString(extended)
+}
+
+func windowsExtendedPath(path string) (string, error) {
+	if strings.HasPrefix(path, `\\?\`) || strings.HasPrefix(path, `\\.\`) {
+		return path, nil
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	if strings.HasPrefix(absolute, `\\`) {
+		return `\\?\UNC\` + strings.TrimPrefix(absolute, `\\`), nil
+	}
+	return `\\?\` + absolute, nil
+}

--- a/pkg/crypto/public-keys-file.go
+++ b/pkg/crypto/public-keys-file.go
@@ -1,0 +1,52 @@
+package crypto
+
+import (
+	"os"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/engity-com/bifroest/pkg/common"
+)
+
+type PublicKeysFile string
+
+func (this PublicKeysFile) ForEach(consumer func(i int, key ssh.PublicKey, comment string) (canContinue bool, err error)) error {
+	if this.IsZero() {
+		return nil
+	}
+	f, err := os.Open(string(this))
+	if err != nil {
+		return err
+	}
+	defer common.IgnoreCloseError(f)
+	return parsePublicKeys(f, consumer)
+}
+
+func (this PublicKeysFile) Get() ([]ssh.PublicKey, error) {
+	return getPublicKeysOf(this)
+}
+
+func (this PublicKeysFile) Validate() error {
+	return validatePublicKeysOf(this)
+}
+
+func (this PublicKeysFile) IsZero() bool {
+	return strings.TrimSpace(string(this)) == ""
+}
+
+func (this *PublicKeysFile) Trim() error {
+	*this = PublicKeysFile(strings.TrimSpace(string(*this)))
+	return nil
+}
+
+func (this PublicKeysFile) IsEqualTo(other any) bool {
+	switch v := other.(type) {
+	case PublicKeysFile:
+		return this == v
+	case *PublicKeysFile:
+		return v != nil && this == *v
+	default:
+		return false
+	}
+}

--- a/pkg/crypto/public-keys-file_test.go
+++ b/pkg/crypto/public-keys-file_test.go
@@ -1,0 +1,31 @@
+package crypto
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestPublicKeysFile(t *testing.T) {
+	directory := t.TempDir()
+	valid := filepath.Join(directory, "valid")
+	empty := filepath.Join(directory, "empty")
+	invalid := filepath.Join(directory, "invalid")
+	key := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(ed255191Pub)))
+	require.NoError(t, os.WriteFile(valid, []byte(key+"\n"), 0600))
+	require.NoError(t, os.WriteFile(empty, []byte("# empty\n"), 0600))
+	require.NoError(t, os.WriteFile(invalid, []byte("restrict "+key+"\n"), 0600))
+
+	actual, err := PublicKeysFile(valid).Get()
+	require.NoError(t, err)
+	require.Len(t, actual, 1)
+	require.Equal(t, ed255191Pub.Marshal(), actual[0].Marshal())
+	require.Error(t, PublicKeysFile(empty).Validate())
+	require.Error(t, PublicKeysFile(invalid).Validate())
+	require.Error(t, PublicKeysFile(filepath.Join(directory, "missing")).Validate())
+	require.NoError(t, PublicKeysFile("").Validate())
+}

--- a/pkg/crypto/public-keys.go
+++ b/pkg/crypto/public-keys.go
@@ -1,0 +1,112 @@
+package crypto
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+)
+
+var ErrIllegalPublicKeysFormat = errors.New("illegal public keys format")
+
+type PublicKeys string
+
+func (this PublicKeys) ForEach(consumer func(i int, key ssh.PublicKey, comment string) (canContinue bool, err error)) error {
+	if this.IsZero() {
+		return nil
+	}
+	return parsePublicKeys(bytes.NewReader([]byte(this)), consumer)
+}
+
+func (this PublicKeys) Get() ([]ssh.PublicKey, error) {
+	return getPublicKeysOf(this)
+}
+
+func (this PublicKeys) Validate() error {
+	return validatePublicKeysOf(this)
+}
+
+func (this PublicKeys) IsZero() bool {
+	return strings.TrimSpace(string(this)) == ""
+}
+
+func (this *PublicKeys) Trim() error {
+	*this = PublicKeys(strings.TrimSpace(string(*this)))
+	return nil
+}
+
+func (this PublicKeys) IsEqualTo(other any) bool {
+	switch v := other.(type) {
+	case PublicKeys:
+		return this == v
+	case *PublicKeys:
+		return v != nil && this == *v
+	default:
+		return false
+	}
+}
+
+type publicKeysSource interface {
+	IsZero() bool
+	ForEach(func(int, ssh.PublicKey, string) (bool, error)) error
+}
+
+func getPublicKeysOf(source publicKeysSource) ([]ssh.PublicKey, error) {
+	var result []ssh.PublicKey
+	err := source.ForEach(func(_ int, key ssh.PublicKey, _ string) (bool, error) {
+		result = append(result, key)
+		return true, nil
+	})
+	return result, err
+}
+
+func validatePublicKeysOf(source publicKeysSource) error {
+	if source.IsZero() {
+		return nil
+	}
+	found := false
+	if err := source.ForEach(func(_ int, _ ssh.PublicKey, _ string) (bool, error) {
+		found = true
+		return true, nil
+	}); err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("illegal or non-existent public keys: %v", source)
+	}
+	return nil
+}
+
+func parsePublicKeys(r io.Reader, consumer func(i int, key ssh.PublicKey, comment string) (canContinue bool, err error)) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Split(bufio.ScanLines)
+	scanner.Buffer(make([]byte, maxAuthorizedKeysLineSize), maxAuthorizedKeysLineSize)
+
+	var i int
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 || line[0] == '#' {
+			continue
+		}
+		key, comment, options, rest, err := ssh.ParseAuthorizedKey(line)
+		if err != nil || key == nil || len(bytes.TrimSpace(rest)) != 0 || len(options) != 0 {
+			if err == nil {
+				err = ErrIllegalPublicKeysFormat
+			}
+			return fmt.Errorf("%w at entry #%d: %v", ErrIllegalPublicKeysFormat, i, err)
+		}
+		if _, isCertificate := key.(*ssh.Certificate); isCertificate {
+			return fmt.Errorf("%w at entry #%d: certificates are not CA public keys", ErrIllegalPublicKeysFormat, i)
+		}
+		canContinue, err := consumer(i, key, comment)
+		if err != nil || !canContinue {
+			return err
+		}
+		i++
+	}
+	return scanner.Err()
+}

--- a/pkg/crypto/public-keys_test.go
+++ b/pkg/crypto/public-keys_test.go
@@ -1,0 +1,52 @@
+package crypto
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestPublicKeysGet(t *testing.T) {
+	key1 := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(ed255191Pub)))
+	key2 := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(ed255192Pub)))
+	actual, err := PublicKeys("# CAs\r\n" + key1 + " first\r\n\t" + key2 + "\tsecond\r\n").Get()
+	require.NoError(t, err)
+	require.Len(t, actual, 2)
+	require.Equal(t, ed255191Pub.Marshal(), actual[0].Marshal())
+	require.Equal(t, ed255192Pub.Marshal(), actual[1].Marshal())
+}
+
+func TestPublicKeysRejectsIllegalEntries(t *testing.T) {
+	key := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(ed255191Pub)))
+	for name, value := range map[string]string{
+		"authorized-key-option": "restrict " + key,
+		"invalid-key":           "ssh-ed25519 invalid",
+		"invalid-second-key":    key + "\nssh-ed25519 invalid",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := PublicKeys(value).Get()
+			require.ErrorIs(t, err, ErrIllegalPublicKeysFormat)
+			require.Error(t, PublicKeys(value).Validate())
+		})
+	}
+}
+
+func TestPublicKeysValidation(t *testing.T) {
+	require.NoError(t, PublicKeys("").Validate())
+	require.Error(t, PublicKeys("# no key").Validate())
+	key := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(ed255191Pub)))
+	require.NoError(t, PublicKeys(key+" comment").Validate())
+}
+
+func TestPublicKeysForEachCanStop(t *testing.T) {
+	value := PublicKeys(fmt.Sprintf("%s\n%s", ssh.MarshalAuthorizedKey(ed255191Pub), ssh.MarshalAuthorizedKey(ed255192Pub)))
+	count := 0
+	require.NoError(t, value.ForEach(func(_ int, _ ssh.PublicKey, _ string) (bool, error) {
+		count++
+		return false, nil
+	}))
+	require.Equal(t, 1, count)
+}

--- a/pkg/environment/docker-usage-specific.go
+++ b/pkg/environment/docker-usage-specific.go
@@ -100,8 +100,9 @@ func (this *docker) Run(t Task) (exitCode int, rErr error) {
 	if v, ok := os.LookupEnv("TZ"); ok {
 		ev.Set("TZ", v)
 	}
-	ev.AddAllOf(t.Authorization().EnvVars())
-	ev.Add(t.SshSession().Environ()...)
+	if err := applyTaskEnvironment(&ev, this.repository.hostOs, t); err != nil {
+		return fail(err)
+	}
 	setReservedEnvironment(&ev, this.repository.hostOs,
 		session.EnvName, sess.Id().String(),
 		connection.EnvName, t.Connection().Id().String(),
@@ -141,14 +142,14 @@ func (this *docker) Run(t Task) (exitCode int, rErr error) {
 		} else {
 			defer common.IgnoreCloseError(ln)
 			go ssh.ForwardAgentConnections(ln, l, sshSess)
-			ev.Set(ssh.AuthSockEnvName, ln.Path())
+			setReservedEnvironment(&ev, this.repository.hostOs, ssh.AuthSockEnvName, ln.Path())
 		}
 	}
 
 	var winCh <-chan essh.Window
 	if ptyReq, windows, isPty := sshSess.Pty(); isPty {
 		winCh = windows
-		ev.Set("TERM", ptyReq.Term)
+		setReservedEnvironment(&ev, this.repository.hostOs, "TERM", ptyReq.Term)
 		opts.Tty = true
 		opts.ConsoleSize = &[2]uint{uint(ptyReq.Window.Height), uint(ptyReq.Window.Width)}
 	}

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -22,3 +22,9 @@ type Environment interface {
 	// Close can be safely called more than once.
 	Close() error
 }
+
+// ReversePortForwardingPolicy allows an environment to specialize reverse
+// forwarding independently from local and dynamic forwarding.
+type ReversePortForwardingPolicy interface {
+	IsReversePortForwardingAllowed(net.HostPort) (bool, error)
+}

--- a/pkg/environment/execution_lifecycle_test.go
+++ b/pkg/environment/execution_lifecycle_test.go
@@ -71,6 +71,20 @@ func TestSetReservedEnvironmentCanonicalizesWindowsAliases(t *testing.T) {
 	}, environment)
 }
 
+func TestAddEnvironmentLayerCanonicalizesEveryWindowsLayer(t *testing.T) {
+	environment := sys.EnvVars{"Path": "backend", "OTHER": "preserved"}
+	require.NoError(t, addEnvironmentLayer(&environment, sys.OsWindows, sys.EnvVars{"PATH": "client"}))
+	require.NoError(t, addEnvironmentLayer(&environment, sys.OsWindows, sys.EnvVars{"path": "authorization"}))
+
+	require.Equal(t, sys.EnvVars{"path": "authorization", "OTHER": "preserved"}, environment)
+}
+
+func TestAddEnvironmentLayerRejectsAmbiguousWindowsLayer(t *testing.T) {
+	environment := sys.EnvVars{}
+	err := addEnvironmentLayer(&environment, sys.OsWindows, sys.EnvVars{"Path": "one", "PATH": "two"})
+	require.ErrorContains(t, err, "ambiguous case-insensitive environment variables")
+}
+
 func TestAttachDockerExecWithTimeoutBoundsApiSetup(t *testing.T) {
 	started := time.Now()
 	_, err := attachDockerExecWithTimeout(context.Background(), 20*time.Millisecond, func(ctx context.Context) (types.HijackedResponse, error) {

--- a/pkg/environment/facade-repository.go
+++ b/pkg/environment/facade-repository.go
@@ -10,18 +10,39 @@ import (
 	"github.com/engity-com/bifroest/pkg/alternatives"
 	"github.com/engity-com/bifroest/pkg/common"
 	"github.com/engity-com/bifroest/pkg/configuration"
+	"github.com/engity-com/bifroest/pkg/crypto"
 	"github.com/engity-com/bifroest/pkg/errors"
 	"github.com/engity-com/bifroest/pkg/imp"
 	"github.com/engity-com/bifroest/pkg/session"
 )
 
 func NewRepositoryFacade(ctx context.Context, flows *configuration.Flows, ap alternatives.Provider, i imp.Imp) (*RepositoryFacade, error) {
+	return newRepositoryFacade(ctx, flows, ap, i)
+}
+
+func NewRepositoryFacadeWithHostKeys(ctx context.Context, flows *configuration.Flows, ap alternatives.Provider, i imp.Imp, hostKeys []crypto.PrivateKey) (*RepositoryFacade, error) {
+	ctx = context.WithValue(ctx, repositoryDependenciesContextKey{}, repositoryDependencies{hostKeys: hostKeys})
+	return newRepositoryFacade(ctx, flows, ap, i)
+}
+
+func newRepositoryFacade(ctx context.Context, flows *configuration.Flows, ap alternatives.Provider, i imp.Imp) (*RepositoryFacade, error) {
 	if flows == nil {
 		return &RepositoryFacade{}, nil
 	}
 
 	entries := make(map[configuration.FlowName]CloseableRepository, len(*flows))
+	success := false
+	defer func() {
+		if !success {
+			for _, entry := range entries {
+				_ = entry.Close()
+			}
+		}
+	}()
 	for _, flow := range *flows {
+		if _, exists := entries[flow.Name]; exists {
+			return nil, fmt.Errorf("duplicate flow name %q", flow.Name)
+		}
 		instance, err := newInstance(ctx, &flow, ap, i)
 		if err != nil {
 			return nil, err
@@ -29,6 +50,7 @@ func NewRepositoryFacade(ctx context.Context, flows *configuration.Flows, ap alt
 		entries[flow.Name] = instance
 	}
 
+	success = true
 	return &RepositoryFacade{entries}, nil
 }
 
@@ -126,4 +148,15 @@ func RegisterRepository[C any, R CloseableRepository](factory RepositoryFactory[
 	ct := reflect.TypeFor[C]()
 	configurationTypeToRepositoryFactory[ct] = factory
 	return factory
+}
+
+type repositoryDependenciesContextKey struct{}
+
+type repositoryDependencies struct {
+	hostKeys []crypto.PrivateKey
+}
+
+func repositoryDependenciesFrom(ctx context.Context) repositoryDependencies {
+	result, _ := ctx.Value(repositoryDependenciesContextKey{}).(repositoryDependencies)
+	return result
 }

--- a/pkg/environment/facade-repository.go
+++ b/pkg/environment/facade-repository.go
@@ -94,6 +94,36 @@ func (this *RepositoryFacade) FindBySession(ctx context.Context, sess session.Se
 	return candidate.FindBySession(ctx, sess, opts)
 }
 
+func (this *RepositoryFacade) IsSessionCompatible(ctx context.Context, sess session.Session) (bool, error) {
+	if sess == nil {
+		return false, nil
+	}
+	candidate, ok := this.entries[sess.Flow()]
+	if !ok {
+		return false, nil
+	}
+	checker, ok := candidate.(SessionCompatibilityChecker)
+	if !ok {
+		return true, nil
+	}
+	return checker.IsSessionCompatible(ctx, sess)
+}
+
+func (this *RepositoryFacade) IsSessionCompatibleWith(ctx Context, sess session.Session) (bool, error) {
+	if sess == nil {
+		return false, nil
+	}
+	candidate, ok := this.entries[sess.Flow()]
+	if !ok {
+		return false, nil
+	}
+	checker, ok := candidate.(ContextualSessionCompatibilityChecker)
+	if !ok {
+		return true, nil
+	}
+	return checker.IsSessionCompatibleWith(ctx, sess)
+}
+
 func (this *RepositoryFacade) Close() (rErr error) {
 	for _, entity := range this.entries {
 		//goland:noinspection GoDeferInLoop

--- a/pkg/environment/kubernetes-usage-specific.go
+++ b/pkg/environment/kubernetes-usage-specific.go
@@ -95,8 +95,9 @@ func (this *kubernetes) Run(t Task) (exitCode int, rErr error) {
 	if v, ok := os.LookupEnv("TZ"); ok {
 		ev.Set("TZ", v)
 	}
-	ev.AddAllOf(t.Authorization().EnvVars())
-	ev.Add(t.SshSession().Environ()...)
+	if err := applyTaskEnvironment(&ev, this.repository.conf.Os, t); err != nil {
+		return fail(err)
+	}
 	setReservedEnvironment(&ev, this.repository.conf.Os,
 		session.EnvName, sess.Id().String(),
 		connection.EnvName, t.Connection().Id().String(),
@@ -146,12 +147,12 @@ func (this *kubernetes) Run(t Task) (exitCode int, rErr error) {
 		} else {
 			defer common.IgnoreCloseError(ln)
 			go ssh.ForwardAgentConnections(ln, l, sshSess)
-			ev.Set(ssh.AuthSockEnvName, ln.Path())
+			setReservedEnvironment(&ev, this.repository.conf.Os, ssh.AuthSockEnvName, ln.Path())
 		}
 	}
 
 	if ptyReq, winCh, isPty := sshSess.Pty(); isPty {
-		ev.Set("TERM", ptyReq.Term)
+		setReservedEnvironment(&ev, this.repository.conf.Os, "TERM", ptyReq.Term)
 		opts.TTY = true
 		opts.Stderr = false
 		streamOpts.Tty = true

--- a/pkg/environment/local.go
+++ b/pkg/environment/local.go
@@ -80,7 +80,7 @@ func (this *local) Run(t Task) (exitCode int, rErr error) {
 		}
 		defer common.IgnoreCloseError(ln)
 		go ssh.ForwardAgentConnections(ln, l, sshSess)
-		ev.Set(ssh.AuthSockEnvName, ln.Path())
+		setReservedEnvironment(ev, localTargetOs, ssh.AuthSockEnvName, ln.Path())
 	}
 
 	cmd.Stdin = sshSess
@@ -105,7 +105,7 @@ func (this *local) Run(t Task) (exitCode int, rErr error) {
 		}
 		defer common.IgnoreCloseError(fPty)
 		defer common.IgnoreCloseError(fTty)
-		ev.Set("TERM", ptyReq.Term)
+		setReservedEnvironment(ev, localTargetOs, "TERM", ptyReq.Term)
 		initialSize := pty.Winsize{Rows: uint16(ptyReq.Window.Height), Cols: uint16(ptyReq.Window.Width)}
 		if err := pty.Setsize(fPty, &initialSize); err != nil {
 			return failf("cannot set initial pty size: %w", err)

--- a/pkg/environment/local_environment_unix_test.go
+++ b/pkg/environment/local_environment_unix_test.go
@@ -1,0 +1,57 @@
+//go:build unix
+
+package environment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/engity-com/bifroest/pkg/configuration"
+	"github.com/engity-com/bifroest/pkg/connection"
+	"github.com/engity-com/bifroest/pkg/session"
+	"github.com/engity-com/bifroest/pkg/sys"
+	"github.com/engity-com/bifroest/pkg/user"
+)
+
+func TestLocalEnvironmentProtectsUserIdentityVariables(t *testing.T) {
+	ctx, cancel := newSshTestContext()
+	defer cancel()
+	storedSession := &sshTestStoredSession{id: session.MustNewId()}
+	auth := &sshTestAuthorization{
+		session: storedSession,
+		environment: sys.EnvVars{
+			"HOME":    "/forged/authorization",
+			"USER":    "forged-authorization",
+			"LOGNAME": "forged-authorization",
+			"SHELL":   "/forged/authorization-shell",
+		},
+	}
+	sshSession := newSshTestSession(ctx, "true", nil)
+	sshSession.environment = []string{
+		"HOME=/forged/client",
+		"USER=forged-client",
+		"LOGNAME=forged-client",
+		"SHELL=/forged/client-shell",
+	}
+	task := &sshTestTask{
+		context:       ctx,
+		connection:    &sshTestConnection{id: connection.MustNewId(), context: ctx},
+		authorization: auth,
+		session:       sshSession,
+		taskType:      TaskTypeShell,
+		environmentVariables: configuration.EnvironmentVariables{
+			"HOME":    {},
+			"USER":    {},
+			"LOGNAME": {},
+			"SHELL":   {},
+		},
+	}
+	local := &local{user: &user.User{Name: "trusted-user", HomeDir: "/trusted/home", Shell: "/trusted/shell"}}
+	_, environment, err := local.createCmdAndEnv(task)
+	require.NoError(t, err)
+	require.Equal(t, "/trusted/home", (*environment)["HOME"])
+	require.Equal(t, "trusted-user", (*environment)["USER"])
+	require.Equal(t, "trusted-user", (*environment)["LOGNAME"])
+	require.Equal(t, "/trusted/shell", (*environment)["SHELL"])
+}

--- a/pkg/environment/local_unix.go
+++ b/pkg/environment/local_unix.go
@@ -78,8 +78,9 @@ func (this *local) createCmdAndEnv(t Task) (*exec.Cmd, *sys.EnvVars, error) {
 	if v, ok := os.LookupEnv("TZ"); ok {
 		ev.Set("TZ", v)
 	}
-	ev.AddAllOf(t.Authorization().EnvVars())
-	ev.Add(t.SshSession().Environ()...)
+	if err := applyTaskEnvironment(&ev, localTargetOs, t); err != nil {
+		return nil, nil, err
+	}
 	ev.Set(
 		"HOME", this.user.HomeDir,
 		"USER", this.user.Name,

--- a/pkg/environment/local_windows.go
+++ b/pkg/environment/local_windows.go
@@ -63,8 +63,9 @@ func (this *local) createCmdAndEnv(t Task) (*exec.Cmd, *sys.EnvVars, error) {
 	if v, ok := os.LookupEnv("TZ"); ok {
 		ev.Set("TZ", v)
 	}
-	ev.AddAllOf(t.Authorization().EnvVars())
-	ev.Add(t.SshSession().Environ()...)
+	if err := applyTaskEnvironment(&ev, localTargetOs, t); err != nil {
+		return nil, nil, err
+	}
 
 	return &cmd, &ev, nil
 }

--- a/pkg/environment/repository.go
+++ b/pkg/environment/repository.go
@@ -48,6 +48,16 @@ type CloseableRepository interface {
 	io.Closer
 }
 
+// SessionCompatibilityChecker can prevent an existing session from being
+// selected when persisted environment credentials no longer match its flow.
+type SessionCompatibilityChecker interface {
+	IsSessionCompatible(context.Context, session.Session) (bool, error)
+}
+
+type ContextualSessionCompatibilityChecker interface {
+	IsSessionCompatibleWith(Context, session.Session) (bool, error)
+}
+
 // FindOpts adds some more hints what should happen when find methods of
 // Repository are executed.
 type FindOpts struct {

--- a/pkg/environment/ssh-certificate-keys.go
+++ b/pkg/environment/ssh-certificate-keys.go
@@ -1,0 +1,64 @@
+package environment
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/engity-com/bifroest/pkg/configuration"
+	"github.com/engity-com/bifroest/pkg/crypto"
+	"github.com/engity-com/bifroest/pkg/template"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+var sshCertificateKeyRequirement = crypto.KeyRequirement{Type: crypto.KeyTypeEd25519}
+
+func EnsureSshCertificateAuthority(flow *configuration.Flow) (crypto.PrivateKey, string, error) {
+	if flow == nil {
+		return nil, "", fmt.Errorf("nil flow")
+	}
+	conf, ok := flow.Environment.V.(*configuration.EnvironmentSsh)
+	if !ok {
+		return nil, "", fmt.Errorf("flow %q does not use an SSH environment", flow.Name)
+	}
+	if conf.Certificate == nil {
+		return nil, "", fmt.Errorf("flow %q does not configure an SSH certificate", flow.Name)
+	}
+	key, path, err := ensureSshCertificateKey(conf.Certificate.AuthorityIdentityFile, "certificate authority")
+	if err != nil {
+		return nil, "", fmt.Errorf("cannot ensure SSH certificate authority for flow %q: %w", flow.Name, err)
+	}
+	return key, path, nil
+}
+
+func ValidateSshCertificateAuthority(authority crypto.PrivateKey, hostKeys []crypto.PrivateKey) error {
+	if authority == nil {
+		return fmt.Errorf("nil SSH certificate authority")
+	}
+	authorityFingerprint := gossh.FingerprintSHA256(authority.ToSsh().PublicKey())
+	for _, hostKey := range hostKeys {
+		if hostKey != nil && gossh.FingerprintSHA256(hostKey.ToSsh().PublicKey()) == authorityFingerprint {
+			return fmt.Errorf("SSH certificate authority must not reuse an SSH server host key")
+		}
+	}
+	return nil
+}
+
+func ensureSshCertificateIdentity(conf *configuration.EnvironmentSshCertificate) (crypto.PrivateKey, string, error) {
+	return ensureSshCertificateKey(conf.IdentityFile, "certificate identity")
+}
+
+func ensureSshCertificateAuthority(conf *configuration.EnvironmentSshCertificate) (crypto.PrivateKey, string, error) {
+	return ensureSshCertificateKey(conf.AuthorityIdentityFile, "certificate authority")
+}
+
+func ensureSshCertificateKey(configured template.String, kind string) (crypto.PrivateKey, string, error) {
+	path := strings.TrimSpace(configured.String())
+	if path == "" || !configured.IsHardCoded() {
+		return nil, "", fmt.Errorf("SSH %s identity file has to be a static non-empty path", kind)
+	}
+	key, err := crypto.EnsureKeyFile(path, &sshCertificateKeyRequirement, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("cannot ensure SSH %s identity file %q: %w", kind, path, err)
+	}
+	return key, path, nil
+}

--- a/pkg/environment/ssh-certificate-keys_test.go
+++ b/pkg/environment/ssh-certificate-keys_test.go
@@ -1,0 +1,55 @@
+package environment
+
+import (
+	goos "os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/engity-com/bifroest/pkg/configuration"
+	"github.com/engity-com/bifroest/pkg/template"
+)
+
+func TestEnsureSshCertificateAuthorityCreatesAndReusesKeyWithoutPublicFile(t *testing.T) {
+	directory := t.TempDir()
+	authorityFile := filepath.Join(directory, "ca")
+	flow := newSshCertificateKeyTestFlow(t, authorityFile)
+
+	first, firstPath, err := EnsureSshCertificateAuthority(flow)
+	require.NoError(t, err)
+	second, secondPath, err := EnsureSshCertificateAuthority(flow)
+	require.NoError(t, err)
+	require.Equal(t, authorityFile, firstPath)
+	require.Equal(t, firstPath, secondPath)
+	require.Equal(t, gossh.FingerprintSHA256(first.ToSsh().PublicKey()), gossh.FingerprintSHA256(second.ToSsh().PublicKey()))
+	require.FileExists(t, authorityFile)
+	require.NoFileExists(t, authorityFile+".pub")
+}
+
+func TestEnsureSshCertificateAuthorityDoesNotReplaceInvalidKey(t *testing.T) {
+	authorityFile := filepath.Join(t.TempDir(), "ca")
+	require.NoError(t, goos.WriteFile(authorityFile, []byte("invalid"), 0400))
+	flow := newSshCertificateKeyTestFlow(t, authorityFile)
+
+	_, _, err := EnsureSshCertificateAuthority(flow)
+	require.Error(t, err)
+	actual, readErr := goos.ReadFile(authorityFile)
+	require.NoError(t, readErr)
+	require.Equal(t, []byte("invalid"), actual)
+}
+
+func newSshCertificateKeyTestFlow(t *testing.T, authorityFile string) *configuration.Flow {
+	t.Helper()
+	certificate := &configuration.EnvironmentSshCertificate{}
+	require.NoError(t, certificate.SetDefaults())
+	certificate.IdentityFile = template.MustNewString(filepath.Join(filepath.Dir(authorityFile), "client-key"))
+	certificate.AuthorityIdentityFile = template.MustNewString(authorityFile)
+	return &configuration.Flow{
+		Name: "entry",
+		Environment: configuration.Environment{V: &configuration.EnvironmentSsh{
+			Certificate: certificate,
+		}},
+	}
+}

--- a/pkg/environment/ssh-certificate.go
+++ b/pkg/environment/ssh-certificate.go
@@ -1,0 +1,512 @@
+package environment
+
+import (
+	"context"
+	crand "crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/engity-com/bifroest/pkg/authorization"
+	"github.com/engity-com/bifroest/pkg/configuration"
+	bnet "github.com/engity-com/bifroest/pkg/net"
+	"github.com/engity-com/bifroest/pkg/session"
+)
+
+const sshUserCertificateSchema = "bifroest.ssh-user-certificate/v1"
+
+const maxSshUserCertificateEvidenceSize = 4 * 1024
+
+var sshUserCertificateMetadataExtensions = map[string]struct{}{
+	"session-id@bifroest.engity.org":         {},
+	"original-user@bifroest.engity.org":      {},
+	"original-host@bifroest.engity.org":      {},
+	"authorization-kind@bifroest.engity.org": {},
+	"evidence-v1@bifroest.engity.org":        {},
+}
+
+type sshCertificateKeys struct {
+	subject              gossh.Signer
+	subjectIdentityFile  string
+	subjectFingerprint   string
+	authority            gossh.Signer
+	authorityFingerprint string
+	configurationKey     string
+}
+
+type sshCertificateSpec struct {
+	validity          time.Duration
+	validAfterSkew    time.Duration
+	principals        []string
+	extensions        map[string]string
+	authorizationKind string
+}
+
+type sshUserCertificateState struct {
+	Schema                string            `json:"schema"`
+	State                 string            `json:"state"`
+	SessionId             string            `json:"sessionId"`
+	Flow                  string            `json:"flow"`
+	TargetAddress         string            `json:"targetAddress"`
+	TargetUser            string            `json:"targetUser"`
+	SubjectKeyFingerprint string            `json:"subjectKeyFingerprint"`
+	CaFingerprint         string            `json:"caFingerprint"`
+	Serial                uint64            `json:"serial"`
+	KeyId                 string            `json:"keyId"`
+	IssuedAt              time.Time         `json:"issuedAt"`
+	ValidAfter            time.Time         `json:"validAfter"`
+	MaxValidUntil         time.Time         `json:"maxValidUntil"`
+	ValidBefore           time.Time         `json:"validBefore"`
+	Principals            []string          `json:"principals"`
+	Extensions            map[string]string `json:"extensions,omitempty"`
+	Certificate           string            `json:"certificate"`
+	ConfigurationKey      string            `json:"configurationKey"`
+	AuthorizationKind     string            `json:"authorizationKind,omitempty"`
+}
+
+type sshUserCertificateEvidence struct {
+	Schema            string    `json:"schema"`
+	SessionId         string    `json:"sessionId"`
+	Flow              string    `json:"flow"`
+	CreatedAt         time.Time `json:"createdAt,omitempty"`
+	OriginalUser      string    `json:"originalUser,omitempty"`
+	OriginalHost      string    `json:"originalHost,omitempty"`
+	AuthorizationKind string    `json:"authorizationKind,omitempty"`
+	TargetUser        string    `json:"targetUser"`
+	Principals        []string  `json:"principals"`
+	PtyAllowed        bool      `json:"ptyAllowed"`
+	PortForwarding    bool      `json:"portForwardingAllowed"`
+	AgentForwarding   bool      `json:"agentForwardingAllowed"`
+}
+
+func resolveSshCertificateSpec(conf *configuration.EnvironmentSshCertificate, req Context, settings *sshResolvedSettings) (*sshCertificateSpec, error) {
+	validity, err := conf.Validity.Render(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot render SSH certificate validity: %w", err)
+	}
+	if validity <= 0 {
+		return nil, fmt.Errorf("rendered SSH certificate validity has to be positive")
+	}
+	validAfterSkew, err := conf.ValidAfterSkew.Render(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot render SSH certificate valid-after skew: %w", err)
+	}
+	if validAfterSkew < 0 {
+		return nil, fmt.Errorf("rendered SSH certificate valid-after skew cannot be negative")
+	}
+	principals, err := conf.Principals.Render(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot render SSH certificate principals: %w", err)
+	}
+	principals = append([]string(nil), principals...)
+	for i, principal := range principals {
+		principal = strings.TrimSpace(principal)
+		if principal == "" {
+			return nil, fmt.Errorf("rendered SSH certificate principal [%d] is empty", i)
+		}
+		if strings.IndexByte(principal, 0) >= 0 {
+			return nil, fmt.Errorf("rendered SSH certificate principal [%d] contains NUL", i)
+		}
+		principals[i] = principal
+	}
+	if !slices.Contains(principals, settings.user) {
+		principals = append(principals, settings.user)
+	}
+	slices.Sort(principals)
+	principals = slices.Compact(principals)
+
+	extensions, err := conf.Extensions.Render(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot render SSH certificate extensions: %w", err)
+	}
+	policy := authorization.AuthorizedKeyPolicyOf(req.Authorization())
+	if policy != nil && !policy.PtyAllowed {
+		delete(extensions, "permit-pty")
+	}
+	if !settings.forwardAllowed || policy != nil && !policy.PortForwardingAllowed {
+		delete(extensions, "permit-port-forwarding")
+	}
+	if !authorization.IsAgentForwardingAllowed(req.Authorization()) {
+		delete(extensions, "permit-agent-forwarding")
+	}
+
+	return &sshCertificateSpec{
+		validity:          validity,
+		validAfterSkew:    validAfterSkew,
+		principals:        principals,
+		extensions:        extensions,
+		authorizationKind: authorization.KindOf(req.Authorization()),
+	}, nil
+}
+
+func (this *SshRepository) ensureUserCertificate(ctx context.Context, req Request, sess session.Session, settings *sshResolvedSettings) (gossh.Signer, string, error) {
+	unlock := this.sessionLocks.Lock(sess.Id())
+	defer unlock()
+	info, err := sess.Info(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("cannot load session state before SSH certificate issuance: %w", err)
+	}
+	if info != nil && info.State() == session.StateDisposed {
+		return nil, "", fmt.Errorf("cannot issue or load an SSH certificate for disposed session %s", sess.Id())
+	}
+
+	raw, err := sess.EnvironmentToken(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("cannot load SSH certificate state: %w", err)
+	}
+	var state *sshUserCertificateState
+	if len(raw) == 0 {
+		state, err = this.issueUserCertificate(ctx, req, sess, settings)
+		if err != nil {
+			return nil, "", err
+		}
+		raw, err = json.Marshal(state)
+		if err != nil {
+			return nil, "", fmt.Errorf("cannot encode SSH certificate state: %w", err)
+		}
+		if err := sess.SetEnvironmentToken(ctx, raw); err != nil {
+			return nil, "", fmt.Errorf("cannot persist SSH certificate state: %w", err)
+		}
+	} else {
+		state, err = decodeSshUserCertificateState(raw)
+		if err != nil {
+			return nil, "", err
+		}
+	}
+
+	cert, err := this.validateUserCertificateState(state, sess, settings, time.Now())
+	if err != nil {
+		return nil, "", err
+	}
+	signer, err := gossh.NewCertSigner(cert, this.certificateKeys.subject)
+	if err != nil {
+		return nil, "", fmt.Errorf("cannot combine SSH user certificate with subject key: %w", err)
+	}
+	return signer, state.Certificate, nil
+}
+
+func (this *SshRepository) issueUserCertificate(ctx context.Context, req Request, sess session.Session, settings *sshResolvedSettings) (*sshUserCertificateState, error) {
+	spec := settings.certificate
+	if spec == nil {
+		return nil, fmt.Errorf("SSH certificate settings are absent")
+	}
+	issuedAt := time.Now().UTC().Truncate(time.Second)
+	maxValidUntil := issuedAt.Add(spec.validity)
+	if !maxValidUntil.After(issuedAt) {
+		return nil, fmt.Errorf("rendered SSH certificate validity exceeds the supported time range")
+	}
+	validAfter := issuedAt.Add(-spec.validAfterSkew)
+	if validAfter.Unix() < 0 || maxValidUntil.Unix() < 0 {
+		return nil, fmt.Errorf("SSH certificate validity is outside of the supported Unix time range")
+	}
+
+	serial, err := randomSshCertificateSerial()
+	if err != nil {
+		return nil, fmt.Errorf("cannot generate SSH certificate serial: %w", err)
+	}
+	keyId := "bifroest:" + this.flow.String() + ":" + sess.Id().String()
+	extensions := make(map[string]string, len(spec.extensions)+len(sshUserCertificateMetadataExtensions))
+	for key, value := range spec.extensions {
+		extensions[key] = value
+	}
+	extensions["session-id@bifroest.engity.org"] = sess.Id().String()
+	authorizationKind := authorization.KindOf(req.Authorization())
+	if authorizationKind != "" {
+		extensions["authorization-kind@bifroest.engity.org"] = authorizationKind
+	}
+	evidence := sshUserCertificateEvidence{
+		Schema:            "bifroest.authorization-evidence/v1",
+		SessionId:         sess.Id().String(),
+		Flow:              sess.Flow().String(),
+		AuthorizationKind: authorizationKind,
+		TargetUser:        settings.user,
+		Principals:        append([]string(nil), spec.principals...),
+	}
+	_, evidence.PtyAllowed = extensions["permit-pty"]
+	_, evidence.PortForwarding = extensions["permit-port-forwarding"]
+	_, evidence.AgentForwarding = extensions["permit-agent-forwarding"]
+	info, err := sess.Info(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load session information for SSH certificate: %w", err)
+	}
+	if info != nil {
+		created, err := info.Created(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("cannot load session creation information for SSH certificate: %w", err)
+		}
+		if created != nil && created.Remote() != nil {
+			evidence.CreatedAt = created.At()
+			evidence.OriginalUser = created.Remote().User()
+			evidence.OriginalHost = created.Remote().Host().String()
+			extensions["original-user@bifroest.engity.org"] = created.Remote().User()
+			extensions["original-host@bifroest.engity.org"] = created.Remote().Host().String()
+		}
+	}
+	evidenceRaw, err := json.Marshal(evidence)
+	if err != nil {
+		return nil, fmt.Errorf("cannot encode SSH certificate evidence: %w", err)
+	}
+	if len(evidenceRaw) > maxSshUserCertificateEvidenceSize {
+		return nil, fmt.Errorf("SSH certificate evidence exceeds %d bytes", maxSshUserCertificateEvidenceSize)
+	}
+	extensions["evidence-v1@bifroest.engity.org"] = string(evidenceRaw)
+
+	cert := &gossh.Certificate{
+		Nonce:           nil,
+		Key:             this.certificateKeys.subject.PublicKey(),
+		Serial:          serial,
+		CertType:        gossh.UserCert,
+		KeyId:           keyId,
+		ValidPrincipals: append([]string(nil), spec.principals...),
+		ValidAfter:      uint64(validAfter.Unix()),
+		ValidBefore:     uint64(maxValidUntil.Unix()),
+		Permissions: gossh.Permissions{
+			Extensions: extensions,
+		},
+	}
+	if err := cert.SignCert(crand.Reader, this.certificateKeys.authority); err != nil {
+		return nil, fmt.Errorf("cannot sign SSH user certificate: %w", err)
+	}
+
+	return &sshUserCertificateState{
+		Schema:                sshUserCertificateSchema,
+		State:                 "ready",
+		SessionId:             sess.Id().String(),
+		Flow:                  sess.Flow().String(),
+		TargetAddress:         settings.address.String(),
+		TargetUser:            settings.user,
+		SubjectKeyFingerprint: this.certificateKeys.subjectFingerprint,
+		CaFingerprint:         this.certificateKeys.authorityFingerprint,
+		Serial:                serial,
+		KeyId:                 keyId,
+		IssuedAt:              issuedAt,
+		ValidAfter:            validAfter,
+		MaxValidUntil:         maxValidUntil,
+		ValidBefore:           maxValidUntil,
+		Principals:            append([]string(nil), spec.principals...),
+		Extensions:            extensions,
+		Certificate:           strings.TrimSpace(string(gossh.MarshalAuthorizedKey(cert))),
+		ConfigurationKey:      this.certificateKeys.configurationKey,
+		AuthorizationKind:     authorizationKind,
+	}, nil
+}
+
+func decodeSshUserCertificateState(raw []byte) (*sshUserCertificateState, error) {
+	var state sshUserCertificateState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return nil, fmt.Errorf("cannot decode SSH certificate state: %w", err)
+	}
+	if state.Schema != sshUserCertificateSchema || state.State != "ready" {
+		return nil, fmt.Errorf("unsupported or incomplete SSH certificate state")
+	}
+	return &state, nil
+}
+
+func (this *SshRepository) validateUserCertificateState(state *sshUserCertificateState, sess session.Session, settings *sshResolvedSettings, now time.Time) (*gossh.Certificate, error) {
+	fail := func(reason string) (*gossh.Certificate, error) {
+		return nil, fmt.Errorf("stored SSH certificate is incompatible with session %s: %s", sess.Id(), reason)
+	}
+	if state.SessionId != sess.Id().String() || state.Flow != sess.Flow().String() {
+		return fail("session identity changed")
+	}
+	if state.ConfigurationKey != this.certificateKeys.configurationKey {
+		return fail("certificate configuration changed")
+	}
+	if settings.certificate == nil || state.AuthorizationKind != settings.certificate.authorizationKind {
+		return fail("authorization kind changed")
+	}
+	if err := this.validateSubjectIdentityFile(); err != nil {
+		return fail(err.Error())
+	}
+	if state.TargetAddress != settings.address.String() || state.TargetUser != settings.user {
+		return fail("target changed")
+	}
+	if state.SubjectKeyFingerprint != this.certificateKeys.subjectFingerprint {
+		return fail("subject key changed")
+	}
+	if !now.Before(state.MaxValidUntil) || !state.ValidBefore.Equal(state.MaxValidUntil) {
+		return fail("certificate expired or has an invalid validity boundary")
+	}
+	if settings.certificate == nil || !slices.Equal(state.Principals, settings.certificate.principals) {
+		return fail("principals changed")
+	}
+	if !sshCertificateExtensionsEqual(state.Extensions, settings.certificate.extensions) {
+		return fail("required extensions changed")
+	}
+
+	public, _, _, rest, err := gossh.ParseAuthorizedKey([]byte(state.Certificate))
+	if err != nil || len(strings.TrimSpace(string(rest))) > 0 {
+		return fail("certificate cannot be parsed")
+	}
+	cert, ok := public.(*gossh.Certificate)
+	if !ok || cert.CertType != gossh.UserCert {
+		return fail("credential is not an SSH user certificate")
+	}
+	if cert.Serial != state.Serial || cert.KeyId != state.KeyId ||
+		gossh.FingerprintSHA256(cert.Key) != state.SubjectKeyFingerprint ||
+		gossh.FingerprintSHA256(cert.SignatureKey) != state.CaFingerprint ||
+		cert.ValidAfter != uint64(state.ValidAfter.Unix()) || cert.ValidBefore != uint64(state.ValidBefore.Unix()) ||
+		!slices.Equal(cert.ValidPrincipals, state.Principals) {
+		return fail("certificate does not match its persisted metadata")
+	}
+	if len(cert.CriticalOptions) > 0 || !maps.Equal(cert.Extensions, state.Extensions) {
+		return fail("certificate permissions do not match their persisted metadata")
+	}
+	checker := gossh.CertChecker{
+		IsUserAuthority: func(authority gossh.PublicKey) bool {
+			return gossh.FingerprintSHA256(authority) == state.CaFingerprint
+		},
+		Clock: func() time.Time { return now },
+	}
+	if err := checker.CheckCert(settings.user, cert); err != nil {
+		return fail(err.Error())
+	}
+	return cert, nil
+}
+
+func (this *SshRepository) validateSubjectIdentityFile() error {
+	raw, err := os.ReadFile(this.certificateKeys.subjectIdentityFile)
+	if err != nil {
+		return fmt.Errorf("subject identity file is unavailable: %w", err)
+	}
+	signer, err := gossh.ParsePrivateKey(raw)
+	if err != nil {
+		return fmt.Errorf("subject identity file is invalid: %w", err)
+	}
+	if gossh.FingerprintSHA256(signer.PublicKey()) != this.certificateKeys.subjectFingerprint {
+		return fmt.Errorf("subject identity key changed")
+	}
+	return nil
+}
+
+func randomSshCertificateSerial() (uint64, error) {
+	for {
+		var raw [8]byte
+		if _, err := crand.Read(raw[:]); err != nil {
+			return 0, err
+		}
+		if result := binary.BigEndian.Uint64(raw[:]); result != 0 {
+			return result, nil
+		}
+	}
+}
+
+func (this *SshRepository) IsSessionCompatible(ctx context.Context, sess session.Session) (bool, error) {
+	raw, err := sess.EnvironmentToken(ctx)
+	if err != nil {
+		return false, fmt.Errorf("cannot load SSH certificate state: %w", err)
+	}
+	if this.conf.Certificate == nil {
+		return len(raw) == 0, nil
+	}
+	if len(raw) == 0 {
+		return false, nil
+	}
+	state, err := decodeSshUserCertificateState(raw)
+	if err != nil {
+		this.logger().With("session", sess).WithError(err).Warn("stored SSH certificate state is incompatible")
+		return false, nil
+	}
+	var address bnet.HostPort
+	if err := address.Set(state.TargetAddress); err != nil {
+		return false, nil
+	}
+	settings := &sshResolvedSettings{
+		address: address,
+		user:    state.TargetUser,
+		certificate: &sshCertificateSpec{
+			principals:        append([]string(nil), state.Principals...),
+			extensions:        sshCertificateUserExtensions(state.Extensions),
+			authorizationKind: state.AuthorizationKind,
+		},
+	}
+	_, err = this.validateUserCertificateState(state, sess, settings, time.Now())
+	if err != nil {
+		this.logger().With("session", sess).WithError(err).Debug("stored SSH certificate is not reusable")
+		return false, nil
+	}
+	return true, nil
+}
+
+func (this *SshRepository) IsSessionCompatibleWith(ctx Context, sess session.Session) (bool, error) {
+	if this.conf.Certificate == nil {
+		return this.IsSessionCompatible(ctx.Context(), sess)
+	}
+	raw, err := sess.EnvironmentToken(ctx.Context())
+	if err != nil {
+		return false, fmt.Errorf("cannot load SSH certificate state: %w", err)
+	}
+	if len(raw) == 0 {
+		return false, nil
+	}
+	state, err := decodeSshUserCertificateState(raw)
+	if err != nil {
+		return false, nil
+	}
+	settings, err := this.resolveSettings(ctx)
+	if err != nil {
+		return false, err
+	}
+	if _, err := this.validateUserCertificateState(state, sess, settings, time.Now()); err != nil {
+		this.logger().With("session", sess).WithError(err).Debug("stored SSH certificate is not compatible with the current authorization")
+		return false, nil
+	}
+	return true, nil
+}
+
+func (this *SshRepository) disposeUserCertificate(ctx context.Context, sess session.Session) (bool, error) {
+	unlock := this.sessionLocks.Lock(sess.Id())
+	defer unlock()
+	raw, err := sess.EnvironmentToken(ctx)
+	if err != nil {
+		return false, fmt.Errorf("cannot load SSH certificate state before disposal: %w", err)
+	}
+	if len(raw) == 0 {
+		return false, nil
+	}
+	if err := sess.SetEnvironmentToken(ctx, nil); err != nil {
+		return false, fmt.Errorf("cannot remove SSH certificate state: %w", err)
+	}
+	return true, nil
+}
+
+func sshCertificateUserExtensions(extensions map[string]string) map[string]string {
+	result := make(map[string]string, len(extensions))
+	for key, value := range extensions {
+		if _, reserved := sshUserCertificateMetadataExtensions[key]; !reserved {
+			result[key] = value
+		}
+	}
+	return result
+}
+
+func sshCertificateExtensionsEqual(stored, required map[string]string) bool {
+	return maps.Equal(sshCertificateUserExtensions(stored), required)
+}
+
+func sshCertificateConfigurationKey(conf *configuration.EnvironmentSsh) string {
+	values := []string{"address=" + conf.Address.String(), "user=" + conf.User.String()}
+	for i, principal := range conf.Certificate.Principals {
+		values = append(values, fmt.Sprintf("principal[%d]=%s", i, principal.String()))
+	}
+	keys := make([]string, 0, len(conf.Certificate.Extensions))
+	for key := range conf.Certificate.Extensions {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		values = append(values, "extension="+key+"="+conf.Certificate.Extensions[key].String())
+	}
+	digest := sha256.Sum256([]byte(strings.Join(values, "\x00")))
+	return "SHA256:" + hex.EncodeToString(digest[:])
+}

--- a/pkg/environment/ssh-certificate.go
+++ b/pkg/environment/ssh-certificate.go
@@ -21,18 +21,13 @@ import (
 	"github.com/engity-com/bifroest/pkg/configuration"
 	bnet "github.com/engity-com/bifroest/pkg/net"
 	"github.com/engity-com/bifroest/pkg/session"
+	bfssh "github.com/engity-com/bifroest/pkg/ssh"
 )
 
 const sshUserCertificateSchema = "bifroest.ssh-user-certificate/v1"
 
-const maxSshUserCertificateEvidenceSize = 4 * 1024
-
 var sshUserCertificateMetadataExtensions = map[string]struct{}{
-	"session-id@bifroest.engity.org":         {},
-	"original-user@bifroest.engity.org":      {},
-	"original-host@bifroest.engity.org":      {},
-	"authorization-kind@bifroest.engity.org": {},
-	"evidence-v1@bifroest.engity.org":        {},
+	authorization.AuthorizationEvidenceExtension: {},
 }
 
 type sshCertificateKeys struct {
@@ -50,6 +45,10 @@ type sshCertificateSpec struct {
 	principals        []string
 	extensions        map[string]string
 	authorizationKind string
+	audience          string
+	parentEvidence    *authorization.AuthorizationEvidence
+	parentDigest      string
+	maxValidBefore    time.Time
 }
 
 type sshUserCertificateState struct {
@@ -69,24 +68,13 @@ type sshUserCertificateState struct {
 	ValidBefore           time.Time         `json:"validBefore"`
 	Principals            []string          `json:"principals"`
 	Extensions            map[string]string `json:"extensions,omitempty"`
+	CriticalOptions       map[string]string `json:"criticalOptions,omitempty"`
 	Certificate           string            `json:"certificate"`
 	ConfigurationKey      string            `json:"configurationKey"`
 	AuthorizationKind     string            `json:"authorizationKind,omitempty"`
-}
-
-type sshUserCertificateEvidence struct {
-	Schema            string    `json:"schema"`
-	SessionId         string    `json:"sessionId"`
-	Flow              string    `json:"flow"`
-	CreatedAt         time.Time `json:"createdAt,omitempty"`
-	OriginalUser      string    `json:"originalUser,omitempty"`
-	OriginalHost      string    `json:"originalHost,omitempty"`
-	AuthorizationKind string    `json:"authorizationKind,omitempty"`
-	TargetUser        string    `json:"targetUser"`
-	Principals        []string  `json:"principals"`
-	PtyAllowed        bool      `json:"ptyAllowed"`
-	PortForwarding    bool      `json:"portForwardingAllowed"`
-	AgentForwarding   bool      `json:"agentForwardingAllowed"`
+	Audience              string            `json:"audience,omitempty"`
+	EvidenceDigest        string            `json:"evidenceDigest"`
+	ParentEvidenceDigest  string            `json:"parentEvidenceDigest,omitempty"`
 }
 
 func resolveSshCertificateSpec(conf *configuration.EnvironmentSshCertificate, req Context, settings *sshResolvedSettings) (*sshCertificateSpec, error) {
@@ -103,6 +91,17 @@ func resolveSshCertificateSpec(conf *configuration.EnvironmentSshCertificate, re
 	}
 	if validAfterSkew < 0 {
 		return nil, fmt.Errorf("rendered SSH certificate valid-after skew cannot be negative")
+	}
+	audience, err := conf.Audience.Render(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot render SSH certificate audience: %w", err)
+	}
+	audience = strings.TrimSpace(audience)
+	if !conf.Audience.IsZero() && audience == "" {
+		return nil, fmt.Errorf("rendered SSH certificate audience is empty")
+	}
+	if strings.IndexByte(audience, 0) >= 0 {
+		return nil, fmt.Errorf("rendered SSH certificate audience contains NUL")
 	}
 	principals, err := conf.Principals.Render(req)
 	if err != nil {
@@ -129,15 +128,33 @@ func resolveSshCertificateSpec(conf *configuration.EnvironmentSshCertificate, re
 	if err != nil {
 		return nil, fmt.Errorf("cannot render SSH certificate extensions: %w", err)
 	}
+	for _, name := range []string{"permit-pty", "permit-port-forwarding", "permit-agent-forwarding"} {
+		if value, exists := extensions[name]; exists && value != "" {
+			return nil, fmt.Errorf("rendered SSH certificate extension %q must have an empty value", name)
+		}
+	}
 	policy := authorization.AuthorizedKeyPolicyOf(req.Authorization())
 	if policy != nil && !policy.PtyAllowed {
 		delete(extensions, "permit-pty")
 	}
-	if !settings.forwardAllowed || policy != nil && !policy.PortForwardingAllowed {
+	if !settings.forwardAllowed || policy != nil && (!policy.PortForwardingAllowed || policy.HasPortForwardingDestinationRestrictions()) {
 		delete(extensions, "permit-port-forwarding")
 	}
 	if !authorization.IsAgentForwardingAllowed(req.Authorization()) {
 		delete(extensions, "permit-agent-forwarding")
+	}
+	parentEvidence := authorization.AuthorizationEvidenceOf(req.Authorization())
+	parentDigest := ""
+	var maxValidBefore time.Time
+	if parentEvidence != nil {
+		parentRaw, err := authorization.EncodeAuthorizationEvidence(parentEvidence)
+		if err != nil {
+			return nil, fmt.Errorf("cannot encode inherited authorization evidence: %w", err)
+		}
+		parentDigest = sshCertificateEvidenceDigest(parentRaw)
+		if last := parentEvidence.LastHop(); last != nil {
+			maxValidBefore = last.ValidBefore
+		}
 	}
 
 	return &sshCertificateSpec{
@@ -146,6 +163,10 @@ func resolveSshCertificateSpec(conf *configuration.EnvironmentSshCertificate, re
 		principals:        principals,
 		extensions:        extensions,
 		authorizationKind: authorization.KindOf(req.Authorization()),
+		audience:          audience,
+		parentEvidence:    parentEvidence,
+		parentDigest:      parentDigest,
+		maxValidBefore:    maxValidBefore,
 	}, nil
 }
 
@@ -206,7 +227,19 @@ func (this *SshRepository) issueUserCertificate(ctx context.Context, req Request
 		return nil, fmt.Errorf("rendered SSH certificate validity exceeds the supported time range")
 	}
 	validAfter := issuedAt.Add(-spec.validAfterSkew)
-	if validAfter.Unix() < 0 || maxValidUntil.Unix() < 0 {
+	validBefore := maxValidUntil
+	if parent := spec.parentEvidence.LastHop(); parent != nil {
+		if parent.ValidAfter.After(validAfter) {
+			validAfter = parent.ValidAfter.UTC().Truncate(time.Second)
+		}
+		if parent.ValidBefore.Before(validBefore) {
+			validBefore = parent.ValidBefore.UTC().Truncate(time.Second)
+		}
+	}
+	if !validBefore.After(issuedAt) {
+		return nil, fmt.Errorf("inherited authorization evidence expires before a new SSH certificate can be issued")
+	}
+	if validAfter.Unix() < 0 || validBefore.Unix() < 0 {
 		return nil, fmt.Errorf("SSH certificate validity is outside of the supported Unix time range")
 	}
 
@@ -215,51 +248,75 @@ func (this *SshRepository) issueUserCertificate(ctx context.Context, req Request
 		return nil, fmt.Errorf("cannot generate SSH certificate serial: %w", err)
 	}
 	keyId := "bifroest:" + this.flow.String() + ":" + sess.Id().String()
-	extensions := make(map[string]string, len(spec.extensions)+len(sshUserCertificateMetadataExtensions))
+	extensions := make(map[string]string, len(spec.extensions)+1)
 	for key, value := range spec.extensions {
 		extensions[key] = value
 	}
-	extensions["session-id@bifroest.engity.org"] = sess.Id().String()
 	authorizationKind := authorization.KindOf(req.Authorization())
-	if authorizationKind != "" {
-		extensions["authorization-kind@bifroest.engity.org"] = authorizationKind
+	if authorizationKind == "" {
+		return nil, fmt.Errorf("cannot issue SSH certificate without an authorization kind")
 	}
-	evidence := sshUserCertificateEvidence{
-		Schema:            "bifroest.authorization-evidence/v1",
-		SessionId:         sess.Id().String(),
-		Flow:              sess.Flow().String(),
-		AuthorizationKind: authorizationKind,
-		TargetUser:        settings.user,
-		Principals:        append([]string(nil), spec.principals...),
-	}
-	_, evidence.PtyAllowed = extensions["permit-pty"]
-	_, evidence.PortForwarding = extensions["permit-port-forwarding"]
-	_, evidence.AgentForwarding = extensions["permit-agent-forwarding"]
 	info, err := sess.Info(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("cannot load session information for SSH certificate: %w", err)
 	}
-	if info != nil {
-		created, err := info.Created(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("cannot load session creation information for SSH certificate: %w", err)
+	var evidence *authorization.AuthorizationEvidence
+	if spec.parentEvidence != nil {
+		evidence = spec.parentEvidence.Clone()
+	} else {
+		origin := req.Authorization().Remote()
+		if info != nil {
+			created, err := info.Created(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("cannot load session creation information for SSH certificate: %w", err)
+			}
+			if created != nil && created.Remote() != nil {
+				origin = created.Remote()
+			}
 		}
-		if created != nil && created.Remote() != nil {
-			evidence.CreatedAt = created.At()
-			evidence.OriginalUser = created.Remote().User()
-			evidence.OriginalHost = created.Remote().Host().String()
-			extensions["original-user@bifroest.engity.org"] = created.Remote().User()
-			extensions["original-host@bifroest.engity.org"] = created.Remote().Host().String()
+		if origin == nil {
+			return nil, fmt.Errorf("cannot issue SSH certificate without session origin")
+		}
+		evidence = &authorization.AuthorizationEvidence{
+			Schema: authorization.AuthorizationEvidenceSchema,
+			Origin: authorization.AuthorizationEvidenceOrigin{
+				User:              origin.User(),
+				Host:              origin.Host().String(),
+				AuthorizationKind: authorizationKind,
+			},
 		}
 	}
-	evidenceRaw, err := json.Marshal(evidence)
+	_, ptyAllowed := extensions["permit-pty"]
+	_, portForwardingAllowed := extensions["permit-port-forwarding"]
+	_, agentForwardingAllowed := extensions["permit-agent-forwarding"]
+	if err := evidence.Append(authorization.AuthorizationEvidenceHop{
+		CaFingerprint:          this.certificateKeys.authorityFingerprint,
+		SubjectKeyFingerprint:  this.certificateKeys.subjectFingerprint,
+		Serial:                 serial,
+		KeyId:                  keyId,
+		SessionId:              sess.Id().String(),
+		Flow:                   sess.Flow().String(),
+		AuthorizationKind:      authorizationKind,
+		Audience:               spec.audience,
+		TargetUser:             settings.user,
+		IssuedAt:               issuedAt,
+		ValidAfter:             validAfter,
+		ValidBefore:            validBefore,
+		PtyAllowed:             ptyAllowed,
+		PortForwardingAllowed:  portForwardingAllowed,
+		AgentForwardingAllowed: agentForwardingAllowed,
+	}); err != nil {
+		return nil, fmt.Errorf("cannot append SSH certificate authorization evidence: %w", err)
+	}
+	evidenceRaw, err := authorization.EncodeAuthorizationEvidence(evidence)
 	if err != nil {
 		return nil, fmt.Errorf("cannot encode SSH certificate evidence: %w", err)
 	}
-	if len(evidenceRaw) > maxSshUserCertificateEvidenceSize {
-		return nil, fmt.Errorf("SSH certificate evidence exceeds %d bytes", maxSshUserCertificateEvidenceSize)
+	extensions[authorization.AuthorizationEvidenceExtension] = string(evidenceRaw)
+	criticalOptions := map[string]string{}
+	if spec.audience != "" {
+		criticalOptions[authorization.BifroestDelegationCriticalOption] = ""
 	}
-	extensions["evidence-v1@bifroest.engity.org"] = string(evidenceRaw)
 
 	cert := &gossh.Certificate{
 		Nonce:           nil,
@@ -269,9 +326,10 @@ func (this *SshRepository) issueUserCertificate(ctx context.Context, req Request
 		KeyId:           keyId,
 		ValidPrincipals: append([]string(nil), spec.principals...),
 		ValidAfter:      uint64(validAfter.Unix()),
-		ValidBefore:     uint64(maxValidUntil.Unix()),
+		ValidBefore:     uint64(validBefore.Unix()),
 		Permissions: gossh.Permissions{
-			Extensions: extensions,
+			CriticalOptions: criticalOptions,
+			Extensions:      extensions,
 		},
 	}
 	if err := cert.SignCert(crand.Reader, this.certificateKeys.authority); err != nil {
@@ -292,12 +350,16 @@ func (this *SshRepository) issueUserCertificate(ctx context.Context, req Request
 		IssuedAt:              issuedAt,
 		ValidAfter:            validAfter,
 		MaxValidUntil:         maxValidUntil,
-		ValidBefore:           maxValidUntil,
+		ValidBefore:           validBefore,
 		Principals:            append([]string(nil), spec.principals...),
 		Extensions:            extensions,
+		CriticalOptions:       criticalOptions,
 		Certificate:           strings.TrimSpace(string(gossh.MarshalAuthorizedKey(cert))),
 		ConfigurationKey:      this.certificateKeys.configurationKey,
 		AuthorizationKind:     authorizationKind,
+		Audience:              spec.audience,
+		EvidenceDigest:        sshCertificateEvidenceDigest(evidenceRaw),
+		ParentEvidenceDigest:  spec.parentDigest,
 	}, nil
 }
 
@@ -334,8 +396,14 @@ func (this *SshRepository) validateUserCertificateState(state *sshUserCertificat
 	if state.SubjectKeyFingerprint != this.certificateKeys.subjectFingerprint {
 		return fail("subject key changed")
 	}
-	if !now.Before(state.MaxValidUntil) || !state.ValidBefore.Equal(state.MaxValidUntil) {
+	if !now.Before(state.ValidBefore) || state.ValidBefore.After(state.MaxValidUntil) {
 		return fail("certificate expired or has an invalid validity boundary")
+	}
+	if state.EvidenceDigest == "" || state.Audience != settings.certificate.audience || state.ParentEvidenceDigest != settings.certificate.parentDigest {
+		return fail("authorization evidence changed or is incomplete")
+	}
+	if !settings.certificate.maxValidBefore.IsZero() && state.ValidBefore.After(settings.certificate.maxValidBefore) {
+		return fail("certificate exceeds inherited validity")
 	}
 	if settings.certificate == nil || !slices.Equal(state.Principals, settings.certificate.principals) {
 		return fail("principals changed")
@@ -359,10 +427,53 @@ func (this *SshRepository) validateUserCertificateState(state *sshUserCertificat
 		!slices.Equal(cert.ValidPrincipals, state.Principals) {
 		return fail("certificate does not match its persisted metadata")
 	}
-	if len(cert.CriticalOptions) > 0 || !maps.Equal(cert.Extensions, state.Extensions) {
+	if !maps.Equal(cert.CriticalOptions, state.CriticalOptions) || !maps.Equal(cert.Extensions, state.Extensions) {
 		return fail("certificate permissions do not match their persisted metadata")
 	}
+	expectedCriticalOptions := map[string]string{}
+	if state.Audience != "" {
+		expectedCriticalOptions[authorization.BifroestDelegationCriticalOption] = ""
+	}
+	if !maps.Equal(state.CriticalOptions, expectedCriticalOptions) {
+		return fail("certificate delegation marker does not match its audience")
+	}
+	evidenceRaw, exists := cert.Extensions[authorization.AuthorizationEvidenceExtension]
+	if !exists || sshCertificateEvidenceDigest([]byte(evidenceRaw)) != state.EvidenceDigest {
+		return fail("certificate evidence does not match its persisted digest")
+	}
+	evidence, err := authorization.DecodeAuthorizationEvidence([]byte(evidenceRaw))
+	if err != nil {
+		return fail(err.Error())
+	}
+	last := evidence.LastHop()
+	expectedKeyId := "bifroest:" + sess.Flow().String() + ":" + sess.Id().String()
+	if last == nil || last.SessionId != sess.Id().String() || last.Flow != sess.Flow().String() ||
+		last.KeyId != expectedKeyId || last.AuthorizationKind != state.AuthorizationKind ||
+		last.Audience != state.Audience || !last.IssuedAt.Equal(state.IssuedAt) {
+		return fail("certificate evidence does not match its session metadata")
+	}
+	expectedParentDigest := ""
+	if len(evidence.Hops) > 1 {
+		parent := evidence.Clone()
+		parent.Hops = parent.Hops[:len(parent.Hops)-1]
+		parentRaw, err := authorization.EncodeAuthorizationEvidence(parent)
+		if err != nil {
+			return fail(err.Error())
+		}
+		expectedParentDigest = sshCertificateEvidenceDigest(parentRaw)
+	}
+	if state.ParentEvidenceDigest != expectedParentDigest {
+		return fail("certificate evidence does not match its parent digest")
+	}
+	if _, err := authorization.ValidateAuthorizationEvidenceCertificate(evidence, cert, settings.user, now); err != nil {
+		return fail(err.Error())
+	}
+	var supportedCriticalOptions []string
+	if state.Audience != "" {
+		supportedCriticalOptions = []string{authorization.BifroestDelegationCriticalOption}
+	}
 	checker := gossh.CertChecker{
+		SupportedCriticalOptions: supportedCriticalOptions,
 		IsUserAuthority: func(authority gossh.PublicKey) bool {
 			return gossh.FingerprintSHA256(authority) == state.CaFingerprint
 		},
@@ -428,6 +539,8 @@ func (this *SshRepository) IsSessionCompatible(ctx context.Context, sess session
 			principals:        append([]string(nil), state.Principals...),
 			extensions:        sshCertificateUserExtensions(state.Extensions),
 			authorizationKind: state.AuthorizationKind,
+			audience:          state.Audience,
+			parentDigest:      state.ParentEvidenceDigest,
 		},
 	}
 	_, err = this.validateUserCertificateState(state, sess, settings, time.Now())
@@ -495,7 +608,13 @@ func sshCertificateExtensionsEqual(stored, required map[string]string) bool {
 }
 
 func sshCertificateConfigurationKey(conf *configuration.EnvironmentSsh) string {
-	values := []string{"address=" + conf.Address.String(), "user=" + conf.User.String()}
+	address := conf.Address.String()
+	if conf.Address.IsHardCoded() {
+		if resolved, err := bfssh.ParseAddress(address); err == nil {
+			address = resolved.String()
+		}
+	}
+	values := []string{"address=" + address, "user=" + conf.User.String(), "audience=" + conf.Certificate.Audience.String()}
 	for i, principal := range conf.Certificate.Principals {
 		values = append(values, fmt.Sprintf("principal[%d]=%s", i, principal.String()))
 	}
@@ -508,5 +627,10 @@ func sshCertificateConfigurationKey(conf *configuration.EnvironmentSsh) string {
 		values = append(values, "extension="+key+"="+conf.Certificate.Extensions[key].String())
 	}
 	digest := sha256.Sum256([]byte(strings.Join(values, "\x00")))
+	return "SHA256:" + hex.EncodeToString(digest[:])
+}
+
+func sshCertificateEvidenceDigest(raw []byte) string {
+	digest := sha256.Sum256(raw)
 	return "SHA256:" + hex.EncodeToString(digest[:])
 }

--- a/pkg/environment/ssh-repository.go
+++ b/pkg/environment/ssh-repository.go
@@ -15,6 +15,7 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/engity-com/bifroest/pkg/alternatives"
+	"github.com/engity-com/bifroest/pkg/common"
 	"github.com/engity-com/bifroest/pkg/configuration"
 	"github.com/engity-com/bifroest/pkg/connection"
 	"github.com/engity-com/bifroest/pkg/crypto"
@@ -34,6 +35,7 @@ type sshResolvedSettings struct {
 	connectTimeout time.Duration
 	forwardAllowed bool
 	signers        []gossh.Signer
+	certificate    *sshCertificateSpec
 	cacheKey       string
 }
 
@@ -41,16 +43,25 @@ type SshRepository struct {
 	flow            configuration.FlowName
 	conf            *configuration.EnvironmentSsh
 	hostSigners     []gossh.Signer
+	certificateKeys *sshCertificateKeys
 	hostKeyCallback gossh.HostKeyCallback
 	context         context.Context
 	cancel          context.CancelFunc
 
 	Logger log.Logger
 
-	mutex      sync.Mutex
-	transports map[connection.Id]*sshTransport
-	attempts   map[connection.Id]*sshTransportAttempt
-	closed     bool
+	mutex        sync.Mutex
+	sessionLocks common.KeyedMutex[session.Id]
+	transports   map[connection.Id]*sshTransport
+	attempts     map[connection.Id]*sshTransportAttempt
+	closed       bool
+}
+
+func (this *SshRepository) logger() log.Logger {
+	if this.Logger != nil {
+		return this.Logger
+	}
+	return log.GetLogger("environment.ssh")
 }
 
 func NewSshRepository(ctx context.Context, flow configuration.FlowName, conf *configuration.EnvironmentSsh, _ alternatives.Provider, _ imp.Imp) (*SshRepository, error) {
@@ -84,11 +95,52 @@ func newSshRepository(ctx context.Context, flow configuration.FlowName, conf *co
 			return nil, fmt.Errorf("SSH host key at index %d has no signer", i)
 		}
 	}
+	var certificateKeys *sshCertificateKeys
+	if conf.Certificate != nil {
+		identityFile := strings.TrimSpace(conf.Certificate.IdentityFile.String())
+		if identityFile == "" || !conf.Certificate.IdentityFile.IsHardCoded() {
+			return nil, fmt.Errorf("SSH certificate identityFile has to be a static non-empty path")
+		}
+		subject, err := crypto.EnsureKeyFile(identityFile, &crypto.KeyRequirement{Type: crypto.KeyTypeEd25519}, nil)
+		if err != nil {
+			return nil, fmt.Errorf("cannot ensure SSH certificate identity file %q: %w", identityFile, err)
+		}
+		subjectSigner := subject.ToSsh()
+		var authoritySigner gossh.Signer
+		authorityIdentityFile := strings.TrimSpace(conf.Certificate.AuthorityIdentityFile.String())
+		if authorityIdentityFile != "" {
+			if !conf.Certificate.AuthorityIdentityFile.IsHardCoded() {
+				return nil, fmt.Errorf("SSH certificate authorityIdentityFile has to be a static path")
+			}
+			raw, err := os.ReadFile(authorityIdentityFile)
+			if err != nil {
+				return nil, fmt.Errorf("cannot read SSH certificate authority identity file %q: %w", authorityIdentityFile, err)
+			}
+			authoritySigner, err = gossh.ParsePrivateKey(raw)
+			if err != nil {
+				return nil, fmt.Errorf("cannot parse SSH certificate authority identity file %q: %w", authorityIdentityFile, err)
+			}
+		} else {
+			if len(hostSigners) == 0 {
+				return nil, fmt.Errorf("no SSH host key is available as certificate authority fallback")
+			}
+			authoritySigner = hostSigners[0]
+		}
+		certificateKeys = &sshCertificateKeys{
+			subject:              subjectSigner,
+			subjectIdentityFile:  identityFile,
+			subjectFingerprint:   gossh.FingerprintSHA256(subjectSigner.PublicKey()),
+			authority:            authoritySigner,
+			authorityFingerprint: gossh.FingerprintSHA256(authoritySigner.PublicKey()),
+			configurationKey:     sshCertificateConfigurationKey(conf),
+		}
+	}
 	repositoryContext, cancel := context.WithCancel(ctx)
 	return &SshRepository{
 		flow:            flow,
 		conf:            conf,
 		hostSigners:     hostSigners,
+		certificateKeys: certificateKeys,
 		hostKeyCallback: hostKeyCallback,
 		context:         repositoryContext,
 		cancel:          cancel,
@@ -121,6 +173,14 @@ func (this *SshRepository) Ensure(req Request) (Environment, error) {
 	if err != nil {
 		return nil, err
 	}
+	if this.certificateKeys != nil {
+		signer, certificateKey, err := this.ensureUserCertificate(req.Context(), req, sess, settings)
+		if err != nil {
+			return nil, err
+		}
+		settings.signers = []gossh.Signer{signer}
+		settings.cacheKey += "\x00certificate\x00" + sess.Id().String() + "\x00" + certificateKey
+	}
 	lifetime, ok := connectionLifetime(req.Connection())
 	if !ok {
 		return nil, fmt.Errorf("SSH environment requires a connection with a lifetime context")
@@ -134,7 +194,7 @@ func (this *SshRepository) Ensure(req Request) (Environment, error) {
 	}, nil
 }
 
-func (this *SshRepository) resolveSettings(req Request) (*sshResolvedSettings, error) {
+func (this *SshRepository) resolveSettings(req Context) (*sshResolvedSettings, error) {
 	addressValue, err := this.conf.Address.Render(req)
 	if err != nil {
 		return nil, fmt.Errorf("cannot render SSH target address: %w", err)
@@ -171,7 +231,21 @@ func (this *SshRepository) resolveSettings(req Request) (*sshResolvedSettings, e
 
 	var signers []gossh.Signer
 	identityKey := "fallback"
-	if len(this.conf.IdentityFiles) > 0 {
+	if this.conf.Certificate != nil {
+		certificate, err := resolveSshCertificateSpec(this.conf.Certificate, req, &sshResolvedSettings{user: user, forwardAllowed: forwardAllowed})
+		if err != nil {
+			return nil, err
+		}
+		identityKey = "certificate\x00" + this.certificateKeys.subjectFingerprint
+		return &sshResolvedSettings{
+			address:        address,
+			user:           user,
+			connectTimeout: connectTimeout,
+			forwardAllowed: forwardAllowed,
+			certificate:    certificate,
+			cacheKey:       address.String() + "\x00" + user + "\x00" + connectTimeout.String() + "\x00" + identityKey,
+		}, nil
+	} else if len(this.conf.IdentityFiles) > 0 {
 		files, err := this.conf.IdentityFiles.Render(req)
 		if err != nil {
 			return nil, fmt.Errorf("cannot render SSH identity files: %w", err)
@@ -213,8 +287,25 @@ func (this *SshRepository) resolveSettings(req Request) (*sshResolvedSettings, e
 	}, nil
 }
 
-func (this *SshRepository) FindBySession(context.Context, session.Session, *FindOpts) (Environment, error) {
-	return nil, ErrNoSuchEnvironment
+func (this *SshRepository) FindBySession(ctx context.Context, sess session.Session, opts *FindOpts) (Environment, error) {
+	raw, err := sess.EnvironmentToken(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load SSH environment token: %w", err)
+	}
+	if len(raw) == 0 {
+		return nil, ErrNoSuchEnvironment
+	}
+	if _, err := decodeSshUserCertificateState(raw); err != nil {
+		if !opts.IsAutoCleanUpAllowed() {
+			return nil, err
+		}
+		if err := sess.SetEnvironmentToken(ctx, nil); err != nil {
+			return nil, fmt.Errorf("cannot remove broken SSH environment token: %w", err)
+		}
+		opts.GetLogger(this.logger).With("session", sess).Warn("removed broken SSH environment token")
+		return nil, ErrNoSuchEnvironment
+	}
+	return &sshEnvironment{repository: this, session: sess}, nil
 }
 
 func (this *SshRepository) Cleanup(context.Context, *CleanupOpts) error { return nil }

--- a/pkg/environment/ssh-repository.go
+++ b/pkg/environment/ssh-repository.go
@@ -1,0 +1,479 @@
+package environment
+
+import (
+	"context"
+	"fmt"
+	gonet "net"
+	"os"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/echocat/slf4g"
+	essh "github.com/engity-com/ssh-server-go"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/engity-com/bifroest/pkg/alternatives"
+	"github.com/engity-com/bifroest/pkg/configuration"
+	"github.com/engity-com/bifroest/pkg/connection"
+	"github.com/engity-com/bifroest/pkg/crypto"
+	"github.com/engity-com/bifroest/pkg/errors"
+	"github.com/engity-com/bifroest/pkg/imp"
+	bnet "github.com/engity-com/bifroest/pkg/net"
+	"github.com/engity-com/bifroest/pkg/session"
+)
+
+var _ = RegisterRepository(NewSshRepository)
+
+const maxSshTargetChannels = 64
+
+type sshResolvedSettings struct {
+	address        bnet.HostPort
+	user           string
+	connectTimeout time.Duration
+	forwardAllowed bool
+	signers        []gossh.Signer
+	cacheKey       string
+}
+
+type SshRepository struct {
+	flow            configuration.FlowName
+	conf            *configuration.EnvironmentSsh
+	hostSigners     []gossh.Signer
+	hostKeyCallback gossh.HostKeyCallback
+	context         context.Context
+	cancel          context.CancelFunc
+
+	Logger log.Logger
+
+	mutex      sync.Mutex
+	transports map[connection.Id]*sshTransport
+	attempts   map[connection.Id]*sshTransportAttempt
+	closed     bool
+}
+
+func NewSshRepository(ctx context.Context, flow configuration.FlowName, conf *configuration.EnvironmentSsh, _ alternatives.Provider, _ imp.Imp) (*SshRepository, error) {
+	return newSshRepository(ctx, flow, conf, repositoryDependenciesFrom(ctx).hostKeys)
+}
+
+func NewSshRepositoryWithHostKeys(ctx context.Context, flow configuration.FlowName, conf *configuration.EnvironmentSsh, hostKeys []crypto.PrivateKey) (*SshRepository, error) {
+	return newSshRepository(ctx, flow, conf, hostKeys)
+}
+
+func newSshRepository(ctx context.Context, flow configuration.FlowName, conf *configuration.EnvironmentSsh, hostKeys []crypto.PrivateKey) (*SshRepository, error) {
+	if conf == nil {
+		return nil, fmt.Errorf("nil configuration")
+	}
+	var hostKeyCallback gossh.HostKeyCallback
+	var err error
+	if conf.AcceptAllHostKeys {
+		hostKeyCallback = gossh.InsecureIgnoreHostKey()
+		log.GetLogger("environment.ssh").Warn("SSH target host-key verification is disabled by acceptAllHostKeys")
+	} else if hostKeyCallback, err = crypto.NewKnownHostsCallback(conf.KnownHosts, conf.KnownHostsFile); err != nil {
+		return nil, err
+	}
+	hostSigners := make([]gossh.Signer, len(hostKeys))
+	for i, key := range hostKeys {
+		value := reflect.ValueOf(key)
+		if key == nil || value.Kind() == reflect.Pointer && value.IsNil() {
+			return nil, fmt.Errorf("nil SSH host key at index %d", i)
+		}
+		hostSigners[i] = key.ToSsh()
+		if hostSigners[i] == nil {
+			return nil, fmt.Errorf("SSH host key at index %d has no signer", i)
+		}
+	}
+	repositoryContext, cancel := context.WithCancel(ctx)
+	return &SshRepository{
+		flow:            flow,
+		conf:            conf,
+		hostSigners:     hostSigners,
+		hostKeyCallback: hostKeyCallback,
+		context:         repositoryContext,
+		cancel:          cancel,
+		transports:      make(map[connection.Id]*sshTransport),
+		attempts:        make(map[connection.Id]*sshTransportAttempt),
+	}, nil
+}
+
+func (this *SshRepository) WillBeAccepted(ctx Context) (bool, error) {
+	return this.conf.LoginAllowed.Render(ctx)
+}
+
+func (this *SshRepository) DoesSupportPty(Context, essh.Pty) (bool, error) {
+	return true, nil
+}
+
+func (this *SshRepository) Ensure(req Request) (Environment, error) {
+	accepted, err := this.WillBeAccepted(req)
+	if err != nil {
+		return nil, err
+	}
+	if !accepted {
+		return nil, ErrNotAcceptable
+	}
+	sess := req.Authorization().FindSession()
+	if sess == nil {
+		return nil, errors.System.Newf("authorization without session")
+	}
+	settings, err := this.resolveSettings(req)
+	if err != nil {
+		return nil, err
+	}
+	lifetime, ok := connectionLifetime(req.Connection())
+	if !ok {
+		return nil, fmt.Errorf("SSH environment requires a connection with a lifetime context")
+	}
+	return &sshEnvironment{
+		repository: this,
+		connection: req.Connection(),
+		lifetime:   lifetime,
+		session:    sess,
+		settings:   settings,
+	}, nil
+}
+
+func (this *SshRepository) resolveSettings(req Request) (*sshResolvedSettings, error) {
+	addressValue, err := this.conf.Address.Render(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot render SSH target address: %w", err)
+	}
+	var address bnet.HostPort
+	if err := address.Set(strings.TrimSpace(addressValue)); err != nil {
+		return nil, fmt.Errorf("illegal rendered SSH target address %q: %w", addressValue, err)
+	}
+	if err := address.Validate(); err != nil {
+		return nil, fmt.Errorf("illegal rendered SSH target address %q: %w", addressValue, err)
+	}
+	if address.IsZero() {
+		return nil, fmt.Errorf("rendered SSH target address is empty")
+	}
+	user, err := this.conf.User.Render(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot render SSH target user: %w", err)
+	}
+	user = strings.TrimSpace(user)
+	if user == "" {
+		return nil, fmt.Errorf("rendered SSH target user is empty")
+	}
+	connectTimeout, err := this.conf.ConnectTimeout.Render(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot render SSH connect timeout: %w", err)
+	}
+	if connectTimeout < 0 {
+		return nil, fmt.Errorf("rendered SSH connect timeout cannot be negative")
+	}
+	forwardAllowed, err := this.conf.PortForwardingAllowed.Render(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot render SSH port forwarding setting: %w", err)
+	}
+
+	var signers []gossh.Signer
+	identityKey := "fallback"
+	if len(this.conf.IdentityFiles) > 0 {
+		files, err := this.conf.IdentityFiles.Render(req)
+		if err != nil {
+			return nil, fmt.Errorf("cannot render SSH identity files: %w", err)
+		}
+		signers = make([]gossh.Signer, len(files))
+		for i, file := range files {
+			file = strings.TrimSpace(file)
+			if file == "" {
+				return nil, fmt.Errorf("rendered SSH identity file [%d] is empty", i)
+			}
+			raw, err := os.ReadFile(file)
+			if err != nil {
+				return nil, fmt.Errorf("cannot read SSH identity file %q: %w", file, err)
+			}
+			signer, err := gossh.ParsePrivateKey(raw)
+			if err != nil {
+				return nil, fmt.Errorf("cannot parse SSH identity file %q: %w", file, err)
+			}
+			signers[i] = signer
+			identityKey += "\x00" + file + "\x00" + gossh.FingerprintSHA256(signer.PublicKey())
+		}
+	} else {
+		signers = append([]gossh.Signer(nil), this.hostSigners...)
+		for _, signer := range signers {
+			identityKey += "\x00" + gossh.FingerprintSHA256(signer.PublicKey())
+		}
+	}
+	if len(signers) == 0 {
+		return nil, fmt.Errorf("no SSH client identity is available")
+	}
+
+	return &sshResolvedSettings{
+		address:        address,
+		user:           user,
+		connectTimeout: connectTimeout,
+		forwardAllowed: forwardAllowed,
+		signers:        signers,
+		cacheKey:       address.String() + "\x00" + user + "\x00" + connectTimeout.String() + "\x00" + identityKey,
+	}, nil
+}
+
+func (this *SshRepository) FindBySession(context.Context, session.Session, *FindOpts) (Environment, error) {
+	return nil, ErrNoSuchEnvironment
+}
+
+func (this *SshRepository) Cleanup(context.Context, *CleanupOpts) error { return nil }
+
+func (this *SshRepository) transportFor(env *sshEnvironment, requestContexts ...context.Context) (*sshTransport, error) {
+	id := env.connection.Id()
+	requestContext := env.lifetime
+	if len(requestContexts) > 0 && requestContexts[0] != nil {
+		requestContext = requestContexts[0]
+	}
+
+	for {
+		this.mutex.Lock()
+		if this.closed {
+			this.mutex.Unlock()
+			return nil, fmt.Errorf("SSH environment repository is closed")
+		}
+		if existing := this.transports[id]; existing != nil {
+			this.mutex.Unlock()
+			if existing.cacheKey != env.settings.cacheKey {
+				return nil, fmt.Errorf("SSH target settings changed within connection %s", id)
+			}
+			return existing, nil
+		}
+		if attempt := this.attempts[id]; attempt != nil {
+			if attempt.cacheKey != env.settings.cacheKey {
+				this.mutex.Unlock()
+				return nil, fmt.Errorf("SSH target settings changed within connection %s", id)
+			}
+			this.mutex.Unlock()
+			select {
+			case <-attempt.done:
+				continue
+			case <-requestContext.Done():
+				return nil, requestContext.Err()
+			case <-env.lifetime.Done():
+				return nil, env.lifetime.Err()
+			case <-this.context.Done():
+				return nil, fmt.Errorf("SSH environment repository is closed")
+			}
+		}
+		attempt := &sshTransportAttempt{cacheKey: env.settings.cacheKey, done: make(chan struct{})}
+		this.attempts[id] = attempt
+		this.mutex.Unlock()
+
+		dialContext, cancel := context.WithCancel(requestContext)
+		stopLifetime := context.AfterFunc(env.lifetime, cancel)
+		stopRepository := context.AfterFunc(this.context, cancel)
+		transport, err := this.dial(dialContext, env.connection.Logger(), env.settings)
+		stopLifetime()
+		stopRepository()
+		cancel()
+
+		this.mutex.Lock()
+		delete(this.attempts, id)
+		usable := err == nil && !this.closed && env.lifetime.Err() == nil && requestContext.Err() == nil
+		if usable {
+			this.transports[id] = transport
+		}
+		close(attempt.done)
+		this.mutex.Unlock()
+		if err != nil {
+			return nil, err
+		}
+		if !usable {
+			_ = transport.Close()
+			if err := env.lifetime.Err(); err != nil {
+				return nil, err
+			}
+			if err := requestContext.Err(); err != nil {
+				return nil, err
+			}
+			return nil, fmt.Errorf("SSH environment repository is closed")
+		}
+
+		go func() {
+			_ = transport.client.Wait()
+			this.removeTransport(id, transport)
+		}()
+		go func() {
+			select {
+			case <-env.lifetime.Done():
+				this.removeTransport(id, transport)
+			case <-transport.done:
+			}
+		}()
+		return transport, nil
+	}
+}
+
+func connectionLifetime(conn connection.Connection) (context.Context, bool) {
+	if provider, ok := conn.(connection.LifetimeAware); ok {
+		if result := provider.Lifetime(); result != nil {
+			return result, true
+		}
+	}
+	return nil, false
+}
+
+func (this *SshRepository) dial(lifetime context.Context, logger log.Logger, settings *sshResolvedSettings) (*sshTransport, error) {
+	ctx := lifetime
+	cancel := func() {}
+	if settings.connectTimeout > 0 {
+		ctx, cancel = context.WithTimeout(lifetime, settings.connectTimeout)
+	}
+	defer cancel()
+
+	raw, err := (&gonet.Dialer{}).DialContext(ctx, "tcp", settings.address.String())
+	if err != nil {
+		return nil, fmt.Errorf("cannot connect to SSH target %s: %w", settings.address, err)
+	}
+	success := false
+	defer func() {
+		if !success {
+			_ = raw.Close()
+		}
+	}()
+	if deadline, ok := ctx.Deadline(); ok {
+		if err := raw.SetDeadline(deadline); err != nil {
+			return nil, fmt.Errorf("cannot configure SSH handshake deadline: %w", err)
+		}
+	}
+	handshakeDone := make(chan struct{})
+	watcherDone := make(chan struct{})
+	go func() {
+		defer close(watcherDone)
+		select {
+		case <-ctx.Done():
+			_ = raw.Close()
+		case <-handshakeDone:
+		}
+	}()
+	clientConn, channels, requests, err := gossh.NewClientConn(raw, settings.address.String(), &gossh.ClientConfig{
+		User:            settings.user,
+		Auth:            []gossh.AuthMethod{gossh.PublicKeys(settings.signers...)},
+		HostKeyCallback: this.hostKeyCallback,
+	})
+	close(handshakeDone)
+	<-watcherDone
+	if err != nil {
+		return nil, fmt.Errorf("cannot establish SSH target connection to %s: %w", settings.address, err)
+	}
+	if err := ctx.Err(); err != nil {
+		_ = clientConn.Close()
+		return nil, err
+	}
+	if err := raw.SetDeadline(time.Time{}); err != nil {
+		_ = clientConn.Close()
+		return nil, fmt.Errorf("cannot clear SSH handshake deadline: %w", err)
+	}
+	success = true
+	logger.With("target", settings.address).With("user", settings.user).Debug("SSH target connection established")
+	return newSshTransport(gossh.NewClient(clientConn, channels, requests), settings.cacheKey), nil
+}
+
+func (this *SshRepository) removeTransport(id connection.Id, transport *sshTransport) {
+	this.mutex.Lock()
+	if this.transports[id] == transport {
+		delete(this.transports, id)
+	}
+	this.mutex.Unlock()
+	_ = transport.Close()
+}
+
+func (this *SshRepository) Close() error {
+	this.cancel()
+	this.mutex.Lock()
+	if this.closed {
+		this.mutex.Unlock()
+		return nil
+	}
+	this.closed = true
+	transports := make([]*sshTransport, 0, len(this.transports))
+	for _, transport := range this.transports {
+		transports = append(transports, transport)
+	}
+	clear(this.transports)
+	this.mutex.Unlock()
+	var result error
+	for _, transport := range transports {
+		if err := transport.Close(); err != nil && result == nil {
+			result = err
+		}
+	}
+	return result
+}
+
+type sshTransportAttempt struct {
+	cacheKey string
+	done     chan struct{}
+}
+
+type sshTransport struct {
+	client   *gossh.Client
+	cacheKey string
+	done     chan struct{}
+	channels chan struct{}
+
+	closeOnce sync.Once
+	agentMu   sync.Mutex
+	agent     *sshAgentBridge
+}
+
+func newSshTransport(client *gossh.Client, cacheKey string) *sshTransport {
+	return &sshTransport{client: client, cacheKey: cacheKey, done: make(chan struct{}), channels: make(chan struct{}, maxSshTargetChannels)}
+}
+
+func (this *sshTransport) acquireChannel(ctx context.Context) error {
+	select {
+	case this.channels <- struct{}{}:
+		select {
+		case <-this.done:
+			this.releaseChannel()
+			return fmt.Errorf("SSH target transport is closed")
+		default:
+			return nil
+		}
+	case <-this.done:
+		return fmt.Errorf("SSH target transport is closed")
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (this *sshTransport) tryAcquireChannel() bool {
+	select {
+	case <-this.done:
+		return false
+	default:
+	}
+	select {
+	case this.channels <- struct{}{}:
+		select {
+		case <-this.done:
+			this.releaseChannel()
+			return false
+		default:
+			return true
+		}
+	default:
+		return false
+	}
+}
+
+func (this *sshTransport) releaseChannel() {
+	<-this.channels
+}
+
+func (this *sshTransport) Close() (result error) {
+	this.closeOnce.Do(func() {
+		this.agentMu.Lock()
+		if this.agent != nil {
+			result = this.agent.Close()
+		}
+		this.agentMu.Unlock()
+		if err := this.client.Close(); err != nil && result == nil {
+			result = err
+		}
+		close(this.done)
+	})
+	return result
+}

--- a/pkg/environment/ssh-repository.go
+++ b/pkg/environment/ssh-repository.go
@@ -23,6 +23,7 @@ import (
 	"github.com/engity-com/bifroest/pkg/imp"
 	bnet "github.com/engity-com/bifroest/pkg/net"
 	"github.com/engity-com/bifroest/pkg/session"
+	bfssh "github.com/engity-com/bifroest/pkg/ssh"
 )
 
 var _ = RegisterRepository(NewSshRepository)
@@ -97,35 +98,19 @@ func newSshRepository(ctx context.Context, flow configuration.FlowName, conf *co
 	}
 	var certificateKeys *sshCertificateKeys
 	if conf.Certificate != nil {
-		identityFile := strings.TrimSpace(conf.Certificate.IdentityFile.String())
-		if identityFile == "" || !conf.Certificate.IdentityFile.IsHardCoded() {
-			return nil, fmt.Errorf("SSH certificate identityFile has to be a static non-empty path")
-		}
-		subject, err := crypto.EnsureKeyFile(identityFile, &crypto.KeyRequirement{Type: crypto.KeyTypeEd25519}, nil)
+		subject, identityFile, err := ensureSshCertificateIdentity(conf.Certificate)
 		if err != nil {
-			return nil, fmt.Errorf("cannot ensure SSH certificate identity file %q: %w", identityFile, err)
+			return nil, err
 		}
 		subjectSigner := subject.ToSsh()
-		var authoritySigner gossh.Signer
-		authorityIdentityFile := strings.TrimSpace(conf.Certificate.AuthorityIdentityFile.String())
-		if authorityIdentityFile != "" {
-			if !conf.Certificate.AuthorityIdentityFile.IsHardCoded() {
-				return nil, fmt.Errorf("SSH certificate authorityIdentityFile has to be a static path")
-			}
-			raw, err := os.ReadFile(authorityIdentityFile)
-			if err != nil {
-				return nil, fmt.Errorf("cannot read SSH certificate authority identity file %q: %w", authorityIdentityFile, err)
-			}
-			authoritySigner, err = gossh.ParsePrivateKey(raw)
-			if err != nil {
-				return nil, fmt.Errorf("cannot parse SSH certificate authority identity file %q: %w", authorityIdentityFile, err)
-			}
-		} else {
-			if len(hostSigners) == 0 {
-				return nil, fmt.Errorf("no SSH host key is available as certificate authority fallback")
-			}
-			authoritySigner = hostSigners[0]
+		authority, _, err := ensureSshCertificateAuthority(conf.Certificate)
+		if err != nil {
+			return nil, err
 		}
+		if err := ValidateSshCertificateAuthority(authority, hostKeys); err != nil {
+			return nil, err
+		}
+		authoritySigner := authority.ToSsh()
 		certificateKeys = &sshCertificateKeys{
 			subject:              subjectSigner,
 			subjectIdentityFile:  identityFile,
@@ -199,15 +184,9 @@ func (this *SshRepository) resolveSettings(req Context) (*sshResolvedSettings, e
 	if err != nil {
 		return nil, fmt.Errorf("cannot render SSH target address: %w", err)
 	}
-	var address bnet.HostPort
-	if err := address.Set(strings.TrimSpace(addressValue)); err != nil {
+	address, err := bfssh.ParseAddress(addressValue)
+	if err != nil {
 		return nil, fmt.Errorf("illegal rendered SSH target address %q: %w", addressValue, err)
-	}
-	if err := address.Validate(); err != nil {
-		return nil, fmt.Errorf("illegal rendered SSH target address %q: %w", addressValue, err)
-	}
-	if address.IsZero() {
-		return nil, fmt.Errorf("rendered SSH target address is empty")
 	}
 	user, err := this.conf.User.Render(req)
 	if err != nil {

--- a/pkg/environment/ssh.go
+++ b/pkg/environment/ssh.go
@@ -1,0 +1,598 @@
+package environment
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	gonet "net"
+	"strings"
+	"sync"
+
+	essh "github.com/engity-com/ssh-server-go"
+	gossh "golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+
+	"github.com/engity-com/bifroest/pkg/authorization"
+	"github.com/engity-com/bifroest/pkg/connection"
+	"github.com/engity-com/bifroest/pkg/execution"
+	bnet "github.com/engity-com/bifroest/pkg/net"
+	"github.com/engity-com/bifroest/pkg/session"
+	bssh "github.com/engity-com/bifroest/pkg/ssh"
+	"github.com/engity-com/bifroest/pkg/sys"
+)
+
+type sshEnvironment struct {
+	repository *SshRepository
+	connection connection.Connection
+	lifetime   context.Context
+	session    session.Session
+	settings   *sshResolvedSettings
+}
+
+func (this *sshEnvironment) Banner(req Request) (io.ReadCloser, error) {
+	banner, err := this.repository.conf.Banner.Render(req)
+	if err != nil {
+		return nil, err
+	}
+	if banner == "" {
+		return nil, nil
+	}
+	return io.NopCloser(strings.NewReader(banner)), nil
+}
+
+func (this *sshEnvironment) Run(task Task) (int, error) {
+	transport, err := this.repository.transportFor(this, task.Context())
+	if err != nil {
+		return -1, err
+	}
+	environment, err := this.environmentFor(task)
+	if err != nil {
+		return -1, err
+	}
+	if err := transport.acquireChannel(task.Context()); err != nil {
+		return -1, err
+	}
+	type result struct {
+		code int
+		err  error
+	}
+	completed := make(chan result, 1)
+	go func() {
+		defer transport.releaseChannel()
+		var code int
+		var err error
+		switch task.TaskType() {
+		case TaskTypeShell:
+			code, err = this.runShell(task, transport, environment)
+		case TaskTypeSftp:
+			code, err = this.runSftp(task, transport, environment)
+		default:
+			code, err = -1, fmt.Errorf("illegal task type: %v", task.TaskType())
+		}
+		completed <- result{code, err}
+	}()
+	select {
+	case actual := <-completed:
+		return actual.code, actual.err
+	case <-task.Context().Done():
+		return -1, task.Context().Err()
+	}
+}
+
+func (this *sshEnvironment) environmentFor(task Task) (sys.EnvVars, error) {
+	result := sys.EnvVars{}
+	targetOs := this.repository.conf.Os
+	if err := applyTaskEnvironment(&result, targetOs, task); err != nil {
+		return nil, err
+	}
+	executionId, err := execution.NewId()
+	if err != nil {
+		return nil, fmt.Errorf("cannot create execution ID: %w", err)
+	}
+	setReservedEnvironment(&result, targetOs,
+		session.EnvName, this.session.Id().String(),
+		connection.EnvName, this.connection.Id().String(),
+		execution.EnvName, executionId.String(),
+	)
+	return result, nil
+}
+
+type sshRequestSender interface {
+	SendRequest(string, bool, []byte) (bool, error)
+}
+
+func sendSshEnvironment(channel sshRequestSender, environment sys.EnvVars) error {
+	type environmentRequest struct {
+		Name  string
+		Value string
+	}
+	for key, value := range environment {
+		if _, err := channel.SendRequest("env", false, gossh.Marshal(&environmentRequest{key, value})); err != nil {
+			return fmt.Errorf("cannot send SSH environment variable %s: %w", key, err)
+		}
+	}
+	return nil
+}
+
+func (this *sshEnvironment) runShell(task Task, transport *sshTransport, environment sys.EnvVars) (int, error) {
+	target, err := this.openTargetSession(task.Context(), transport)
+	if err != nil {
+		return -1, fmt.Errorf("cannot open SSH target session: %w", err)
+	}
+	defer func() { _ = target.Close() }()
+	targetDone := make(chan struct{})
+	defer close(targetDone)
+	go func() {
+		select {
+		case <-task.Context().Done():
+			_ = target.Close()
+		case <-targetDone:
+		}
+	}()
+
+	sshSession := task.SshSession()
+	target.Stdin = sshSession
+	target.Stdout = sshSession
+	target.Stderr = sshSession.Stderr()
+	if err := sendSshEnvironment(target, environment); err != nil {
+		return -1, err
+	}
+
+	runContext, cancel := context.WithCancel(task.Context())
+	var workers sync.WaitGroup
+	defer func() {
+		cancel()
+		workers.Wait()
+	}()
+
+	if pty, windows, ok := sshSession.Pty(); ok {
+		if err := requestTargetPty(target, pty); err != nil {
+			return -1, fmt.Errorf("cannot request SSH target PTY: %w", err)
+		}
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for {
+				select {
+				case <-runContext.Done():
+					return
+				case window, ok := <-windows:
+					if !ok {
+						return
+					}
+					if err := sendTargetWindowChange(target, window); err != nil {
+						this.connection.Logger().WithError(err).Warn("cannot forward SSH target window change")
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	if bssh.AgentRequested(sshSession) && authorization.IsAgentForwardingAllowed(task.Authorization()) {
+		if err := transport.ensureAgent(task, this.lifetime); err != nil {
+			return -1, fmt.Errorf("cannot forward SSH agent to target: %w", err)
+		}
+		if err := agent.RequestAgentForwarding(target); err != nil {
+			return -1, fmt.Errorf("cannot request SSH agent forwarding at target: %w", err)
+		}
+	}
+
+	signals := make(chan essh.Signal, 16)
+	sshSession.Signals(signals)
+	defer sshSession.Signals(nil)
+	workers.Add(1)
+	go func() {
+		defer workers.Done()
+		for {
+			select {
+			case <-runContext.Done():
+				return
+			case signal, ok := <-signals:
+				if !ok {
+					return
+				}
+				if err := target.Signal(gossh.Signal(signal)); err != nil {
+					this.connection.Logger().WithError(err).With("signal", signal).Warn("cannot forward SSH target signal")
+				}
+			}
+		}
+	}()
+
+	if command := sshSession.RawCommand(); command != "" {
+		err = target.Start(command)
+	} else {
+		err = target.Shell()
+	}
+	if err != nil {
+		if contextErr := task.Context().Err(); contextErr != nil {
+			return -1, contextErr
+		}
+		return -1, fmt.Errorf("cannot start SSH target session: %w", err)
+	}
+
+	waitDone := make(chan error, 1)
+	go func() {
+		waitDone <- target.Wait()
+	}()
+	select {
+	case err = <-waitDone:
+	case <-task.Context().Done():
+		_ = target.Close()
+		err = <-waitDone
+	}
+	cancel()
+	var exitError *gossh.ExitError
+	if errors.As(err, &exitError) {
+		return exitError.ExitStatus(), nil
+	}
+	if err != nil {
+		return -1, fmt.Errorf("SSH target session failed: %w", err)
+	}
+	return 0, nil
+}
+
+func (this *sshEnvironment) openTargetSession(ctx context.Context, transport *sshTransport) (*gossh.Session, error) {
+	type result struct {
+		session *gossh.Session
+		err     error
+	}
+	completed := make(chan result, 1)
+	go func() {
+		session, err := transport.client.NewSession()
+		completed <- result{session, err}
+	}()
+	select {
+	case actual := <-completed:
+		if actual.err != nil {
+			this.invalidateTransportAfterOpenError(transport, actual.err)
+		}
+		return actual.session, actual.err
+	case <-ctx.Done():
+		actual := <-completed
+		if actual.session != nil {
+			_ = actual.session.Close()
+		}
+		return nil, ctx.Err()
+	}
+}
+
+func requestTargetPty(target sshRequestSender, pty essh.Pty) error {
+	var modes []byte
+	for key, value := range pty.TerminalModes {
+		modes = append(modes, gossh.Marshal(&struct {
+			Key byte
+			Val uint32
+		}{key, value})...)
+	}
+	modes = append(modes, 0)
+	payload := struct {
+		Term         string
+		Columns      uint32
+		Rows         uint32
+		WidthPixels  uint32
+		HeightPixels uint32
+		Modelist     string
+	}{
+		Term:         pty.Term,
+		Columns:      uint32(pty.Window.Width),
+		Rows:         uint32(pty.Window.Height),
+		WidthPixels:  uint32(pty.Window.WidthPixels),
+		HeightPixels: uint32(pty.Window.HeightPixels),
+		Modelist:     string(modes),
+	}
+	accepted, err := target.SendRequest("pty-req", true, gossh.Marshal(&payload))
+	if err != nil {
+		return err
+	}
+	if !accepted {
+		return fmt.Errorf("SSH target rejected PTY request")
+	}
+	return nil
+}
+
+func sendTargetWindowChange(target sshRequestSender, window essh.Window) error {
+	payload := struct {
+		Columns      uint32
+		Rows         uint32
+		WidthPixels  uint32
+		HeightPixels uint32
+	}{
+		Columns:      uint32(window.Width),
+		Rows:         uint32(window.Height),
+		WidthPixels:  uint32(window.WidthPixels),
+		HeightPixels: uint32(window.HeightPixels),
+	}
+	_, err := target.SendRequest("window-change", false, gossh.Marshal(&payload))
+	return err
+}
+
+func (this *sshEnvironment) runSftp(task Task, transport *sshTransport, environment sys.EnvVars) (int, error) {
+	channel, requests, err := this.openTargetChannel(task.Context(), transport, "session", nil)
+	if err != nil {
+		return -1, fmt.Errorf("cannot open SSH target SFTP channel: %w", err)
+	}
+	defer func() { _ = channel.Close() }()
+	channelDone := make(chan struct{})
+	defer close(channelDone)
+	go func() {
+		select {
+		case <-task.Context().Done():
+			_ = channel.Close()
+		case <-channelDone:
+		}
+	}()
+	if err := sendSshEnvironment(channel, environment); err != nil {
+		return -1, err
+	}
+	type subsystemRequest struct{ Subsystem string }
+	accepted, err := channel.SendRequest("subsystem", true, gossh.Marshal(&subsystemRequest{"sftp"}))
+	if err != nil {
+		if contextErr := task.Context().Err(); contextErr != nil {
+			return -1, contextErr
+		}
+		return -1, fmt.Errorf("cannot request SSH target SFTP subsystem: %w", err)
+	}
+	if !accepted {
+		return -1, fmt.Errorf("SSH target rejected SFTP subsystem")
+	}
+
+	exitStatus := make(chan struct {
+		status int
+		err    error
+	}, 1)
+	requestsDone := make(chan struct{})
+	go func() {
+		defer close(requestsDone)
+		status, err := collectSftpExitStatus(requests)
+		exitStatus <- struct {
+			status int
+			err    error
+		}{status, err}
+	}()
+	stderrDone := make(chan struct{})
+	go func() {
+		defer close(stderrDone)
+		_, _ = io.Copy(task.SshSession().Stderr(), channel.Stderr())
+	}()
+	copyDone := make(chan error, 1)
+	go func() {
+		copyDone <- essh.FullDuplexCopy(task.Context(), task.SshSession(), channel, nil)
+	}()
+	select {
+	case err = <-copyDone:
+	case <-task.Context().Done():
+		_ = channel.Close()
+		err = <-copyDone
+	}
+	_ = channel.Close()
+	<-requestsDone
+	<-stderrDone
+	if contextErr := task.Context().Err(); contextErr != nil {
+		return -1, contextErr
+	}
+	if err != nil && task.Context().Err() != nil {
+		return -1, task.Context().Err()
+	}
+	if err != nil {
+		return -1, fmt.Errorf("SSH target SFTP stream failed: %w", err)
+	}
+	status := <-exitStatus
+	if status.err != nil {
+		return -1, status.err
+	}
+	return status.status, nil
+}
+
+func collectSftpExitStatus(requests <-chan *gossh.Request) (int, error) {
+	result := -1
+	received := false
+	var resultErr error
+	for request := range requests {
+		switch request.Type {
+		case "exit-status":
+			var payload struct{ Status uint32 }
+			if err := gossh.Unmarshal(request.Payload, &payload); err != nil {
+				resultErr = fmt.Errorf("cannot decode SSH target SFTP exit status: %w", err)
+			} else {
+				result = int(payload.Status)
+				received = true
+			}
+		case "exit-signal":
+			resultErr = fmt.Errorf("SSH target SFTP subsystem exited by signal")
+		}
+		if request.WantReply {
+			_ = request.Reply(false, nil)
+		}
+	}
+	if !received && resultErr == nil {
+		resultErr = fmt.Errorf("SSH target SFTP subsystem did not report an exit status")
+	}
+	return result, resultErr
+}
+
+func (this *sshEnvironment) openTargetChannel(ctx context.Context, transport *sshTransport, channelType string, data []byte) (gossh.Channel, <-chan *gossh.Request, error) {
+	type result struct {
+		channel  gossh.Channel
+		requests <-chan *gossh.Request
+		err      error
+	}
+	completed := make(chan result, 1)
+	go func() {
+		channel, requests, err := transport.client.OpenChannel(channelType, data)
+		completed <- result{channel, requests, err}
+	}()
+	select {
+	case actual := <-completed:
+		if actual.err != nil {
+			this.invalidateTransportAfterOpenError(transport, actual.err)
+		}
+		return actual.channel, actual.requests, actual.err
+	case <-ctx.Done():
+		actual := <-completed
+		if actual.channel != nil {
+			_ = actual.channel.Close()
+		}
+		return nil, nil, ctx.Err()
+	}
+}
+
+func (this *sshEnvironment) invalidateTransportAfterOpenError(transport *sshTransport, err error) {
+	var rejection *gossh.OpenChannelError
+	if !errors.As(err, &rejection) {
+		this.repository.removeTransport(this.connection.Id(), transport)
+	}
+}
+
+func (this *sshEnvironment) IsPortForwardingAllowed(bnet.HostPort) (bool, error) {
+	return this.settings.forwardAllowed, nil
+}
+
+func (*sshEnvironment) IsReversePortForwardingAllowed(bnet.HostPort) (bool, error) {
+	return false, nil
+}
+
+func (this *sshEnvironment) NewDestinationConnection(ctx context.Context, destination bnet.HostPort) (io.ReadWriteCloser, error) {
+	transport, err := this.repository.transportFor(this, ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := transport.acquireChannel(ctx); err != nil {
+		return nil, err
+	}
+	type result struct {
+		connection gonet.Conn
+		err        error
+	}
+	completed := make(chan result, 1)
+	go func() {
+		connection, err := transport.client.Dial("tcp", destination.String())
+		completed <- result{connection, err}
+	}()
+	select {
+	case actual := <-completed:
+		if actual.err != nil {
+			transport.releaseChannel()
+			this.invalidateTransportAfterOpenError(transport, actual.err)
+			return nil, fmt.Errorf("cannot open SSH target connection to %s: %w", destination, actual.err)
+		}
+		return &sshDestinationConnection{Conn: actual.connection, release: transport.releaseChannel}, nil
+	case <-ctx.Done():
+		go func() {
+			defer transport.releaseChannel()
+			actual := <-completed
+			if actual.connection != nil {
+				_ = actual.connection.Close()
+			}
+		}()
+		return nil, ctx.Err()
+	}
+}
+
+type sshDestinationConnection struct {
+	gonet.Conn
+	releaseOnce sync.Once
+	release     func()
+}
+
+func (this *sshDestinationConnection) Close() error {
+	err := this.Conn.Close()
+	this.releaseOnce.Do(this.release)
+	return err
+}
+
+func (this *sshDestinationConnection) CloseWrite() error {
+	if connection, ok := this.Conn.(interface{ CloseWrite() error }); ok {
+		return connection.CloseWrite()
+	}
+	return fmt.Errorf("SSH target connection does not support closing its write side")
+}
+
+func (this *sshEnvironment) Dispose(context.Context) (bool, error) { return false, nil }
+
+func (this *sshEnvironment) Close() error { return nil }
+
+type sshAgentBridge struct {
+	listener bnet.NamedPipe
+	conn     io.Closer
+}
+
+func (this *sshAgentBridge) Close() error {
+	if this == nil {
+		return nil
+	}
+	err := this.conn.Close()
+	if closeErr := this.listener.Close(); err == nil {
+		err = closeErr
+	}
+	return err
+}
+
+type sshLifetimeSession struct {
+	essh.Session
+	context essh.Context
+}
+
+func (this *sshLifetimeSession) Context() essh.Context { return this.context }
+
+func (this *sshTransport) ensureAgent(task Task, lifetimeContext context.Context) error {
+	this.agentMu.Lock()
+	defer this.agentMu.Unlock()
+	if this.agent != nil {
+		return nil
+	}
+	// OpenSSH agent channels are connection-scoped. Phase 1 intentionally shares
+	// one source agent across all allowed sessions on this source connection.
+	lifetime, ok := lifetimeContext.(essh.Context)
+	if !ok {
+		return fmt.Errorf("connection lifetime does not provide an SSH context")
+	}
+	listener, err := bnet.NewNamedPipe("ssh-agent")
+	if err != nil {
+		return err
+	}
+	go bssh.ForwardAgentConnections(listener, task.Connection().Logger(), &sshLifetimeSession{task.SshSession(), lifetime})
+	conn, err := bnet.ConnectToNamedPipe(lifetimeContext, listener.Path())
+	if err != nil {
+		_ = listener.Close()
+		return err
+	}
+	if err := this.forwardToAgent(agent.NewClient(conn)); err != nil {
+		_ = conn.Close()
+		_ = listener.Close()
+		return err
+	}
+	this.agent = &sshAgentBridge{listener: listener, conn: conn}
+	return nil
+}
+
+func (this *sshTransport) forwardToAgent(keyring agent.Agent) error {
+	channels := this.client.HandleChannelOpen("auth-agent@openssh.com")
+	if channels == nil {
+		return fmt.Errorf("SSH agent channel handler is already registered")
+	}
+	go func() {
+		for pending := range channels {
+			if !this.tryAcquireChannel() {
+				_ = pending.Reject(gossh.ResourceShortage, "too many open SSH target channels")
+				continue
+			}
+			channel, requests, err := pending.Accept()
+			if err != nil {
+				this.releaseChannel()
+				continue
+			}
+			go gossh.DiscardRequests(requests)
+			go func() {
+				_, _ = io.Copy(io.Discard, channel.Stderr())
+			}()
+			go func() {
+				defer this.releaseChannel()
+				_ = agent.ServeAgent(keyring, channel)
+				_ = channel.Close()
+			}()
+		}
+	}()
+	return nil
+}

--- a/pkg/environment/ssh.go
+++ b/pkg/environment/ssh.go
@@ -509,7 +509,12 @@ func (this *sshDestinationConnection) CloseWrite() error {
 	return fmt.Errorf("SSH target connection does not support closing its write side")
 }
 
-func (this *sshEnvironment) Dispose(context.Context) (bool, error) { return false, nil }
+func (this *sshEnvironment) Dispose(ctx context.Context) (bool, error) {
+	if this.session == nil || this.repository == nil {
+		return false, nil
+	}
+	return this.repository.disposeUserCertificate(ctx, this.session)
+}
 
 func (this *sshEnvironment) Close() error { return nil }
 

--- a/pkg/environment/ssh_test.go
+++ b/pkg/environment/ssh_test.go
@@ -1,0 +1,561 @@
+package environment
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"io"
+	gonet "net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	log "github.com/echocat/slf4g"
+	essh "github.com/engity-com/ssh-server-go"
+	"github.com/stretchr/testify/require"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/engity-com/bifroest/pkg/authorization"
+	"github.com/engity-com/bifroest/pkg/configuration"
+	"github.com/engity-com/bifroest/pkg/connection"
+	"github.com/engity-com/bifroest/pkg/crypto"
+	bnet "github.com/engity-com/bifroest/pkg/net"
+	"github.com/engity-com/bifroest/pkg/session"
+	"github.com/engity-com/bifroest/pkg/sys"
+	"github.com/engity-com/bifroest/pkg/template"
+)
+
+func TestSshEnvironmentSharesTransportForExecSftpAndDirectTcpIp(t *testing.T) {
+	target := newSshTarget(t)
+	defer target.Close()
+
+	ctx, cancel := newSshTestContext()
+	defer cancel()
+	conn := &sshTestConnection{id: connection.MustNewId(), context: ctx}
+	sess := &sshTestStoredSession{id: session.MustNewId()}
+	auth := &sshTestAuthorization{session: sess, environment: sys.EnvVars{"LAYER": "authorization", "SSH_ORIGINAL_COMMAND": "forged-by-authorization"}}
+	hostKey := newSshTestPrivateKey(t)
+	conf := &configuration.EnvironmentSsh{}
+	require.NoError(t, conf.SetDefaults())
+	conf.Address = template.MustNewString(target.Address())
+	conf.User = template.MustNewString("target-user")
+	conf.AcceptAllHostKeys = true
+	repositoryContext := context.WithValue(context.Background(), repositoryDependenciesContextKey{}, repositoryDependencies{hostKeys: []crypto.PrivateKey{hostKey}})
+	repository, err := NewSshRepository(repositoryContext, "test", conf, nil, nil)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, repository.Close()) }()
+
+	execSession := newSshTestSession(ctx, "show-environment", nil)
+	execSession.originalCommand = "trusted-original-command"
+	execSession.hasOriginalCommand = true
+	execTask := &sshTestTask{
+		context: ctx, connection: conn, authorization: auth, session: execSession,
+		taskType: TaskTypeShell,
+		environmentVariables: configuration.EnvironmentVariables{
+			"LAYER":                template.MustNewString("flow"),
+			"SSH_ORIGINAL_COMMAND": template.MustNewString("forged-by-flow"),
+		},
+	}
+	resolved, err := repository.Ensure(execTask)
+	require.NoError(t, err)
+	environment := resolved.(*sshEnvironment)
+	type transportResult struct {
+		transport *sshTransport
+		err       error
+	}
+	transports := make(chan transportResult, 16)
+	var transportWorkers sync.WaitGroup
+	for range 16 {
+		transportWorkers.Add(1)
+		go func() {
+			defer transportWorkers.Done()
+			transport, err := repository.transportFor(environment)
+			transports <- transportResult{transport, err}
+		}()
+	}
+	transportWorkers.Wait()
+	close(transports)
+	var sharedTransport *sshTransport
+	for result := range transports {
+		require.NoError(t, result.err)
+		if sharedTransport == nil {
+			sharedTransport = result.transport
+		}
+		require.Same(t, sharedTransport, result.transport)
+	}
+	_, _, err = environment.openTargetChannel(ctx, sharedTransport, "unsupported", nil)
+	var rejection *gossh.OpenChannelError
+	require.ErrorAs(t, err, &rejection)
+	transportAfterRejection, err := repository.transportFor(environment)
+	require.NoError(t, err)
+	require.Same(t, sharedTransport, transportAfterRejection)
+
+	exitCode, err := environment.Run(execTask)
+	require.NoError(t, err)
+	require.Equal(t, 7, exitCode)
+	require.Contains(t, execSession.stdout.String(), "command=show-environment")
+	require.Contains(t, execSession.stdout.String(), "LAYER=flow")
+	require.Contains(t, execSession.stdout.String(), session.EnvName+"="+sess.id.String())
+	require.Contains(t, execSession.stdout.String(), "SSH_ORIGINAL_COMMAND=trusted-original-command")
+	require.Equal(t, "target stderr", execSession.stderr.String())
+
+	sftpSession := newSshTestSession(ctx, "", []byte("sftp-payload"))
+	sftpTask := &sshTestTask{context: ctx, connection: conn, authorization: auth, session: sftpSession, taskType: TaskTypeSftp}
+	exitCode, err = environment.Run(sftpTask)
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+	require.Equal(t, "sftp-payload", sftpSession.stdout.String())
+
+	destination, err := environment.NewDestinationConnection(ctx, bnet.MustNewHostPort("example.org:443"))
+	require.NoError(t, err)
+	_, err = destination.Write([]byte("forwarded"))
+	require.NoError(t, err)
+	require.NoError(t, destination.(interface{ CloseWrite() error }).CloseWrite())
+	forwarded, err := io.ReadAll(destination)
+	require.NoError(t, err)
+	require.Equal(t, "forwarded", string(forwarded))
+	_ = destination.Close()
+
+	require.Equal(t, int32(1), target.connections.Load())
+	cancel()
+	require.Eventually(t, func() bool {
+		repository.mutex.Lock()
+		defer repository.mutex.Unlock()
+		return len(repository.transports) == 0
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestSshEnvironmentCancellationDoesNotCloseSharedTransport(t *testing.T) {
+	target := newSshTarget(t)
+	defer target.Close()
+
+	connectionContext, cancelConnection := newSshTestContext()
+	defer cancelConnection()
+	conn := &sshTestConnection{id: connection.MustNewId(), context: connectionContext}
+	sess := &sshTestStoredSession{id: session.MustNewId()}
+	auth := &sshTestAuthorization{session: sess}
+	conf := &configuration.EnvironmentSsh{}
+	require.NoError(t, conf.SetDefaults())
+	conf.Address = template.MustNewString(target.Address())
+	conf.User = template.MustNewString("target-user")
+	conf.AcceptAllHostKeys = true
+	repository, err := NewSshRepositoryWithHostKeys(context.Background(), "test", conf, []crypto.PrivateKey{newSshTestPrivateKey(t)})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, repository.Close()) }()
+
+	taskContext, cancelTask := newSshTestContext()
+	blockedSession := newSshTestSession(taskContext, "block-request", nil)
+	blockedTask := &sshTestTask{context: taskContext, connection: conn, authorization: auth, session: blockedSession, taskType: TaskTypeShell}
+	resolved, err := repository.Ensure(blockedTask)
+	require.NoError(t, err)
+	blockedEnvironment := resolved.(*sshEnvironment)
+	transport, err := repository.transportFor(blockedEnvironment)
+	require.NoError(t, err)
+	type runResult struct {
+		code int
+		err  error
+	}
+	runDone := make(chan runResult, 1)
+	go func() {
+		code, err := blockedEnvironment.Run(blockedTask)
+		runDone <- runResult{code, err}
+	}()
+	select {
+	case <-target.blockedExec:
+	case <-time.After(time.Second):
+		t.Fatal("target did not receive blocked exec request")
+	}
+	cancelTask()
+	select {
+	case result := <-runDone:
+		require.Equal(t, -1, result.code)
+		require.ErrorIs(t, result.err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("canceled SSH task did not return")
+	}
+	require.Eventually(t, func() bool { return len(transport.channels) == 0 }, time.Second, 10*time.Millisecond)
+
+	remaining, err := repository.transportFor(blockedEnvironment)
+	require.NoError(t, err)
+	require.Same(t, transport, remaining)
+	require.Equal(t, int32(1), target.connections.Load())
+}
+
+func TestSshPtyRequestsPreservePixelDimensions(t *testing.T) {
+	sender := &sshTestRequestSender{accepted: true}
+	pty := essh.Pty{
+		Term:          "xterm",
+		Window:        essh.Window{Width: 120, Height: 40, WidthPixels: 1920, HeightPixels: 1080},
+		TerminalModes: gossh.TerminalModes{gossh.ECHO: 0},
+	}
+	require.NoError(t, requestTargetPty(sender, pty))
+	require.Equal(t, "pty-req", sender.name)
+	var initial struct {
+		Term         string
+		Columns      uint32
+		Rows         uint32
+		WidthPixels  uint32
+		HeightPixels uint32
+		Modelist     string
+	}
+	require.NoError(t, gossh.Unmarshal(sender.payload, &initial))
+	require.Equal(t, uint32(1920), initial.WidthPixels)
+	require.Equal(t, uint32(1080), initial.HeightPixels)
+
+	window := essh.Window{Width: 80, Height: 24, WidthPixels: 1280, HeightPixels: 720}
+	require.NoError(t, sendTargetWindowChange(sender, window))
+	require.Equal(t, "window-change", sender.name)
+	var changed struct {
+		Columns      uint32
+		Rows         uint32
+		WidthPixels  uint32
+		HeightPixels uint32
+	}
+	require.NoError(t, gossh.Unmarshal(sender.payload, &changed))
+	require.Equal(t, uint32(1280), changed.WidthPixels)
+	require.Equal(t, uint32(720), changed.HeightPixels)
+}
+
+func TestNewSshRepositoryWithHostKeysRejectsNilKey(t *testing.T) {
+	conf := &configuration.EnvironmentSsh{AcceptAllHostKeys: true}
+	_, err := NewSshRepositoryWithHostKeys(context.Background(), "test", conf, []crypto.PrivateKey{nil})
+	require.ErrorContains(t, err, "nil SSH host key")
+}
+
+func TestSshRepositoryRejectsEmptyRenderedAddress(t *testing.T) {
+	ctx, cancel := newSshTestContext()
+	defer cancel()
+	conf := &configuration.EnvironmentSsh{}
+	require.NoError(t, conf.SetDefaults())
+	conf.Address = template.MustNewString("   ")
+	conf.User = template.MustNewString("target-user")
+	conf.AcceptAllHostKeys = true
+	repository, err := NewSshRepositoryWithHostKeys(context.Background(), "test", conf, []crypto.PrivateKey{newSshTestPrivateKey(t)})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, repository.Close()) }()
+	storedSession := &sshTestStoredSession{id: session.MustNewId()}
+	task := &sshTestTask{
+		context:       ctx,
+		connection:    &sshTestConnection{id: connection.MustNewId(), context: ctx},
+		authorization: &sshTestAuthorization{session: storedSession},
+		session:       newSshTestSession(ctx, "true", nil),
+		taskType:      TaskTypeShell,
+	}
+	_, err = repository.resolveSettings(task)
+	require.ErrorContains(t, err, "address is empty")
+}
+
+func TestSshEnvironmentRejectsReversePortForwarding(t *testing.T) {
+	environment := &sshEnvironment{}
+	allowed, err := environment.IsReversePortForwardingAllowed(bnet.MustNewHostPort("127.0.0.1:2222"))
+	require.NoError(t, err)
+	require.False(t, allowed)
+}
+
+func TestCollectSftpExitStatusRequiresStatus(t *testing.T) {
+	requests := make(chan *gossh.Request)
+	close(requests)
+	status, err := collectSftpExitStatus(requests)
+	require.Equal(t, -1, status)
+	require.ErrorContains(t, err, "did not report an exit status")
+}
+
+type sshTestRequestSender struct {
+	name     string
+	payload  []byte
+	accepted bool
+}
+
+func (this *sshTestRequestSender) SendRequest(name string, _ bool, payload []byte) (bool, error) {
+	this.name = name
+	this.payload = append([]byte(nil), payload...)
+	return this.accepted, nil
+}
+
+type sshTarget struct {
+	listener    gonet.Listener
+	config      *gossh.ServerConfig
+	connections atomic.Int32
+	done        chan struct{}
+	closeOnce   sync.Once
+	blockedExec chan struct{}
+}
+
+func newSshTarget(t *testing.T) *sshTarget {
+	t.Helper()
+	listener, err := gonet.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	config := &gossh.ServerConfig{NoClientAuth: true}
+	config.AddHostKey(newSshTestSigner(t))
+	result := &sshTarget{
+		listener: listener, config: config, done: make(chan struct{}),
+		blockedExec: make(chan struct{}, 1),
+	}
+	go result.serve()
+	return result
+}
+
+func (this *sshTarget) Address() string { return this.listener.Addr().String() }
+
+func (this *sshTarget) Close() {
+	this.closeOnce.Do(func() {
+		close(this.done)
+		_ = this.listener.Close()
+	})
+}
+
+func (this *sshTarget) serve() {
+	for {
+		raw, err := this.listener.Accept()
+		if err != nil {
+			return
+		}
+		this.connections.Add(1)
+		go this.serveConnection(raw)
+	}
+}
+
+func (this *sshTarget) serveConnection(raw gonet.Conn) {
+	connection, channels, requests, err := gossh.NewServerConn(raw, this.config)
+	if err != nil {
+		_ = raw.Close()
+		return
+	}
+	defer func() { _ = connection.Close() }()
+	go gossh.DiscardRequests(requests)
+	for channel := range channels {
+		switch channel.ChannelType() {
+		case "session":
+			go serveSshTargetSession(channel, this.blockedExec)
+		case "direct-tcpip":
+			go serveSshTargetForward(channel)
+		default:
+			_ = channel.Reject(gossh.UnknownChannelType, "unsupported")
+		}
+	}
+}
+
+func serveSshTargetSession(channel gossh.NewChannel, blockedExec chan<- struct{}) {
+	stream, requests, err := channel.Accept()
+	if err != nil {
+		return
+	}
+	environment := make(map[string]string)
+	for request := range requests {
+		switch request.Type {
+		case "env":
+			var payload struct {
+				Name  string
+				Value string
+			}
+			if gossh.Unmarshal(request.Payload, &payload) == nil {
+				environment[payload.Name] = payload.Value
+			}
+			_ = request.Reply(true, nil)
+		case "exec":
+			var payload struct{ Command string }
+			_ = gossh.Unmarshal(request.Payload, &payload)
+			if payload.Command == "block-request" {
+				blockedExec <- struct{}{}
+				continue
+			}
+			_ = request.Reply(true, nil)
+			_, _ = io.WriteString(stream, "command="+payload.Command+" LAYER="+environment["LAYER"]+" "+session.EnvName+"="+environment[session.EnvName]+" SSH_ORIGINAL_COMMAND="+environment["SSH_ORIGINAL_COMMAND"])
+			_, _ = io.WriteString(stream.Stderr(), "target stderr")
+			_, _ = stream.SendRequest("exit-status", false, gossh.Marshal(&struct{ Status uint32 }{7}))
+			_ = stream.Close()
+			return
+		case "subsystem":
+			var payload struct{ Subsystem string }
+			_ = gossh.Unmarshal(request.Payload, &payload)
+			accepted := payload.Subsystem == "sftp"
+			_ = request.Reply(accepted, nil)
+			if !accepted {
+				_ = stream.Close()
+				return
+			}
+			_, _ = io.Copy(stream, stream)
+			_, _ = stream.SendRequest("exit-status", false, gossh.Marshal(&struct{ Status uint32 }{0}))
+			_ = stream.Close()
+			return
+		default:
+			_ = request.Reply(false, nil)
+		}
+	}
+	_ = stream.Close()
+}
+
+func serveSshTargetForward(channel gossh.NewChannel) {
+	stream, requests, err := channel.Accept()
+	if err != nil {
+		return
+	}
+	go gossh.DiscardRequests(requests)
+	_, _ = io.Copy(stream, stream)
+	_ = stream.Close()
+}
+
+func newSshTestPrivateKey(t *testing.T) crypto.PrivateKey {
+	t.Helper()
+	_, private, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	result, err := crypto.PrivateKeyFromSdk(private)
+	require.NoError(t, err)
+	return result
+}
+
+func newSshTestSigner(t *testing.T) gossh.Signer { return newSshTestPrivateKey(t).ToSsh() }
+
+type sshTestContext struct {
+	context.Context
+	sync.Mutex
+	values      map[any]any
+	permissions essh.Permissions
+}
+
+func newSshTestContext() (*sshTestContext, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &sshTestContext{Context: ctx, values: make(map[any]any)}, cancel
+}
+
+func (this *sshTestContext) User() string                   { return "source-user" }
+func (this *sshTestContext) SessionID() string              { return "test-session" }
+func (this *sshTestContext) ClientVersion() string          { return "test-client" }
+func (this *sshTestContext) ServerVersion() string          { return "test-server" }
+func (this *sshTestContext) RemoteAddr() gonet.Addr         { return sshTestAddress("remote") }
+func (this *sshTestContext) LocalAddr() gonet.Addr          { return sshTestAddress("local") }
+func (this *sshTestContext) Permissions() *essh.Permissions { return &this.permissions }
+func (this *sshTestContext) SetValue(key, value any)        { this.values[key] = value }
+func (this *sshTestContext) Value(key any) any {
+	if value, ok := this.values[key]; ok {
+		return value
+	}
+	return this.Context.Value(key)
+}
+
+type sshTestAddress string
+
+func (this sshTestAddress) Network() string { return "test" }
+func (this sshTestAddress) String() string  { return string(this) }
+
+type sshTestRemote struct{}
+
+func (sshTestRemote) User() string    { return "source-user" }
+func (sshTestRemote) Host() bnet.Host { return bnet.MustNewHost("127.0.0.1") }
+func (sshTestRemote) String() string  { return "source-user@127.0.0.1" }
+
+type sshTestConnection struct {
+	id      connection.Id
+	context *sshTestContext
+}
+
+func (this *sshTestConnection) Id() connection.Id         { return this.id }
+func (this *sshTestConnection) Remote() bnet.Remote       { return sshTestRemote{} }
+func (this *sshTestConnection) Logger() log.Logger        { return log.GetLogger("test.ssh-environment") }
+func (this *sshTestConnection) Lifetime() context.Context { return this.context }
+
+type sshTestStoredSession struct{ id session.Id }
+
+func (*sshTestStoredSession) Flow() configuration.FlowName                       { return "test" }
+func (this *sshTestStoredSession) Id() session.Id                                { return this.id }
+func (*sshTestStoredSession) Info(context.Context) (session.Info, error)         { return nil, nil }
+func (*sshTestStoredSession) AuthorizationToken(context.Context) ([]byte, error) { return nil, nil }
+func (*sshTestStoredSession) EnvironmentToken(context.Context) ([]byte, error)   { return nil, nil }
+func (*sshTestStoredSession) HasPublicKey(context.Context, gossh.PublicKey) (bool, error) {
+	return false, nil
+}
+func (*sshTestStoredSession) ConnectionInterceptor(context.Context) (session.ConnectionInterceptor, error) {
+	return nil, nil
+}
+func (*sshTestStoredSession) SetAuthorizationToken(context.Context, []byte) error    { return nil }
+func (*sshTestStoredSession) SetEnvironmentToken(context.Context, []byte) error      { return nil }
+func (*sshTestStoredSession) AddPublicKey(context.Context, gossh.PublicKey) error    { return nil }
+func (*sshTestStoredSession) DeletePublicKey(context.Context, gossh.PublicKey) error { return nil }
+func (*sshTestStoredSession) NotifyLastAccess(context.Context, bnet.Remote, session.State) (session.State, error) {
+	return session.StateUnchanged, nil
+}
+func (*sshTestStoredSession) Dispose(context.Context) (bool, error) { return false, nil }
+func (this *sshTestStoredSession) String() string                   { return this.id.String() }
+
+type sshTestAuthorization struct {
+	session     session.Session
+	environment sys.EnvVars
+}
+
+func (*sshTestAuthorization) IsAuthorized() bool                     { return true }
+func (this *sshTestAuthorization) EnvVars() sys.EnvVars              { return this.environment }
+func (*sshTestAuthorization) Flow() configuration.FlowName           { return "test" }
+func (*sshTestAuthorization) Remote() bnet.Remote                    { return sshTestRemote{} }
+func (this *sshTestAuthorization) FindSession() session.Session      { return this.session }
+func (*sshTestAuthorization) FindSessionsPublicKey() gossh.PublicKey { return nil }
+func (*sshTestAuthorization) Dispose(context.Context) (bool, error)  { return false, nil }
+
+var _ authorization.Authorization = (*sshTestAuthorization)(nil)
+
+type sshTestTask struct {
+	context              *sshTestContext
+	connection           connection.Connection
+	authorization        authorization.Authorization
+	session              essh.Session
+	taskType             TaskType
+	environmentVariables configuration.EnvironmentVariables
+}
+
+func (this *sshTestTask) Connection() connection.Connection          { return this.connection }
+func (this *sshTestTask) Context() essh.Context                      { return this.context }
+func (this *sshTestTask) Authorization() authorization.Authorization { return this.authorization }
+func (this *sshTestTask) SshSession() essh.Session                   { return this.session }
+func (this *sshTestTask) TaskType() TaskType                         { return this.taskType }
+func (this *sshTestTask) EnvironmentVariables() configuration.EnvironmentVariables {
+	return this.environmentVariables
+}
+func (*sshTestTask) StartPreparation(string, string, PreparationProgressAttributes) (PreparationProgress, error) {
+	return nil, nil
+}
+
+type sshTestSession struct {
+	context            *sshTestContext
+	command            string
+	originalCommand    string
+	hasOriginalCommand bool
+	environment        []string
+	stdin              *bytes.Reader
+	stdout             bytes.Buffer
+	stderr             bytes.Buffer
+	signals            chan<- essh.Signal
+}
+
+func newSshTestSession(ctx *sshTestContext, command string, stdin []byte) *sshTestSession {
+	return &sshTestSession{context: ctx, command: command, environment: []string{"LAYER=client", "SSH_ORIGINAL_COMMAND=forged-by-client"}, stdin: bytes.NewReader(stdin)}
+}
+
+func (this *sshTestSession) Read(value []byte) (int, error)            { return this.stdin.Read(value) }
+func (this *sshTestSession) Write(value []byte) (int, error)           { return this.stdout.Write(value) }
+func (*sshTestSession) Close() error                                   { return nil }
+func (*sshTestSession) CloseWrite() error                              { return nil }
+func (*sshTestSession) SendRequest(string, bool, []byte) (bool, error) { return false, nil }
+func (this *sshTestSession) Stderr() io.ReadWriter                     { return &this.stderr }
+func (*sshTestSession) User() string                                   { return "source-user" }
+func (*sshTestSession) RemoteAddr() gonet.Addr                         { return sshTestAddress("remote") }
+func (*sshTestSession) LocalAddr() gonet.Addr                          { return sshTestAddress("local") }
+func (this *sshTestSession) Environ() []string                         { return append([]string(nil), this.environment...) }
+func (*sshTestSession) Exit(int) error                                 { return nil }
+func (this *sshTestSession) Command() []string {
+	if this.command == "" {
+		return nil
+	}
+	return []string{this.command}
+}
+func (this *sshTestSession) RawCommand() string { return this.command }
+func (this *sshTestSession) OriginalCommand() (string, bool) {
+	return this.originalCommand, this.hasOriginalCommand
+}
+func (*sshTestSession) Subsystem() string                         { return "" }
+func (*sshTestSession) PublicKey() essh.PublicKey                 { return nil }
+func (this *sshTestSession) Context() essh.Context                { return this.context }
+func (*sshTestSession) Permissions() essh.Permissions             { return essh.Permissions{} }
+func (*sshTestSession) Pty() (essh.Pty, <-chan essh.Window, bool) { return essh.Pty{}, nil, false }
+func (this *sshTestSession) Signals(signals chan<- essh.Signal)   { this.signals = signals }
+func (*sshTestSession) Break(chan<- bool)                         {}

--- a/pkg/environment/ssh_test.go
+++ b/pkg/environment/ssh_test.go
@@ -7,6 +7,9 @@ import (
 	"crypto/rand"
 	"io"
 	gonet "net"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -183,6 +186,161 @@ func TestSshEnvironmentCancellationDoesNotCloseSharedTransport(t *testing.T) {
 	require.Equal(t, int32(1), target.connections.Load())
 }
 
+func TestSshEnvironmentPersistsUserCertificateAcrossConnectionsAndCaRotation(t *testing.T) {
+	originalCa := newSshTestPrivateKey(t)
+	rotatedCa := newSshTestPrivateKey(t)
+	originalCaFingerprint := gossh.FingerprintSHA256(originalCa.ToSsh().PublicKey())
+	receivedCertificates := make(chan *gossh.Certificate, 2)
+	checker := gossh.CertChecker{
+		IsUserAuthority: func(key gossh.PublicKey) bool {
+			return gossh.FingerprintSHA256(key) == originalCaFingerprint
+		},
+	}
+	target := newSshTargetWithPublicKeyCallback(t, func(conn gossh.ConnMetadata, key gossh.PublicKey) (*gossh.Permissions, error) {
+		if certificate, ok := key.(*gossh.Certificate); ok {
+			receivedCertificates <- certificate
+		}
+		return checker.Authenticate(conn, key)
+	})
+	defer target.Close()
+
+	directory := t.TempDir()
+	subjectFile := filepath.Join(directory, "subject")
+	originalCaFile := filepath.Join(directory, "ca")
+	rotatedCaFile := filepath.Join(directory, "rotated-ca")
+	writeSshTestPrivateKey(t, originalCaFile, originalCa)
+	writeSshTestPrivateKey(t, rotatedCaFile, rotatedCa)
+
+	newConfiguration := func(authorityFile string) *configuration.EnvironmentSsh {
+		conf := &configuration.EnvironmentSsh{}
+		require.NoError(t, conf.SetDefaults())
+		conf.Address = template.MustNewString(target.Address())
+		conf.User = template.MustNewString("target-user")
+		conf.AcceptAllHostKeys = true
+		certificate := &configuration.EnvironmentSshCertificate{}
+		require.NoError(t, certificate.SetDefaults())
+		certificate.IdentityFile = template.MustNewString(subjectFile)
+		certificate.AuthorityIdentityFile = template.MustNewString(authorityFile)
+		certificate.Validity = template.DurationOf(time.Hour)
+		certificate.Extensions = configuration.EnvironmentSshCertificateExtensions{
+			"permit-pty":             template.MustNewString(""),
+			"audit-role@example.org": template.MustNewString("production"),
+		}
+		conf.Certificate = certificate
+		return conf
+	}
+
+	storedSession := &sshTestStoredSession{id: session.MustNewId()}
+	firstContext, cancelFirst := newSshTestContext()
+	defer cancelFirst()
+	firstTask := &sshTestTask{
+		context:       firstContext,
+		connection:    &sshTestConnection{id: connection.MustNewId(), context: firstContext},
+		authorization: &sshTestAuthorization{session: storedSession},
+		session:       newSshTestSession(firstContext, "true", nil),
+		taskType:      TaskTypeShell,
+	}
+	firstRepository, err := NewSshRepositoryWithHostKeys(context.Background(), "test", newConfiguration(originalCaFile), []crypto.PrivateKey{newSshTestPrivateKey(t)})
+	require.NoError(t, err)
+
+	const workers = 16
+	environments := make(chan *sshEnvironment, workers)
+	errorsFromEnsure := make(chan error, workers)
+	var wait sync.WaitGroup
+	for range workers {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			resolved, err := firstRepository.Ensure(firstTask)
+			if err != nil {
+				errorsFromEnsure <- err
+				return
+			}
+			environments <- resolved.(*sshEnvironment)
+		}()
+	}
+	wait.Wait()
+	close(environments)
+	close(errorsFromEnsure)
+	for err := range errorsFromEnsure {
+		require.NoError(t, err)
+	}
+	require.Equal(t, int32(1), storedSession.environmentTokenWrites.Load())
+	require.FileExists(t, subjectFile)
+	firstEnvironment := <-environments
+	firstTransport, err := firstRepository.transportFor(firstEnvironment)
+	require.NoError(t, err)
+	firstCertificate := <-receivedCertificates
+	require.EqualValues(t, gossh.UserCert, firstCertificate.CertType)
+	require.Equal(t, []string{"target-user"}, firstCertificate.ValidPrincipals)
+	require.Equal(t, storedSession.id.String(), firstCertificate.Extensions["session-id@bifroest.engity.org"])
+	require.Equal(t, "production", firstCertificate.Extensions["audit-role@example.org"])
+	evidence := firstCertificate.Extensions["evidence-v1@bifroest.engity.org"]
+	require.Contains(t, evidence, `"schema":"bifroest.authorization-evidence/v1"`)
+	require.NotContains(t, strings.ToLower(evidence), "password")
+	require.NotContains(t, strings.ToLower(evidence), "token")
+	require.Equal(t, originalCaFingerprint, gossh.FingerprintSHA256(firstCertificate.SignatureKey))
+	firstCertificateBytes := firstCertificate.Marshal()
+	storedToken, err := storedSession.EnvironmentToken(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, storedToken)
+	storedState, err := decodeSshUserCertificateState(storedToken)
+	require.NoError(t, err)
+	require.Equal(t, time.Hour, storedState.MaxValidUntil.Sub(storedState.IssuedAt))
+	compatible, err := firstRepository.IsSessionCompatible(context.Background(), storedSession)
+	require.NoError(t, err)
+	require.True(t, compatible)
+	_, err = firstRepository.validateUserCertificateState(storedState, storedSession, firstEnvironment.settings, storedState.MaxValidUntil)
+	require.ErrorContains(t, err, "expired")
+	require.NoError(t, firstTransport.Close())
+	require.NoError(t, firstRepository.Close())
+
+	secondContext, cancelSecond := newSshTestContext()
+	defer cancelSecond()
+	secondTask := &sshTestTask{
+		context:       secondContext,
+		connection:    &sshTestConnection{id: connection.MustNewId(), context: secondContext},
+		authorization: &sshTestAuthorization{session: storedSession},
+		session:       newSshTestSession(secondContext, "true", nil),
+		taskType:      TaskTypeShell,
+	}
+	rotatedConfiguration := newConfiguration(rotatedCaFile)
+	rotatedConfiguration.Certificate.Validity = template.DurationOf(48 * time.Hour)
+	secondRepository, err := NewSshRepositoryWithHostKeys(context.Background(), "test", rotatedConfiguration, []crypto.PrivateKey{newSshTestPrivateKey(t)})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, secondRepository.Close()) }()
+	compatible, err = secondRepository.IsSessionCompatible(context.Background(), storedSession)
+	require.NoError(t, err)
+	require.True(t, compatible)
+	resolved, err := secondRepository.Ensure(secondTask)
+	require.NoError(t, err)
+	_, err = secondRepository.transportFor(resolved.(*sshEnvironment))
+	require.NoError(t, err)
+	secondCertificate := <-receivedCertificates
+	require.Equal(t, firstCertificateBytes, secondCertificate.Marshal())
+	storedTokenAfterRestart, err := storedSession.EnvironmentToken(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, storedToken, storedTokenAfterRestart)
+	require.Equal(t, int32(1), storedSession.environmentTokenWrites.Load())
+	changedConfiguration := newConfiguration(rotatedCaFile)
+	delete(changedConfiguration.Certificate.Extensions, "audit-role@example.org")
+	changedRepository, err := NewSshRepositoryWithHostKeys(context.Background(), "test", changedConfiguration, []crypto.PrivateKey{newSshTestPrivateKey(t)})
+	require.NoError(t, err)
+	compatible, err = changedRepository.IsSessionCompatible(context.Background(), storedSession)
+	require.NoError(t, err)
+	require.False(t, compatible)
+	require.NoError(t, changedRepository.Close())
+
+	restoredEnvironment, err := secondRepository.FindBySession(context.Background(), storedSession, nil)
+	require.NoError(t, err)
+	disposed, err := restoredEnvironment.Dispose(context.Background())
+	require.NoError(t, err)
+	require.True(t, disposed)
+	remainingToken, err := storedSession.EnvironmentToken(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, remainingToken)
+}
+
 func TestSshPtyRequestsPreservePixelDimensions(t *testing.T) {
 	sender := &sshTestRequestSender{accepted: true}
 	pty := essh.Pty{
@@ -222,6 +380,94 @@ func TestNewSshRepositoryWithHostKeysRejectsNilKey(t *testing.T) {
 	conf := &configuration.EnvironmentSsh{AcceptAllHostKeys: true}
 	_, err := NewSshRepositoryWithHostKeys(context.Background(), "test", conf, []crypto.PrivateKey{nil})
 	require.ErrorContains(t, err, "nil SSH host key")
+}
+
+func TestSshCertificateUsesFirstHostKeyAsAuthorityFallback(t *testing.T) {
+	hostKey := newSshTestPrivateKey(t)
+	conf := newSshCertificateTestConfiguration(t, filepath.Join(t.TempDir(), "subject"), "")
+	repository, err := NewSshRepositoryWithHostKeys(context.Background(), "test", conf, []crypto.PrivateKey{hostKey, newSshTestPrivateKey(t)})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, repository.Close()) }()
+	require.Equal(t, gossh.FingerprintSHA256(hostKey.ToSsh().PublicKey()), repository.certificateKeys.authorityFingerprint)
+}
+
+func TestSshCertificateRejectsInvalidExistingKeys(t *testing.T) {
+	directory := t.TempDir()
+	hostKey := newSshTestPrivateKey(t)
+	for _, test := range []struct {
+		name      string
+		subject   string
+		authority string
+	}{
+		{name: "subject", subject: "invalid", authority: ""},
+		{name: "authority", subject: "", authority: "invalid"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			subjectFile := filepath.Join(directory, test.name+"-subject")
+			authorityFile := ""
+			if test.subject != "" {
+				require.NoError(t, os.WriteFile(subjectFile, []byte(test.subject), 0600))
+			}
+			if test.authority != "" {
+				authorityFile = filepath.Join(directory, test.name+"-authority")
+				require.NoError(t, os.WriteFile(authorityFile, []byte(test.authority), 0600))
+			}
+			conf := newSshCertificateTestConfiguration(t, subjectFile, authorityFile)
+			_, err := NewSshRepositoryWithHostKeys(context.Background(), "test", conf, []crypto.PrivateKey{hostKey})
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestSshCertificateSessionCompatibilityUsesCurrentAuthorizationContext(t *testing.T) {
+	conf := newSshCertificateTestConfiguration(t, filepath.Join(t.TempDir(), "subject"), "")
+	conf.User = template.MustNewString("{{ .targetUser }}")
+	conf.Certificate.Principals = template.MustNewStrings("{{ .targetUser }}")
+	conf.Certificate.Extensions = configuration.EnvironmentSshCertificateExtensions{
+		"permit-port-forwarding": template.MustNewString(""),
+	}
+	repository, err := NewSshRepositoryWithHostKeys(context.Background(), "test", conf, []crypto.PrivateKey{newSshTestPrivateKey(t)})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, repository.Close()) }()
+
+	ctx, cancel := newSshTestContext()
+	defer cancel()
+	storedSession := &sshTestStoredSession{id: session.MustNewId()}
+	base := &sshTestTask{
+		context:       ctx,
+		connection:    &sshTestConnection{id: connection.MustNewId(), context: ctx},
+		authorization: &sshTestAuthorization{session: storedSession, kind: "simple"},
+		session:       newSshTestSession(ctx, "true", nil),
+		taskType:      TaskTypeShell,
+		targetUser:    "target-user",
+	}
+	_, err = repository.Ensure(base)
+	require.NoError(t, err)
+	compatible, err := repository.IsSessionCompatibleWith(base, storedSession)
+	require.NoError(t, err)
+	require.True(t, compatible)
+
+	changedUser := *base
+	changedUser.targetUser = "other-user"
+	compatible, err = repository.IsSessionCompatibleWith(&changedUser, storedSession)
+	require.NoError(t, err)
+	require.False(t, compatible)
+
+	changedKind := *base
+	changedKind.authorization = &sshTestAuthorization{session: storedSession, kind: "htpasswd"}
+	compatible, err = repository.IsSessionCompatibleWith(&changedKind, storedSession)
+	require.NoError(t, err)
+	require.False(t, compatible)
+
+	changedPolicy := *base
+	changedPolicy.authorization = &sshTestAuthorization{
+		session: storedSession,
+		kind:    "simple",
+		policy:  &authorization.AuthorizedKeyPolicy{PtyAllowed: true, PortForwardingAllowed: false, AgentForwardingAllowed: true},
+	}
+	compatible, err = repository.IsSessionCompatibleWith(&changedPolicy, storedSession)
+	require.NoError(t, err)
+	require.False(t, compatible)
 }
 
 func TestSshRepositoryRejectsEmptyRenderedAddress(t *testing.T) {
@@ -284,10 +530,14 @@ type sshTarget struct {
 }
 
 func newSshTarget(t *testing.T) *sshTarget {
+	return newSshTargetWithPublicKeyCallback(t, nil)
+}
+
+func newSshTargetWithPublicKeyCallback(t *testing.T, callback func(gossh.ConnMetadata, gossh.PublicKey) (*gossh.Permissions, error)) *sshTarget {
 	t.Helper()
 	listener, err := gonet.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	config := &gossh.ServerConfig{NoClientAuth: true}
+	config := &gossh.ServerConfig{NoClientAuth: callback == nil, PublicKeyCallback: callback}
 	config.AddHostKey(newSshTestSigner(t))
 	result := &sshTarget{
 		listener: listener, config: config, done: make(chan struct{}),
@@ -408,6 +658,29 @@ func newSshTestPrivateKey(t *testing.T) crypto.PrivateKey {
 
 func newSshTestSigner(t *testing.T) gossh.Signer { return newSshTestPrivateKey(t).ToSsh() }
 
+func writeSshTestPrivateKey(t *testing.T, path string, key crypto.PrivateKey) {
+	t.Helper()
+	var content bytes.Buffer
+	require.NoError(t, crypto.WriteSshPrivateKey(key, &content))
+	require.NoError(t, os.WriteFile(path, content.Bytes(), 0600))
+}
+
+func newSshCertificateTestConfiguration(t *testing.T, subjectFile, authorityFile string) *configuration.EnvironmentSsh {
+	t.Helper()
+	conf := &configuration.EnvironmentSsh{}
+	require.NoError(t, conf.SetDefaults())
+	conf.Address = template.MustNewString("target.example.org:22")
+	conf.User = template.MustNewString("target-user")
+	conf.AcceptAllHostKeys = true
+	certificate := &configuration.EnvironmentSshCertificate{}
+	require.NoError(t, certificate.SetDefaults())
+	certificate.IdentityFile = template.MustNewString(subjectFile)
+	certificate.AuthorityIdentityFile = template.MustNewString(authorityFile)
+	certificate.Validity = template.DurationOf(time.Hour)
+	conf.Certificate = certificate
+	return conf
+}
+
 type sshTestContext struct {
 	context.Context
 	sync.Mutex
@@ -456,21 +729,36 @@ func (this *sshTestConnection) Remote() bnet.Remote       { return sshTestRemote
 func (this *sshTestConnection) Logger() log.Logger        { return log.GetLogger("test.ssh-environment") }
 func (this *sshTestConnection) Lifetime() context.Context { return this.context }
 
-type sshTestStoredSession struct{ id session.Id }
+type sshTestStoredSession struct {
+	id                     session.Id
+	mutex                  sync.Mutex
+	environmentToken       []byte
+	environmentTokenWrites atomic.Int32
+}
 
 func (*sshTestStoredSession) Flow() configuration.FlowName                       { return "test" }
 func (this *sshTestStoredSession) Id() session.Id                                { return this.id }
 func (*sshTestStoredSession) Info(context.Context) (session.Info, error)         { return nil, nil }
 func (*sshTestStoredSession) AuthorizationToken(context.Context) ([]byte, error) { return nil, nil }
-func (*sshTestStoredSession) EnvironmentToken(context.Context) ([]byte, error)   { return nil, nil }
+func (this *sshTestStoredSession) EnvironmentToken(context.Context) ([]byte, error) {
+	this.mutex.Lock()
+	defer this.mutex.Unlock()
+	return append([]byte(nil), this.environmentToken...), nil
+}
 func (*sshTestStoredSession) HasPublicKey(context.Context, gossh.PublicKey) (bool, error) {
 	return false, nil
 }
 func (*sshTestStoredSession) ConnectionInterceptor(context.Context) (session.ConnectionInterceptor, error) {
 	return nil, nil
 }
-func (*sshTestStoredSession) SetAuthorizationToken(context.Context, []byte) error    { return nil }
-func (*sshTestStoredSession) SetEnvironmentToken(context.Context, []byte) error      { return nil }
+func (*sshTestStoredSession) SetAuthorizationToken(context.Context, []byte) error { return nil }
+func (this *sshTestStoredSession) SetEnvironmentToken(_ context.Context, value []byte) error {
+	this.mutex.Lock()
+	defer this.mutex.Unlock()
+	this.environmentToken = append([]byte(nil), value...)
+	this.environmentTokenWrites.Add(1)
+	return nil
+}
 func (*sshTestStoredSession) AddPublicKey(context.Context, gossh.PublicKey) error    { return nil }
 func (*sshTestStoredSession) DeletePublicKey(context.Context, gossh.PublicKey) error { return nil }
 func (*sshTestStoredSession) NotifyLastAccess(context.Context, bnet.Remote, session.State) (session.State, error) {
@@ -482,6 +770,8 @@ func (this *sshTestStoredSession) String() string                   { return thi
 type sshTestAuthorization struct {
 	session     session.Session
 	environment sys.EnvVars
+	kind        string
+	policy      *authorization.AuthorizedKeyPolicy
 }
 
 func (*sshTestAuthorization) IsAuthorized() bool                     { return true }
@@ -491,6 +781,10 @@ func (*sshTestAuthorization) Remote() bnet.Remote                    { return ss
 func (this *sshTestAuthorization) FindSession() session.Session      { return this.session }
 func (*sshTestAuthorization) FindSessionsPublicKey() gossh.PublicKey { return nil }
 func (*sshTestAuthorization) Dispose(context.Context) (bool, error)  { return false, nil }
+func (this *sshTestAuthorization) AuthorizationKind() string         { return this.kind }
+func (this *sshTestAuthorization) AuthorizedKeyPolicy() *authorization.AuthorizedKeyPolicy {
+	return this.policy
+}
 
 var _ authorization.Authorization = (*sshTestAuthorization)(nil)
 
@@ -501,6 +795,14 @@ type sshTestTask struct {
 	session              essh.Session
 	taskType             TaskType
 	environmentVariables configuration.EnvironmentVariables
+	targetUser           string
+}
+
+func (this *sshTestTask) GetField(name string) (any, bool, error) {
+	if name == "targetUser" {
+		return this.targetUser, true, nil
+	}
+	return nil, false, nil
 }
 
 func (this *sshTestTask) Connection() connection.Connection          { return this.connection }

--- a/pkg/environment/ssh_test.go
+++ b/pkg/environment/ssh_test.go
@@ -236,7 +236,7 @@ func TestSshEnvironmentPersistsUserCertificateAcrossConnectionsAndCaRotation(t *
 	firstTask := &sshTestTask{
 		context:       firstContext,
 		connection:    &sshTestConnection{id: connection.MustNewId(), context: firstContext},
-		authorization: &sshTestAuthorization{session: storedSession},
+		authorization: &sshTestAuthorization{session: storedSession, kind: "simple"},
 		session:       newSshTestSession(firstContext, "true", nil),
 		taskType:      TaskTypeShell,
 	}
@@ -273,12 +273,13 @@ func TestSshEnvironmentPersistsUserCertificateAcrossConnectionsAndCaRotation(t *
 	firstCertificate := <-receivedCertificates
 	require.EqualValues(t, gossh.UserCert, firstCertificate.CertType)
 	require.Equal(t, []string{"target-user"}, firstCertificate.ValidPrincipals)
-	require.Equal(t, storedSession.id.String(), firstCertificate.Extensions["session-id@bifroest.engity.org"])
 	require.Equal(t, "production", firstCertificate.Extensions["audit-role@example.org"])
-	evidence := firstCertificate.Extensions["evidence-v1@bifroest.engity.org"]
-	require.Contains(t, evidence, `"schema":"bifroest.authorization-evidence/v1"`)
-	require.NotContains(t, strings.ToLower(evidence), "password")
-	require.NotContains(t, strings.ToLower(evidence), "token")
+	evidenceRaw := firstCertificate.Extensions[authorization.AuthorizationEvidenceExtension]
+	evidence, err := authorization.DecodeAuthorizationEvidence([]byte(evidenceRaw))
+	require.NoError(t, err)
+	require.Equal(t, storedSession.id.String(), evidence.LastHop().SessionId)
+	require.NotContains(t, strings.ToLower(evidenceRaw), "password")
+	require.NotContains(t, strings.ToLower(evidenceRaw), "token")
 	require.Equal(t, originalCaFingerprint, gossh.FingerprintSHA256(firstCertificate.SignatureKey))
 	firstCertificateBytes := firstCertificate.Marshal()
 	storedToken, err := storedSession.EnvironmentToken(context.Background())
@@ -287,6 +288,11 @@ func TestSshEnvironmentPersistsUserCertificateAcrossConnectionsAndCaRotation(t *
 	storedState, err := decodeSshUserCertificateState(storedToken)
 	require.NoError(t, err)
 	require.Equal(t, time.Hour, storedState.MaxValidUntil.Sub(storedState.IssuedAt))
+	transplantedSession := &sshTestStoredSession{id: session.MustNewId()}
+	transplantedState := *storedState
+	transplantedState.SessionId = transplantedSession.id.String()
+	_, err = firstRepository.validateUserCertificateState(&transplantedState, transplantedSession, firstEnvironment.settings, time.Now())
+	require.ErrorContains(t, err, "evidence does not match its session metadata")
 	compatible, err := firstRepository.IsSessionCompatible(context.Background(), storedSession)
 	require.NoError(t, err)
 	require.True(t, compatible)
@@ -300,7 +306,7 @@ func TestSshEnvironmentPersistsUserCertificateAcrossConnectionsAndCaRotation(t *
 	secondTask := &sshTestTask{
 		context:       secondContext,
 		connection:    &sshTestConnection{id: connection.MustNewId(), context: secondContext},
-		authorization: &sshTestAuthorization{session: storedSession},
+		authorization: &sshTestAuthorization{session: storedSession, kind: "simple"},
 		session:       newSshTestSession(secondContext, "true", nil),
 		taskType:      TaskTypeShell,
 	}
@@ -382,13 +388,38 @@ func TestNewSshRepositoryWithHostKeysRejectsNilKey(t *testing.T) {
 	require.ErrorContains(t, err, "nil SSH host key")
 }
 
-func TestSshCertificateUsesFirstHostKeyAsAuthorityFallback(t *testing.T) {
+func TestSshCertificateUsesDedicatedAuthorityInsteadOfHostKey(t *testing.T) {
 	hostKey := newSshTestPrivateKey(t)
-	conf := newSshCertificateTestConfiguration(t, filepath.Join(t.TempDir(), "subject"), "")
+	directory := t.TempDir()
+	authorityFile := filepath.Join(directory, "ca")
+	conf := newSshCertificateTestConfiguration(t, filepath.Join(directory, "subject"), authorityFile)
 	repository, err := NewSshRepositoryWithHostKeys(context.Background(), "test", conf, []crypto.PrivateKey{hostKey, newSshTestPrivateKey(t)})
 	require.NoError(t, err)
 	defer func() { require.NoError(t, repository.Close()) }()
-	require.Equal(t, gossh.FingerprintSHA256(hostKey.ToSsh().PublicKey()), repository.certificateKeys.authorityFingerprint)
+	require.FileExists(t, authorityFile)
+	require.NotEqual(t, gossh.FingerprintSHA256(hostKey.ToSsh().PublicKey()), repository.certificateKeys.authorityFingerprint)
+}
+
+func TestSshCertificateRejectsAuthorityThatReusesHostKey(t *testing.T) {
+	directory := t.TempDir()
+	hostKey := newSshTestPrivateKey(t)
+	authorityFile := filepath.Join(directory, "ca")
+	writeSshTestPrivateKey(t, authorityFile, hostKey)
+	conf := newSshCertificateTestConfiguration(t, filepath.Join(directory, "subject"), authorityFile)
+
+	_, err := NewSshRepositoryWithHostKeys(context.Background(), "test", conf, []crypto.PrivateKey{hostKey})
+	require.ErrorContains(t, err, "must not reuse an SSH server host key")
+}
+
+func TestSshCertificateConfigurationKeyNormalizesDefaultPort(t *testing.T) {
+	directory := t.TempDir()
+	conf := newSshCertificateTestConfiguration(t, filepath.Join(directory, "subject"), filepath.Join(directory, "ca"))
+	conf.Address = template.MustNewString("target.example.org")
+	implicit := sshCertificateConfigurationKey(conf)
+	conf.Address = template.MustNewString("target.example.org:22")
+	require.Equal(t, implicit, sshCertificateConfigurationKey(conf))
+	conf.Address = template.MustNewString("target.example.org:2222")
+	require.NotEqual(t, implicit, sshCertificateConfigurationKey(conf))
 }
 
 func TestSshCertificateRejectsInvalidExistingKeys(t *testing.T) {
@@ -470,6 +501,25 @@ func TestSshCertificateSessionCompatibilityUsesCurrentAuthorizationContext(t *te
 	require.False(t, compatible)
 }
 
+func TestSshCertificateRejectsNonEmptyCapabilityExtensionValue(t *testing.T) {
+	conf := newSshCertificateTestConfiguration(t, filepath.Join(t.TempDir(), "subject"), "")
+	conf.Certificate.Extensions = configuration.EnvironmentSshCertificateExtensions{
+		"permit-pty": template.MustNewString("not-empty"),
+	}
+	repository, err := NewSshRepositoryWithHostKeys(context.Background(), "test", conf, []crypto.PrivateKey{newSshTestPrivateKey(t)})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, repository.Close()) }()
+	ctx, cancel := newSshTestContext()
+	defer cancel()
+	task := &sshTestTask{
+		context: ctx, connection: &sshTestConnection{id: connection.MustNewId(), context: ctx},
+		authorization: &sshTestAuthorization{session: &sshTestStoredSession{id: session.MustNewId()}, kind: "simple"},
+		session:       newSshTestSession(ctx, "true", nil), taskType: TaskTypeShell,
+	}
+	_, err = repository.resolveSettings(task)
+	require.ErrorContains(t, err, "must have an empty value")
+}
+
 func TestSshRepositoryRejectsEmptyRenderedAddress(t *testing.T) {
 	ctx, cancel := newSshTestContext()
 	defer cancel()
@@ -490,7 +540,7 @@ func TestSshRepositoryRejectsEmptyRenderedAddress(t *testing.T) {
 		taskType:      TaskTypeShell,
 	}
 	_, err = repository.resolveSettings(task)
-	require.ErrorContains(t, err, "address is empty")
+	require.ErrorContains(t, err, "host is empty")
 }
 
 func TestSshEnvironmentRejectsReversePortForwarding(t *testing.T) {
@@ -675,6 +725,9 @@ func newSshCertificateTestConfiguration(t *testing.T, subjectFile, authorityFile
 	certificate := &configuration.EnvironmentSshCertificate{}
 	require.NoError(t, certificate.SetDefaults())
 	certificate.IdentityFile = template.MustNewString(subjectFile)
+	if authorityFile == "" {
+		authorityFile = filepath.Join(filepath.Dir(subjectFile), "ca")
+	}
 	certificate.AuthorityIdentityFile = template.MustNewString(authorityFile)
 	certificate.Validity = template.DurationOf(time.Hour)
 	conf.Certificate = certificate

--- a/pkg/environment/task.go
+++ b/pkg/environment/task.go
@@ -2,9 +2,12 @@ package environment
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	essh "github.com/engity-com/ssh-server-go"
 
+	"github.com/engity-com/bifroest/pkg/configuration"
 	"github.com/engity-com/bifroest/pkg/sys"
 )
 
@@ -32,6 +35,85 @@ type Task interface {
 	Context
 	SshSession() essh.Session
 	TaskType() TaskType
+}
+
+type environmentVariablesProvider interface {
+	EnvironmentVariables() configuration.EnvironmentVariables
+}
+
+type layeredSshEnvironmentProvider interface {
+	ClientEnvironment() []string
+	AuthorizedKeyEnvironment() sys.EnvVars
+}
+
+type originalCommandProvider interface {
+	OriginalCommand() (string, bool)
+}
+
+func applyTaskEnvironment(environment *sys.EnvVars, targetOs sys.Os, task Task) error {
+	if provider, ok := task.SshSession().(layeredSshEnvironmentProvider); ok {
+		addEnvironmentEntries(environment, targetOs, provider.ClientEnvironment())
+		if err := addEnvironmentLayer(environment, targetOs, provider.AuthorizedKeyEnvironment()); err != nil {
+			return fmt.Errorf("cannot apply authorized-key environment variables: %w", err)
+		}
+	} else {
+		addEnvironmentEntries(environment, targetOs, task.SshSession().Environ())
+	}
+	if err := addEnvironmentLayer(environment, targetOs, task.Authorization().EnvVars()); err != nil {
+		return fmt.Errorf("cannot apply authorization environment variables: %w", err)
+	}
+	if provider, ok := task.(environmentVariablesProvider); ok {
+		values, err := provider.EnvironmentVariables().Render(task)
+		if err != nil {
+			return fmt.Errorf("cannot render environment variables: %w", err)
+		}
+		if err := addEnvironmentLayer(environment, targetOs, values); err != nil {
+			return fmt.Errorf("cannot apply environment variables: %w", err)
+		}
+	}
+	if provider, ok := task.SshSession().(originalCommandProvider); ok {
+		if value, present := provider.OriginalCommand(); present {
+			setReservedEnvironment(environment, targetOs, "SSH_ORIGINAL_COMMAND", value)
+		}
+	}
+	return nil
+}
+
+func addEnvironmentEntries(environment *sys.EnvVars, targetOs sys.Os, values []string) {
+	for _, value := range values {
+		key, value, _ := strings.Cut(value, "=")
+		if targetOs == sys.OsWindows {
+			environment.SetCanonical(key, value)
+		} else {
+			environment.Set(key, value)
+		}
+	}
+}
+
+func addEnvironmentLayer(environment *sys.EnvVars, targetOs sys.Os, values sys.EnvVars) error {
+	keys := make([]string, 0, len(values))
+	seen := make([]string, 0, len(values))
+	for key := range values {
+		if targetOs == sys.OsWindows {
+			for _, existing := range seen {
+				if strings.EqualFold(existing, key) {
+					return fmt.Errorf("ambiguous case-insensitive environment variables %q and %q", existing, key)
+				}
+			}
+			seen = append(seen, key)
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		value := values[key]
+		if targetOs == sys.OsWindows {
+			environment.SetCanonical(key, value)
+		} else {
+			environment.Set(key, value)
+		}
+	}
+	return nil
 }
 
 func signalFromSsh(value essh.Signal) (sys.Signal, error) {

--- a/pkg/service/authorized-key-session.go
+++ b/pkg/service/authorized-key-session.go
@@ -10,8 +10,12 @@ import (
 
 type authorizedKeySession struct {
 	essh.Session
-	command     string
-	environment sys.EnvVars
+	command                  string
+	originalCommand          string
+	hasOriginalCommand       bool
+	environment              sys.EnvVars
+	clientEnvironment        []string
+	authorizedKeyEnvironment sys.EnvVars
 }
 
 func applyAuthorizedKeyPolicy(auth authorization.Authorization, session essh.Session) (essh.Session, bool) {
@@ -23,17 +27,24 @@ func applyAuthorizedKeyPolicy(auth authorization.Authorization, session essh.Ses
 	environment := sys.EnvVars{}
 	environment.Add(session.Environ()...)
 	environment.AddAllOf(policy.Environment)
-	command := session.RawCommand()
+	authorizedKeyEnvironment := policy.Environment.Clone()
+	originalCommand := session.RawCommand()
+	command := originalCommand
 	forced := policy.ForcedCommand != nil
 	if forced {
 		environment.Set("SSH_ORIGINAL_COMMAND", command)
+		authorizedKeyEnvironment.Set("SSH_ORIGINAL_COMMAND", command)
 		command = *policy.ForcedCommand
 	}
 
 	return &authorizedKeySession{
-		Session:     session,
-		command:     command,
-		environment: environment,
+		Session:                  session,
+		command:                  command,
+		originalCommand:          originalCommand,
+		hasOriginalCommand:       forced,
+		environment:              environment,
+		clientEnvironment:        session.Environ(),
+		authorizedKeyEnvironment: authorizedKeyEnvironment,
 	}, forced
 }
 
@@ -48,4 +59,16 @@ func (this *authorizedKeySession) Command() []string {
 
 func (this *authorizedKeySession) Environ() []string {
 	return this.environment.Strings()
+}
+
+func (this *authorizedKeySession) ClientEnvironment() []string {
+	return append([]string(nil), this.clientEnvironment...)
+}
+
+func (this *authorizedKeySession) AuthorizedKeyEnvironment() sys.EnvVars {
+	return this.authorizedKeyEnvironment.Clone()
+}
+
+func (this *authorizedKeySession) OriginalCommand() (string, bool) {
+	return this.originalCommand, this.hasOriginalCommand
 }

--- a/pkg/service/authorized-keys-restrictions_test.go
+++ b/pkg/service/authorized-keys-restrictions_test.go
@@ -103,6 +103,61 @@ func TestRestrictedAuthorizedKeyAllowsAuthenticationConditions(t *testing.T) {
 	}
 }
 
+func TestNewAuthorizationSessionDoesNotRequireEnvironmentCompatibility(t *testing.T) {
+	server := newAuthorizedKeysTestServer(t, "", &authorizedKeysTestEnvironment{})
+	repository := server.service.environments.(*authorizedKeysTestRepository)
+	repository.isSessionCompatible = func(environment.Context, session.Session) (bool, error) {
+		return false, nil
+	}
+
+	client, err := server.dial()
+	require.NoError(t, err)
+	require.NoError(t, client.Close())
+}
+
+func TestPublicKeyAuthenticationSkipsIncompatibleSession(t *testing.T) {
+	server := newAuthorizedKeysTestServer(t, "", &authorizedKeysTestEnvironment{})
+	ctx := context.Background()
+	remote := authorizedKeysTestRemote{user: server.username}
+	sessions := make([]session.Session, 2)
+	for i := range sessions {
+		var err error
+		sessions[i], err = server.service.sessions.Create(ctx, "restricted-key", remote, nil)
+		require.NoError(t, err)
+		require.NoError(t, sessions[i].AddPublicKey(ctx, server.signer.PublicKey()))
+		_, err = sessions[i].NotifyLastAccess(ctx, remote, session.StateAuthorized)
+		require.NoError(t, err)
+	}
+	var searchOrder []session.Id
+	require.NoError(t, server.service.sessions.FindAll(ctx, func(_ context.Context, candidate session.Session) (bool, error) {
+		searchOrder = append(searchOrder, candidate.Id())
+		return true, nil
+	}, nil))
+	require.Len(t, searchOrder, 2)
+	compatibleId := searchOrder[1]
+
+	repository := server.service.environments.(*authorizedKeysTestRepository)
+	var incompatibleChecked bool
+	repository.isSessionCompatible = func(ctx environment.Context, candidate session.Session) (bool, error) {
+		fieldContext := ctx.(interface {
+			GetField(string) (any, bool, error)
+		})
+		value, found, err := fieldContext.GetField("authorization")
+		require.NoError(t, err)
+		require.True(t, found)
+		candidateAuthorization := value.(authorization.Authorization)
+		require.Equal(t, candidate.Id(), candidateAuthorization.FindSession().Id())
+		compatible := candidate.Id() == compatibleId
+		incompatibleChecked = incompatibleChecked || !compatible
+		return compatible, nil
+	}
+
+	client, err := server.dial()
+	require.NoError(t, err)
+	require.NoError(t, client.Close())
+	require.True(t, incompatibleChecked)
+}
+
 func TestRestrictedAuthorizedKeyRejectsPty(t *testing.T) {
 	for _, options := range []string{"no-pty", "restrict"} {
 		t.Run(options, func(t *testing.T) {
@@ -734,8 +789,17 @@ func (this *authorizedKeysTestServer) mustDial(t *testing.T) *gossh.Client {
 }
 
 type authorizedKeysTestRepository struct {
-	environment *authorizedKeysTestEnvironment
+	environment         *authorizedKeysTestEnvironment
+	isSessionCompatible func(environment.Context, session.Session) (bool, error)
 }
+
+type authorizedKeysTestRemote struct {
+	user string
+}
+
+func (this authorizedKeysTestRemote) User() string   { return this.user }
+func (authorizedKeysTestRemote) Host() bnet.Host     { return bnet.Host{} }
+func (this authorizedKeysTestRemote) String() string { return this.user }
 
 func (*authorizedKeysTestRepository) WillBeAccepted(environment.Context) (bool, error) {
 	return true, nil
@@ -759,6 +823,13 @@ func (*authorizedKeysTestRepository) Cleanup(context.Context, *environment.Clean
 
 func (*authorizedKeysTestRepository) Close() error {
 	return nil
+}
+
+func (this *authorizedKeysTestRepository) IsSessionCompatibleWith(ctx environment.Context, sess session.Session) (bool, error) {
+	if this.isSessionCompatible == nil {
+		return true, nil
+	}
+	return this.isSessionCompatible(ctx, sess)
 }
 
 type authorizedKeysTestEnvironment struct {

--- a/pkg/service/authorized-keys-restrictions_test.go
+++ b/pkg/service/authorized-keys-restrictions_test.go
@@ -409,6 +409,20 @@ func TestEnvironmentRejectsReversePortForwarding(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestEnvironmentReversePortForwardingPolicyOverridesDirectForwarding(t *testing.T) {
+	reverseAllowed := false
+	server := newAuthorizedKeysTestServer(t, "", &authorizedKeysTestEnvironment{
+		portForwardingAllowed:        true,
+		reversePortForwardingAllowed: &reverseAllowed,
+	})
+	client := server.mustDial(t)
+	listener, err := client.Listen("tcp", "127.0.0.1:0")
+	if listener != nil {
+		_ = listener.Close()
+	}
+	require.Error(t, err)
+}
+
 func TestMaxReverseForwardsPerConnectionIsEnforced(t *testing.T) {
 	server := newAuthorizedKeysTestServerWithConfiguration(t, "", &authorizedKeysTestEnvironment{portForwardingAllowed: true}, func(conf *configuration.Configuration) {
 		conf.Ssh.MaxReverseForwardsPerConnection = 1
@@ -748,8 +762,9 @@ func (*authorizedKeysTestRepository) Close() error {
 }
 
 type authorizedKeysTestEnvironment struct {
-	run                   func(environment.Task) (int, error)
-	portForwardingAllowed bool
+	run                          func(environment.Task) (int, error)
+	portForwardingAllowed        bool
+	reversePortForwardingAllowed *bool
 }
 
 func (*authorizedKeysTestEnvironment) Banner(environment.Request) (io.ReadCloser, error) {
@@ -765,6 +780,13 @@ func (this *authorizedKeysTestEnvironment) Run(task environment.Task) (int, erro
 
 func (this *authorizedKeysTestEnvironment) IsPortForwardingAllowed(bnet.HostPort) (bool, error) {
 	return this.portForwardingAllowed, nil
+}
+
+func (this *authorizedKeysTestEnvironment) IsReversePortForwardingAllowed(bnet.HostPort) (bool, error) {
+	if this.reversePortForwardingAllowed == nil {
+		return this.portForwardingAllowed, nil
+	}
+	return *this.reversePortForwardingAllowed, nil
 }
 
 func (*authorizedKeysTestEnvironment) NewDestinationConnection(context.Context, bnet.HostPort) (io.ReadWriteCloser, error) {

--- a/pkg/service/authorized-keys-restrictions_test.go
+++ b/pkg/service/authorized-keys-restrictions_test.go
@@ -726,8 +726,10 @@ flows:
 
 	svc, err := (&Service{Configuration: conf, Version: serviceTestVersion{}}).prepare()
 	require.NoError(t, err)
-	require.NoError(t, svc.environments.Close())
-	svc.environments = &authorizedKeysTestRepository{environment: testEnvironment}
+	if testEnvironment != nil {
+		require.NoError(t, svc.environments.Close())
+		svc.environments = &authorizedKeysTestRepository{environment: testEnvironment}
+	}
 
 	listener, err := gonet.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)

--- a/pkg/service/authorized-keys-restrictions_test.go
+++ b/pkg/service/authorized-keys-restrictions_test.go
@@ -685,6 +685,11 @@ func newAuthorizedKeysTestServer(t *testing.T, options string, testEnvironment *
 func newAuthorizedKeysTestServerWithConfiguration(t *testing.T, options string, testEnvironment *authorizedKeysTestEnvironment, configure func(*configuration.Configuration)) *authorizedKeysTestServer {
 	t.Helper()
 	const username = "restricted-key-user"
+	return newAuthorizedKeysTestServerWithUsernameAndConfiguration(t, username, options, testEnvironment, configure)
+}
+
+func newAuthorizedKeysTestServerWithUsernameAndConfiguration(t *testing.T, username, options string, testEnvironment *authorizedKeysTestEnvironment, configure func(*configuration.Configuration)) *authorizedKeysTestServer {
+	t.Helper()
 
 	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
 	require.NoError(t, err)

--- a/pkg/service/connection.go
+++ b/pkg/service/connection.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	gonet "net"
 	"os"
@@ -151,6 +152,10 @@ func (this *connection) Remote() net.Remote {
 
 func (this *connection) Logger() log.Logger {
 	return this.logger
+}
+
+func (this *connection) Lifetime() context.Context {
+	return this.context
 }
 
 func (this *connection) doWithInterceptor(consumer func(session.ConnectionInterceptor) error) error {

--- a/pkg/service/context.go
+++ b/pkg/service/context.go
@@ -112,6 +112,7 @@ func (this *authorizeRequest) IsSessionCompatible(auth authorization.Authorizati
 type publicKeyAuthorizeRequest struct {
 	authorizeRequest
 	publicKey gossh.PublicKey
+	verified  bool
 }
 
 func (this *publicKeyAuthorizeRequest) GetField(name string) (any, bool, error) {
@@ -125,6 +126,10 @@ func (this *publicKeyAuthorizeRequest) GetField(name string) (any, bool, error) 
 
 func (this *publicKeyAuthorizeRequest) RemotePublicKey() gossh.PublicKey {
 	return this.publicKey
+}
+
+func (this *publicKeyAuthorizeRequest) PublicKeyVerified() bool {
+	return this.verified
 }
 
 type passwordAuthorizeRequest struct {

--- a/pkg/service/context.go
+++ b/pkg/service/context.go
@@ -43,8 +43,9 @@ func (this *remote) String() string {
 }
 
 type authorizeRequest struct {
-	service    *service
-	connection *connection
+	service       *service
+	connection    *connection
+	authorization authorization.Authorization
 }
 
 func (this *authorizeRequest) GetField(name string) (any, bool, error) {
@@ -67,16 +68,45 @@ func (this *authorizeRequest) Connection() bconn.Connection {
 }
 
 func (this *authorizeRequest) Sessions() session.Repository {
-	return this.service.sessions
+	return &compatibleSessionRepository{
+		Repository:       this.service.sessions,
+		environments:     this.service.environments,
+		authorizeRequest: this,
+	}
 }
 
 func (this *authorizeRequest) Validate(auth authorization.Authorization) (bool, error) {
+	this.SetAuthorizationContext(auth)
 	ctx := environmentContext{
 		service:       this.service,
 		connection:    this.connection,
 		authorization: auth,
 	}
 	return this.service.environments.WillBeAccepted(&ctx)
+}
+
+func (this *authorizeRequest) SetAuthorizationContext(auth authorization.Authorization) {
+	this.authorization = auth
+}
+
+func (this *authorizeRequest) IsSessionCompatible(auth authorization.Authorization) (bool, error) {
+	sess := auth.FindSession()
+	if sess == nil {
+		return true, nil
+	}
+	info, err := sess.Info(this.Context())
+	if err != nil {
+		return false, err
+	}
+	if info != nil && info.State() == session.StateNew {
+		return true, nil
+	}
+	checker, ok := this.service.environments.(environment.ContextualSessionCompatibilityChecker)
+	if !ok {
+		return true, nil
+	}
+	ctx := &environmentContext{service: this.service, connection: this.connection, authorization: auth}
+	return checker.IsSessionCompatibleWith(ctx, sess)
 }
 
 type publicKeyAuthorizeRequest struct {

--- a/pkg/service/context.go
+++ b/pkg/service/context.go
@@ -319,6 +319,17 @@ func (this *environmentTask) TaskType() environment.TaskType {
 	return this.taskType
 }
 
+func (this *environmentTask) EnvironmentVariables() configuration.EnvironmentVariables {
+	flowName := this.Authorization().Flow()
+	for i := range this.service.Configuration.Flows {
+		flow := &this.service.Configuration.Flows[i]
+		if flow.Name == flowName {
+			return flow.Environment.Variables
+		}
+	}
+	return nil
+}
+
 func newRememberMeNotificationContext(ctx essh.Context, auth authorization.Authorization, newSession bool, pub essh.PublicKey) *rememberMeNotificationContext {
 	return &rememberMeNotificationContext{
 		ctx,

--- a/pkg/service/housekeeper.go
+++ b/pkg/service/housekeeper.go
@@ -20,6 +20,7 @@ type houseKeeper struct {
 	service       *service
 	closed        atomic.Bool
 	contextCancel context.CancelFunc
+	done          chan struct{}
 }
 
 func (this *houseKeeper) init(service *service) error {
@@ -39,7 +40,11 @@ func (this *houseKeeper) init(service *service) error {
 		nextRunIn = initialDelay.Native()
 	}
 
-	go this.loop(ctx, nextRunIn)
+	this.done = make(chan struct{})
+	go func() {
+		defer close(this.done)
+		this.loop(ctx, nextRunIn)
+	}()
 
 	success = true
 
@@ -161,15 +166,15 @@ func (this *houseKeeper) dispose(ctx context.Context, logger log.Logger, sess se
 		return false, errors.Newf(errors.System, "cannot dispose session %v: %w", sess, err)
 	}
 
+	sessionDisposed, err := sess.Dispose(ctx)
+	if err != nil {
+		return fail(err)
+	}
 	environmentDisposed, err := this.disposeEnvironment(ctx, logger, sess)
 	if err != nil {
 		return fail(err)
 	}
 	authorizationDisposed, err := this.disposeAuthorization(ctx, logger, sess)
-	if err != nil {
-		return fail(err)
-	}
-	sessionDisposed, err := sess.Dispose(ctx)
 	if err != nil {
 		return fail(err)
 	}
@@ -261,7 +266,12 @@ func (this *houseKeeper) Close() error {
 	if !this.closed.CompareAndSwap(false, true) {
 		return nil
 	}
-	this.contextCancel()
+	if this.contextCancel != nil {
+		this.contextCancel()
+	}
+	if this.done != nil {
+		<-this.done
+	}
 	return nil
 }
 

--- a/pkg/service/service-authorization.go
+++ b/pkg/service/service-authorization.go
@@ -48,6 +48,12 @@ func (this *service) handlePublicKey(ctx essh.Context, _ gossh.ConnMetadata, key
 		l.Debug("public key rejected")
 		return false, nil
 	}
+	if compatible, err := authReq.IsSessionCompatible(auth); err != nil {
+		return false, errors.Newf(errors.System, "cannot validate environment session compatibility: %w", err)
+	} else if !compatible {
+		l.Debug("public key session is incompatible with the current environment")
+		return false, nil
+	}
 
 	ctx.SetValue(authorizationCtxKey, auth)
 	// We've authorized via the regular public key we do not store them.
@@ -64,12 +70,10 @@ func (this *service) handlePassword(ctx essh.Context, _ gossh.ConnMetadata, pass
 	}
 	l := conn.logger
 
+	authReq := authorizeRequest{service: this, connection: conn}
 	auth, err := this.authorizer.AuthorizePassword(&passwordAuthorizeRequest{
-		authorizeRequest: authorizeRequest{
-			service:    this,
-			connection: conn,
-		},
-		password: password,
+		authorizeRequest: authReq,
+		password:         password,
 	})
 	if err != nil {
 		if errors.IsType(err, errors.User) {
@@ -80,6 +84,12 @@ func (this *service) handlePassword(ctx essh.Context, _ gossh.ConnMetadata, pass
 	}
 	if auth == nil || !auth.IsAuthorized() {
 		l.Debug("password rejected")
+		return false, nil
+	}
+	if compatible, err := authReq.IsSessionCompatible(auth); err != nil {
+		return false, errors.Newf(errors.System, "cannot validate environment session compatibility: %w", err)
+	} else if !compatible {
+		l.Debug("password session is incompatible with the current environment")
 		return false, nil
 	}
 
@@ -96,12 +106,10 @@ func (this *service) handleKeyboardInteractiveChallenge(ctx essh.Context, _ goss
 	}
 	l := conn.logger
 
+	authReq := authorizeRequest{service: this, connection: conn}
 	auth, err := this.authorizer.AuthorizeInteractive(&interactiveAuthorizeRequest{
-		authorizeRequest: authorizeRequest{
-			service:    this,
-			connection: conn,
-		},
-		challenger: challenger,
+		authorizeRequest: authReq,
+		challenger:       challenger,
 	})
 	if err != nil {
 		if errors.IsType(err, errors.User) {
@@ -112,6 +120,12 @@ func (this *service) handleKeyboardInteractiveChallenge(ctx essh.Context, _ goss
 	}
 	if auth == nil || !auth.IsAuthorized() {
 		l.Debug("interactive rejected")
+		return false, nil
+	}
+	if compatible, err := authReq.IsSessionCompatible(auth); err != nil {
+		return false, errors.Newf(errors.System, "cannot validate environment session compatibility: %w", err)
+	} else if !compatible {
+		l.Debug("interactive session is incompatible with the current environment")
 		return false, nil
 	}
 

--- a/pkg/service/service-authorization.go
+++ b/pkg/service/service-authorization.go
@@ -10,6 +10,10 @@ import (
 )
 
 func (this *service) handlePublicKey(ctx essh.Context, _ gossh.ConnMetadata, key essh.PublicKey) (bool, error) {
+	return this.authorizePublicKey(ctx, key, false)
+}
+
+func (this *service) authorizePublicKey(ctx essh.Context, key essh.PublicKey, verified bool) (bool, error) {
 	conn := this.connection(ctx)
 	if conn == nil {
 		return false, nil
@@ -26,8 +30,10 @@ func (this *service) handlePublicKey(ctx essh.Context, _ gossh.ConnMetadata, key
 		return false, nil
 	}
 
-	if _, ok := ctx.Value(handshakeKeyCtxKey).(essh.PublicKey); !ok {
-		ctx.SetValue(handshakeKeyCtxKey, key)
+	if _, isCertificate := key.(*gossh.Certificate); !isCertificate {
+		if _, ok := ctx.Value(handshakeKeyCtxKey).(essh.PublicKey); !ok {
+			ctx.SetValue(handshakeKeyCtxKey, key)
+		}
 	}
 
 	authReq := authorizeRequest{
@@ -35,7 +41,7 @@ func (this *service) handlePublicKey(ctx essh.Context, _ gossh.ConnMetadata, key
 		connection: conn,
 	}
 
-	auth, err := this.authorizer.AuthorizePublicKey(&publicKeyAuthorizeRequest{authReq, key})
+	auth, err := this.authorizer.AuthorizePublicKey(&publicKeyAuthorizeRequest{authReq, key, verified})
 	if err != nil {
 		if errors.IsType(err, errors.User) {
 			l.WithError(err).Debug("public key failed by user")

--- a/pkg/service/service-direct-tcp-ip.go
+++ b/pkg/service/service-direct-tcp-ip.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/engity-com/bifroest/pkg/authorization"
 	"github.com/engity-com/bifroest/pkg/common"
+	"github.com/engity-com/bifroest/pkg/environment"
 	"github.com/engity-com/bifroest/pkg/errors"
 	"github.com/engity-com/bifroest/pkg/net"
 )
@@ -205,7 +206,12 @@ func (this *service) onReversePortForwardingRequested(ctx essh.Context, _ gossh.
 		return false, errors.Newf(errors.System, "cannot ensure environment for reverse port forwarding: %w", err)
 	}
 	defer common.IgnoreCloseError(env)
-	allowed, err := env.IsPortForwardingAllowed(bind)
+	var allowed bool
+	if policy, ok := env.(environment.ReversePortForwardingPolicy); ok {
+		allowed, err = policy.IsReversePortForwardingAllowed(bind)
+	} else {
+		allowed, err = env.IsPortForwardingAllowed(bind)
+	}
 	if err != nil {
 		return false, errors.Newf(errors.System, "cannot check if reverse port forwarding is allowed: %w", err)
 	}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -260,7 +260,7 @@ func (this *Service) prepare() (svc *service, err error) {
 	if svc.authorizer, err = authorization.NewAuthorizerFacade(ctx, &this.Configuration.Flows); err != nil {
 		return fail(err)
 	}
-	if svc.environments, err = environment.NewRepositoryFacade(ctx, &this.Configuration.Flows, svc.alternatives, svc.imp); err != nil {
+	if svc.environments, err = environment.NewRepositoryFacadeWithHostKeys(ctx, &this.Configuration.Flows, svc.alternatives, svc.imp, hostSigners); err != nil {
 		return fail(err)
 	}
 	if err = svc.houseKeeper.init(svc); err != nil {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -418,6 +418,19 @@ func (this *service) createNewServerConfig(ctx essh.Context, _ gonet.Conn, targe
 		Ciphers:      this.resolvedSshMessagesCiphers,
 		MACs:         this.resolvedSshMessagesAuthentications,
 	}
+	target.VerifiedPublicKeyCallback = func(_ gossh.ConnMetadata, key gossh.PublicKey, permissions *gossh.Permissions, _ string) (*gossh.Permissions, error) {
+		if _, isCertificate := key.(*gossh.Certificate); !isCertificate {
+			return permissions, nil
+		}
+		accepted, err := this.authorizePublicKey(ctx, key, true)
+		if err != nil {
+			return nil, err
+		}
+		if !accepted {
+			return nil, errors.User.Newf("user certificate rejected after public key verification")
+		}
+		return permissions, nil
+	}
 	return nil
 }
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -247,6 +247,9 @@ func (this *Service) prepare() (svc *service, err error) {
 	if err != nil {
 		return fail(err)
 	}
+	if err := this.logCertificateAuthorities(hostSigners); err != nil {
+		return fail(err)
+	}
 
 	if svc.alternatives, err = alternatives.NewProvider(ctx, this.Version, &this.Configuration.Alternatives); err != nil {
 		return fail(err)
@@ -337,14 +340,27 @@ func (this *Service) prepareServer(_ context.Context, svc *service, hostPrivateK
 }
 
 func (this *Service) loadHostPrivateKeys() ([]crypto.PrivateKey, error) {
-	kc := &this.Configuration.Ssh.Keys
+	return EnsureHostPrivateKeys(&this.Configuration)
+}
+
+func EnsureHostPrivateKeys(conf *configuration.Configuration) ([]crypto.PrivateKey, error) {
+	result, _, err := EnsureHostPrivateKeysWithPaths(conf)
+	return result, err
+}
+
+func EnsureHostPrivateKeysWithPaths(conf *configuration.Configuration) ([]crypto.PrivateKey, []string, error) {
+	if conf == nil {
+		return nil, nil, fmt.Errorf("nil configuration")
+	}
+	kc := &conf.Ssh.Keys
 
 	hostKeys, err := kc.HostKeys.Render(noopContext{})
 	if err != nil {
-		return nil, errors.Config.Newf("cannot render hostKeys: %w", err)
+		return nil, nil, errors.Config.Newf("cannot render hostKeys: %w", err)
 	}
 
 	var result []crypto.PrivateKey
+	var resultPaths []string
 	for _, fn := range hostKeys {
 		if fn == "" {
 			continue
@@ -353,17 +369,49 @@ func (this *Service) loadHostPrivateKeys() ([]crypto.PrivateKey, error) {
 			Type: crypto.KeyTypeEd25519,
 		}, nil)
 		if err != nil {
-			return nil, fmt.Errorf("cannot ensure host key: %w", err)
+			return nil, nil, fmt.Errorf("cannot ensure host key: %w", err)
 		}
 
 		if ok, err := kc.KeyAllowed(pk); err != nil {
-			return nil, fmt.Errorf("cannot check if host key %q is allowed or not: %w", fn, err)
+			return nil, nil, fmt.Errorf("cannot check if host key %q is allowed or not: %w", fn, err)
 		} else if !ok {
-			return nil, fmt.Errorf("cannot check if host key %q is not allowed by restrictions: %w", fn, err)
+			return nil, nil, fmt.Errorf("cannot check if host key %q is not allowed by restrictions: %w", fn, err)
 		}
 		result = append(result, pk)
+		resultPaths = append(resultPaths, fn)
 	}
-	return result, nil
+	return result, resultPaths, nil
+}
+
+func (this *Service) logCertificateAuthorities(hostKeys []crypto.PrivateKey) error {
+	seen := make(map[string]struct{})
+	for i := range this.Configuration.Flows {
+		flow := &this.Configuration.Flows[i]
+		sshEnvironment, ok := flow.Environment.V.(*configuration.EnvironmentSsh)
+		if !ok || sshEnvironment.Certificate == nil {
+			continue
+		}
+		key, path, err := environment.EnsureSshCertificateAuthority(flow)
+		if err != nil {
+			return err
+		}
+		if err := environment.ValidateSshCertificateAuthority(key, hostKeys); err != nil {
+			return fmt.Errorf("flow %q: %w", flow.Name, err)
+		}
+		publicKey := key.PublicKey().ToSsh()
+		fingerprint := gossh.FingerprintSHA256(publicKey)
+		if _, exists := seen[fingerprint]; exists {
+			continue
+		}
+		seen[fingerprint] = struct{}{}
+		this.logger().
+			With("flow", flow.Name).
+			With("path", path).
+			With("fingerprint", fingerprint).
+			With("publicKey", strings.TrimSpace(string(gossh.MarshalAuthorizedKey(publicKey)))).
+			Info("SSH certificate authority available")
+	}
+	return nil
 }
 
 type service struct {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -257,6 +257,12 @@ func (this *Service) prepare() (svc *service, err error) {
 	if svc.sessions, err = session.NewFacadeRepository(ctx, &this.Configuration.Session); err != nil {
 		return fail(err)
 	}
+	sessionRepositoryPrepared := false
+	defer func() {
+		if !sessionRepositoryPrepared {
+			_ = svc.sessions.Close()
+		}
+	}()
 	if svc.authorizer, err = authorization.NewAuthorizerFacade(ctx, &this.Configuration.Flows); err != nil {
 		return fail(err)
 	}
@@ -270,6 +276,7 @@ func (this *Service) prepare() (svc *service, err error) {
 		return fail(err)
 	}
 
+	sessionRepositoryPrepared = true
 	return svc, nil
 }
 

--- a/pkg/service/session-repository.go
+++ b/pkg/service/session-repository.go
@@ -77,6 +77,10 @@ func (this *sessionCompatibilityAuthorization) AuthorizedKeyPolicy() *authorizat
 	return authorization.AuthorizedKeyPolicyOf(this.Authorization)
 }
 
+func (this *sessionCompatibilityAuthorization) AuthorizationEvidence() *authorization.AuthorizationEvidence {
+	return authorization.AuthorizationEvidenceOf(this.Authorization)
+}
+
 func (this *sessionCompatibilityAuthorization) GetField(name string, ctx authorization.ContextEnabled) (any, bool, error) {
 	if name == "session" {
 		info, err := this.session.Info(ctx.Context())

--- a/pkg/service/session-repository.go
+++ b/pkg/service/session-repository.go
@@ -1,0 +1,104 @@
+package service
+
+import (
+	"context"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/engity-com/bifroest/pkg/authorization"
+	"github.com/engity-com/bifroest/pkg/configuration"
+	"github.com/engity-com/bifroest/pkg/environment"
+	"github.com/engity-com/bifroest/pkg/session"
+)
+
+type compatibleSessionRepository struct {
+	session.Repository
+	environments     environment.CloseableRepository
+	authorizeRequest *authorizeRequest
+}
+
+func (this *compatibleSessionRepository) FindBy(ctx context.Context, flow configuration.FlowName, id session.Id, opts *session.FindOpts) (session.Session, error) {
+	return this.Repository.FindBy(ctx, flow, id, this.withCompatibility(opts))
+}
+
+func (this *compatibleSessionRepository) FindByPublicKey(ctx context.Context, key ssh.PublicKey, opts *session.FindOpts) (session.Session, error) {
+	return this.Repository.FindByPublicKey(ctx, key, this.withCompatibility(opts))
+}
+
+func (this *compatibleSessionRepository) FindByAccessToken(ctx context.Context, token []byte, opts *session.FindOpts) (session.Session, error) {
+	return this.Repository.FindByAccessToken(ctx, token, this.withCompatibility(opts))
+}
+
+func (this *compatibleSessionRepository) withCompatibility(opts *session.FindOpts) *session.FindOpts {
+	result := &session.FindOpts{}
+	if opts != nil {
+		*result = *opts
+		result.Predicates = append(session.Predicates(nil), opts.Predicates...)
+	}
+	result.Predicates = append(result.Predicates, func(ctx context.Context, candidate session.Session) (bool, error) {
+		if auth := this.authorizeRequest.authorization; auth != nil {
+			checker, ok := this.environments.(environment.ContextualSessionCompatibilityChecker)
+			if ok {
+				candidateAuth := &sessionCompatibilityAuthorization{Authorization: auth, session: candidate}
+				templateContext := &sessionCompatibilityEnvironmentContext{
+					environmentContext: environmentContext{
+						service:       this.authorizeRequest.service,
+						connection:    this.authorizeRequest.connection,
+						authorization: candidateAuth,
+					},
+					session: candidate,
+				}
+				return checker.IsSessionCompatibleWith(templateContext, candidate)
+			}
+		}
+		checker, ok := this.environments.(environment.SessionCompatibilityChecker)
+		if !ok {
+			return true, nil
+		}
+		return checker.IsSessionCompatible(ctx, candidate)
+	})
+	return result
+}
+
+type sessionCompatibilityAuthorization struct {
+	authorization.Authorization
+	session session.Session
+}
+
+func (this *sessionCompatibilityAuthorization) FindSession() session.Session {
+	return this.session
+}
+
+func (this *sessionCompatibilityAuthorization) AuthorizationKind() string {
+	return authorization.KindOf(this.Authorization)
+}
+
+func (this *sessionCompatibilityAuthorization) AuthorizedKeyPolicy() *authorization.AuthorizedKeyPolicy {
+	return authorization.AuthorizedKeyPolicyOf(this.Authorization)
+}
+
+func (this *sessionCompatibilityAuthorization) GetField(name string, ctx authorization.ContextEnabled) (any, bool, error) {
+	if name == "session" {
+		info, err := this.session.Info(ctx.Context())
+		return info, true, err
+	}
+	provider, ok := this.Authorization.(interface {
+		GetField(string, authorization.ContextEnabled) (any, bool, error)
+	})
+	if !ok {
+		return nil, false, nil
+	}
+	return provider.GetField(name, ctx)
+}
+
+type sessionCompatibilityEnvironmentContext struct {
+	environmentContext
+	session session.Session
+}
+
+func (this *sessionCompatibilityEnvironmentContext) GetField(name string) (any, bool, error) {
+	if name == "session" {
+		return this.session, true, nil
+	}
+	return this.environmentContext.GetField(name)
+}

--- a/pkg/service/ssh-certificate_e2e_test.go
+++ b/pkg/service/ssh-certificate_e2e_test.go
@@ -18,6 +18,7 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
 
+	"github.com/engity-com/bifroest/pkg/authorization"
 	"github.com/engity-com/bifroest/pkg/configuration"
 	"github.com/engity-com/bifroest/pkg/crypto"
 	"github.com/engity-com/bifroest/pkg/session"
@@ -71,7 +72,9 @@ func TestSshCertificateFullStack(t *testing.T) {
 	require.Equal(t, firstParts[1], secondParts[1])
 	require.Equal(t, firstCertificate.Marshal(), secondCertificate.Marshal())
 	require.Equal(t, []string{"target-user"}, firstCertificate.ValidPrincipals)
-	require.Equal(t, firstParts[1], firstCertificate.Extensions["session-id@bifroest.engity.org"])
+	evidence, err := authorization.DecodeAuthorizationEvidence([]byte(firstCertificate.Extensions[authorization.AuthorizationEvidenceExtension]))
+	require.NoError(t, err)
+	require.Equal(t, firstParts[1], evidence.LastHop().SessionId)
 	require.FileExists(t, subjectFile)
 }
 

--- a/pkg/service/ssh-certificate_e2e_test.go
+++ b/pkg/service/ssh-certificate_e2e_test.go
@@ -1,0 +1,221 @@
+package service
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"fmt"
+	"io"
+	gonet "net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	gossh "golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+
+	"github.com/engity-com/bifroest/pkg/configuration"
+	"github.com/engity-com/bifroest/pkg/crypto"
+	"github.com/engity-com/bifroest/pkg/session"
+	"github.com/engity-com/bifroest/pkg/template"
+)
+
+func TestSshCertificateFullStack(t *testing.T) {
+	_, authorityKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	authoritySigner, err := gossh.NewSignerFromKey(authorityKey)
+	require.NoError(t, err)
+	target := newSshCertificateE2ETarget(t, authoritySigner.PublicKey())
+
+	directory := t.TempDir()
+	authorityFile := filepath.Join(directory, "authority")
+	subjectFile := filepath.Join(directory, "subject")
+	privateKey, err := gossh.MarshalPrivateKey(authorityKey, "test user CA")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(authorityFile, pem.EncodeToMemory(privateKey), 0600))
+
+	server := newAuthorizedKeysTestServerWithConfiguration(t, "", nil, func(conf *configuration.Configuration) {
+		sshEnvironment := &configuration.EnvironmentSsh{}
+		require.NoError(t, sshEnvironment.SetDefaults())
+		sshEnvironment.Address = template.MustNewString(target.Address())
+		sshEnvironment.User = template.MustNewString("target-user")
+		sshEnvironment.KnownHosts = target.KnownHosts()
+		certificate := &configuration.EnvironmentSshCertificate{}
+		require.NoError(t, certificate.SetDefaults())
+		certificate.IdentityFile = template.MustNewString(subjectFile)
+		certificate.AuthorityIdentityFile = template.MustNewString(authorityFile)
+		certificate.Validity = template.DurationOf(time.Hour)
+		certificate.Extensions = configuration.EnvironmentSshCertificateExtensions{
+			"permit-pty": template.MustNewString(""),
+		}
+		sshEnvironment.Certificate = certificate
+		conf.Flows[0].Environment.V = sshEnvironment
+	})
+
+	firstOutput := runSshCertificateE2ECommand(t, server, "first")
+	firstCertificate := target.NextCertificate(t)
+	secondOutput := runSshCertificateE2ECommand(t, server, "second")
+	secondCertificate := target.NextCertificate(t)
+
+	firstParts := strings.SplitN(firstOutput, "|", 2)
+	secondParts := strings.SplitN(secondOutput, "|", 2)
+	require.Len(t, firstParts, 2)
+	require.Len(t, secondParts, 2)
+	require.Equal(t, []string{"first", firstParts[1]}, firstParts)
+	require.Equal(t, []string{"second", secondParts[1]}, secondParts)
+	require.NotEmpty(t, firstParts[1])
+	require.Equal(t, firstParts[1], secondParts[1])
+	require.Equal(t, firstCertificate.Marshal(), secondCertificate.Marshal())
+	require.Equal(t, []string{"target-user"}, firstCertificate.ValidPrincipals)
+	require.Equal(t, firstParts[1], firstCertificate.Extensions["session-id@bifroest.engity.org"])
+	require.FileExists(t, subjectFile)
+}
+
+func runSshCertificateE2ECommand(t *testing.T, server *authorizedKeysTestServer, command string) string {
+	t.Helper()
+	client, err := server.dial()
+	require.NoError(t, err)
+	sshSession, err := client.NewSession()
+	require.NoError(t, err)
+	output, err := sshSession.Output(command)
+	require.NoError(t, err)
+	require.NoError(t, client.Close())
+	return string(output)
+}
+
+type sshCertificateE2ETarget struct {
+	listener     gonet.Listener
+	config       *gossh.ServerConfig
+	hostKey      gossh.PublicKey
+	certificates chan *gossh.Certificate
+	closeOnce    sync.Once
+	wait         sync.WaitGroup
+}
+
+func newSshCertificateE2ETarget(t *testing.T, authority gossh.PublicKey) *sshCertificateE2ETarget {
+	t.Helper()
+	_, hostKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	hostSigner, err := gossh.NewSignerFromKey(hostKey)
+	require.NoError(t, err)
+	listener, err := gonet.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	certificates := make(chan *gossh.Certificate, 2)
+	checker := &gossh.CertChecker{IsUserAuthority: func(candidate gossh.PublicKey) bool {
+		return gossh.FingerprintSHA256(candidate) == gossh.FingerprintSHA256(authority)
+	}}
+	config := &gossh.ServerConfig{PublicKeyCallback: func(metadata gossh.ConnMetadata, key gossh.PublicKey) (*gossh.Permissions, error) {
+		certificate, ok := key.(*gossh.Certificate)
+		if !ok {
+			return nil, fmt.Errorf("target requires an SSH user certificate")
+		}
+		permissions, err := checker.Authenticate(metadata, certificate)
+		if err != nil {
+			return nil, err
+		}
+		certificates <- certificate
+		return permissions, nil
+	}}
+	config.AddHostKey(hostSigner)
+	target := &sshCertificateE2ETarget{listener: listener, config: config, hostKey: hostSigner.PublicKey(), certificates: certificates}
+	target.wait.Add(1)
+	go target.serve()
+	t.Cleanup(target.Close)
+	return target
+}
+
+func (this *sshCertificateE2ETarget) Address() string {
+	return this.listener.Addr().String()
+}
+
+func (this *sshCertificateE2ETarget) KnownHosts() crypto.KnownHosts {
+	return crypto.KnownHosts(knownhosts.Line([]string{this.Address()}, this.hostKey))
+}
+
+func (this *sshCertificateE2ETarget) NextCertificate(t *testing.T) *gossh.Certificate {
+	t.Helper()
+	select {
+	case certificate := <-this.certificates:
+		return certificate
+	case <-time.After(5 * time.Second):
+		t.Fatal("target did not receive an SSH user certificate")
+		return nil
+	}
+}
+
+func (this *sshCertificateE2ETarget) Close() {
+	this.closeOnce.Do(func() {
+		_ = this.listener.Close()
+		this.wait.Wait()
+	})
+}
+
+func (this *sshCertificateE2ETarget) serve() {
+	defer this.wait.Done()
+	for {
+		connection, err := this.listener.Accept()
+		if err != nil {
+			return
+		}
+		this.wait.Add(1)
+		go func() {
+			defer this.wait.Done()
+			this.serveConnection(connection)
+		}()
+	}
+}
+
+func (this *sshCertificateE2ETarget) serveConnection(raw gonet.Conn) {
+	connection, channels, requests, err := gossh.NewServerConn(raw, this.config)
+	if err != nil {
+		_ = raw.Close()
+		return
+	}
+	defer connection.Close()
+	go gossh.DiscardRequests(requests)
+	for channel := range channels {
+		if channel.ChannelType() != "session" {
+			_ = channel.Reject(gossh.UnknownChannelType, "unsupported")
+			continue
+		}
+		go serveSshCertificateE2ESession(channel)
+	}
+}
+
+func serveSshCertificateE2ESession(channel gossh.NewChannel) {
+	stream, requests, err := channel.Accept()
+	if err != nil {
+		return
+	}
+	defer stream.Close()
+	environment := make(map[string]string)
+	for request := range requests {
+		switch request.Type {
+		case "env":
+			var payload struct {
+				Name  string
+				Value string
+			}
+			if gossh.Unmarshal(request.Payload, &payload) == nil {
+				environment[payload.Name] = payload.Value
+			}
+			_ = request.Reply(true, nil)
+		case "exec":
+			var payload struct{ Command string }
+			if err := gossh.Unmarshal(request.Payload, &payload); err != nil {
+				_ = request.Reply(false, nil)
+				return
+			}
+			_ = request.Reply(true, nil)
+			_, _ = io.WriteString(stream, payload.Command+"|"+environment[session.EnvName])
+			_, _ = stream.SendRequest("exit-status", false, gossh.Marshal(&struct{ Status uint32 }{0}))
+			return
+		default:
+			_ = request.Reply(false, nil)
+		}
+	}
+}

--- a/pkg/service/user-certificate_auth_test.go
+++ b/pkg/service/user-certificate_auth_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	gossh "golang.org/x/crypto/ssh"
 
+	"github.com/engity-com/bifroest/pkg/authorization"
 	"github.com/engity-com/bifroest/pkg/configuration"
 	"github.com/engity-com/bifroest/pkg/crypto"
 	"github.com/engity-com/bifroest/pkg/environment"
@@ -175,6 +176,178 @@ func TestBifroestCertificateChain(t *testing.T) {
 			testBifroestCertificateChain(t, trustPath)
 		})
 	}
+}
+
+func TestBifroestAuthorizationAcceptsDelegationCertificate(t *testing.T) {
+	_, authorityPrivate, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	authority, err := gossh.NewSignerFromKey(authorityPrivate)
+	require.NoError(t, err)
+
+	targetEnvironment := &authorizedKeysTestEnvironment{run: func(task environment.Task) (int, error) {
+		auth, ok := task.Authorization().(*authorization.BifroestAuthorization)
+		if !ok {
+			return 1, fmt.Errorf("unexpected authorization type %T", task.Authorization())
+		}
+		evidence := auth.AuthorizationEvidence()
+		_, err := fmt.Fprintf(task.SshSession(), "%s|%s|%d", evidence.Origin.User, evidence.LastHop().Audience, len(evidence.Hops))
+		return 0, err
+	}}
+	target := newAuthorizedKeysTestServerWithConfiguration(t, "", targetEnvironment, func(conf *configuration.Configuration) {
+		bifroest := &configuration.AuthorizationBifroest{}
+		require.NoError(t, bifroest.SetDefaults())
+		bifroest.TrustedUserCAs = crypto.PublicKeys(strings.TrimSpace(string(gossh.MarshalAuthorizedKey(authority.PublicKey()))))
+		conf.Flows[0].Authorization.V = bifroest
+	})
+
+	directory := t.TempDir()
+	authorityFile := filepath.Join(directory, "authority")
+	privateKey, err := gossh.MarshalPrivateKey(authorityPrivate, "Bifroest delegation test CA")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(authorityFile, pem.EncodeToMemory(privateKey), 0600))
+
+	proxy := newAuthorizedKeysTestServerWithConfiguration(t, "", nil, func(conf *configuration.Configuration) {
+		sshEnvironment := &configuration.EnvironmentSsh{}
+		require.NoError(t, sshEnvironment.SetDefaults())
+		sshEnvironment.Address = template.MustNewString(target.address)
+		sshEnvironment.User = template.MustNewString(target.username)
+		sshEnvironment.AcceptAllHostKeys = true
+		certificate := &configuration.EnvironmentSshCertificate{}
+		require.NoError(t, certificate.SetDefaults())
+		certificate.IdentityFile = template.MustNewString(filepath.Join(directory, "subject"))
+		certificate.AuthorityIdentityFile = template.MustNewString(authorityFile)
+		certificate.Audience = template.MustNewString(conf.Flows[0].Name.String())
+		certificate.Extensions = configuration.EnvironmentSshCertificateExtensions{"permit-pty": template.MustNewString("")}
+		sshEnvironment.Certificate = certificate
+		conf.Flows[0].Environment.V = sshEnvironment
+	})
+
+	client := proxy.mustDial(t)
+	defer func() { require.NoError(t, client.Close()) }()
+	sshSession, err := client.NewSession()
+	require.NoError(t, err)
+	output, err := sshSession.Output("through-a")
+	require.NoError(t, err)
+	require.Equal(t, proxy.username+"|"+target.service.Configuration.Flows[0].Name.String()+"|1", string(output))
+}
+
+func TestSimpleAuthorizationRejectsDelegationProfileCertificate(t *testing.T) {
+	directory := t.TempDir()
+	authority, authorityFile := newBifroestDelegationTestCA(t, directory, "delegation")
+	target := newAuthorizedKeysTestServerWithConfiguration(t, "", &authorizedKeysTestEnvironment{}, func(conf *configuration.Configuration) {
+		simple := conf.Flows[0].Authorization.V.(*configuration.AuthorizationSimple)
+		simple.TrustedUserCAs = crypto.PublicKeys(strings.TrimSpace(string(gossh.MarshalAuthorizedKey(authority.PublicKey()))))
+		simple.Entries[0].AuthorizedKeys = ""
+	})
+	proxy := newAuthorizedKeysTestServerWithConfiguration(t, "", nil, func(conf *configuration.Configuration) {
+		conf.Flows[0].Environment.V = newBifroestDelegationTestEnvironment(
+			t, target, filepath.Join(directory, "subject"), authorityFile,
+			configuration.EnvironmentSshCertificateExtensions{"permit-pty": template.MustNewString("")},
+		)
+	})
+
+	client := proxy.mustDial(t)
+	defer func() { require.NoError(t, client.Close()) }()
+	sshSession, err := client.NewSession()
+	require.NoError(t, err)
+	_, err = sshSession.Output("must-not-run")
+	require.Error(t, err)
+}
+
+func TestBifroestAuthorizationPropagatesEvidenceAcrossTwoHops(t *testing.T) {
+	directory := t.TempDir()
+	aToBCA, aToBCAFile := newBifroestDelegationTestCA(t, directory, "a-to-b")
+	bToCCA, bToCCAFile := newBifroestDelegationTestCA(t, directory, "b-to-c")
+
+	var received *authorization.AuthorizationEvidence
+	targetC := newAuthorizedKeysTestServerWithConfiguration(t, "", &authorizedKeysTestEnvironment{run: func(task environment.Task) (int, error) {
+		auth, ok := task.Authorization().(*authorization.BifroestAuthorization)
+		if !ok {
+			return 1, fmt.Errorf("unexpected authorization type %T", task.Authorization())
+		}
+		received = auth.AuthorizationEvidence()
+		_, err := fmt.Fprint(task.SshSession(), "bifroest-c")
+		return 0, err
+	}}, func(conf *configuration.Configuration) {
+		bifroest := &configuration.AuthorizationBifroest{}
+		require.NoError(t, bifroest.SetDefaults())
+		bifroest.TrustedUserCAs = crypto.PublicKeys(strings.TrimSpace(string(gossh.MarshalAuthorizedKey(bToCCA.PublicKey()))))
+		conf.Flows[0].Authorization.V = bifroest
+	})
+
+	proxyB := newAuthorizedKeysTestServerWithConfiguration(t, "", nil, func(conf *configuration.Configuration) {
+		bifroest := &configuration.AuthorizationBifroest{}
+		require.NoError(t, bifroest.SetDefaults())
+		bifroest.TrustedUserCAs = crypto.PublicKeys(strings.TrimSpace(string(gossh.MarshalAuthorizedKey(aToBCA.PublicKey()))))
+		conf.Flows[0].Authorization.V = bifroest
+		conf.Flows[0].Environment.V = newBifroestDelegationTestEnvironment(
+			t, targetC, filepath.Join(directory, "b-to-c-subject"), bToCCAFile,
+			configuration.EnvironmentSshCertificateExtensions{
+				"permit-pty":             template.MustNewString(""),
+				"permit-port-forwarding": template.MustNewString(""),
+			},
+		)
+	})
+
+	proxyA := newAuthorizedKeysTestServerWithConfiguration(t, `permitopen="allowed.example:22"`, nil, func(conf *configuration.Configuration) {
+		conf.Flows[0].Environment.V = newBifroestDelegationTestEnvironment(
+			t, proxyB, filepath.Join(directory, "a-to-b-subject"), aToBCAFile,
+			configuration.EnvironmentSshCertificateExtensions{
+				"permit-pty":             template.MustNewString(""),
+				"permit-port-forwarding": template.MustNewString(""),
+			},
+		)
+	})
+
+	client := proxyA.mustDial(t)
+	defer func() { require.NoError(t, client.Close()) }()
+	sshSession, err := client.NewSession()
+	require.NoError(t, err)
+	output, err := sshSession.Output("through-two-hops")
+	require.NoError(t, err)
+	require.Equal(t, "bifroest-c", string(output))
+	require.NotNil(t, received)
+	require.Equal(t, proxyA.username, received.Origin.User)
+	require.Equal(t, "simple", received.Origin.AuthorizationKind)
+	require.Len(t, received.Hops, 2)
+	require.Equal(t, proxyB.service.Configuration.Flows[0].Name.String(), received.Hops[0].Audience)
+	require.Equal(t, targetC.service.Configuration.Flows[0].Name.String(), received.Hops[1].Audience)
+	require.Equal(t, "simple", received.Hops[0].AuthorizationKind)
+	require.Equal(t, "bifroest", received.Hops[1].AuthorizationKind)
+	require.False(t, received.Hops[0].PortForwardingAllowed)
+	require.True(t, received.Hops[1].PtyAllowed)
+	require.False(t, received.Hops[1].PortForwardingAllowed)
+	require.False(t, received.Hops[1].ValidBefore.After(received.Hops[0].ValidBefore))
+}
+
+func newBifroestDelegationTestCA(t *testing.T, directory, name string) (gossh.Signer, string) {
+	t.Helper()
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := gossh.NewSignerFromKey(privateKey)
+	require.NoError(t, err)
+	encoded, err := gossh.MarshalPrivateKey(privateKey, name)
+	require.NoError(t, err)
+	filename := filepath.Join(directory, name+"-ca")
+	require.NoError(t, os.WriteFile(filename, pem.EncodeToMemory(encoded), 0600))
+	return signer, filename
+}
+
+func newBifroestDelegationTestEnvironment(t *testing.T, target *authorizedKeysTestServer, subjectFile, authorityFile string, extensions configuration.EnvironmentSshCertificateExtensions) *configuration.EnvironmentSsh {
+	t.Helper()
+	result := &configuration.EnvironmentSsh{}
+	require.NoError(t, result.SetDefaults())
+	result.Address = template.MustNewString(target.address)
+	result.User = template.MustNewString(target.username)
+	result.AcceptAllHostKeys = true
+	certificate := &configuration.EnvironmentSshCertificate{}
+	require.NoError(t, certificate.SetDefaults())
+	certificate.IdentityFile = template.MustNewString(subjectFile)
+	certificate.AuthorityIdentityFile = template.MustNewString(authorityFile)
+	certificate.Audience = template.MustNewString(target.service.Configuration.Flows[0].Name.String())
+	certificate.Extensions = extensions
+	result.Certificate = certificate
+	return result
 }
 
 func testBifroestCertificateChain(t *testing.T, trustPath string) {

--- a/pkg/service/user-certificate_auth_test.go
+++ b/pkg/service/user-certificate_auth_test.go
@@ -1,0 +1,283 @@
+package service
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/engity-com/bifroest/pkg/configuration"
+	"github.com/engity-com/bifroest/pkg/crypto"
+	"github.com/engity-com/bifroest/pkg/environment"
+	"github.com/engity-com/bifroest/pkg/session"
+	"github.com/engity-com/bifroest/pkg/template"
+)
+
+func TestSimpleAuthorizationAcceptsGloballyTrustedUserCertificate(t *testing.T) {
+	authority := newIncomingCertificateTestSigner(t)
+	testEnvironment := &authorizedKeysTestEnvironment{}
+	server := newAuthorizedKeysTestServerWithConfiguration(t, "", testEnvironment, func(conf *configuration.Configuration) {
+		simple := conf.Flows[0].Authorization.V.(*configuration.AuthorizationSimple)
+		simple.TrustedUserCAs = crypto.PublicKeys(strings.TrimSpace(string(gossh.MarshalAuthorizedKey(authority.PublicKey()))))
+		simple.Entries[0].AuthorizedKeys = ""
+	})
+	certificateSigner := newIncomingCertificateSigner(t, authority, server.signer, server.username, map[string]string{"permit-pty": ""})
+
+	client, err := dialAuthorizedKeysTestServer(server, certificateSigner)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+	sshSession, err := client.NewSession()
+	require.NoError(t, err)
+	require.NoError(t, sshSession.RequestPty("xterm", 24, 80, gossh.TerminalModes{}))
+	require.NoError(t, sshSession.Run("true"))
+
+	_, err = server.service.sessions.FindByPublicKey(t.Context(), certificateSigner.PublicKey(), &session.FindOpts{})
+	require.ErrorIs(t, err, session.ErrNoSuchSession)
+	_, err = server.service.sessions.FindByPublicKey(t.Context(), server.signer.PublicKey(), &session.FindOpts{})
+	require.ErrorIs(t, err, session.ErrNoSuchSession)
+}
+
+func TestSimpleAuthorizationAppliesCertificateExtensions(t *testing.T) {
+	authority := newIncomingCertificateTestSigner(t)
+	server := newAuthorizedKeysTestServerWithConfiguration(t, "", &authorizedKeysTestEnvironment{}, func(conf *configuration.Configuration) {
+		simple := conf.Flows[0].Authorization.V.(*configuration.AuthorizationSimple)
+		simple.TrustedUserCAs = crypto.PublicKeys(strings.TrimSpace(string(gossh.MarshalAuthorizedKey(authority.PublicKey()))))
+	})
+	certificateSigner := newIncomingCertificateSigner(t, authority, server.signer, server.username, nil)
+	client, err := dialAuthorizedKeysTestServer(server, certificateSigner)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	sshSession, err := client.NewSession()
+	require.NoError(t, err)
+	require.Error(t, sshSession.RequestPty("xterm", 24, 80, gossh.TerminalModes{}))
+}
+
+func TestSimpleAuthorizationAcceptsTrustedUserCAsFileSnapshot(t *testing.T) {
+	authority := newIncomingCertificateTestSigner(t)
+	replacement := newIncomingCertificateTestSigner(t)
+	filename := filepath.Join(t.TempDir(), "ca")
+	require.NoError(t, os.WriteFile(filename, gossh.MarshalAuthorizedKey(authority.PublicKey()), 0600))
+	server := newAuthorizedKeysTestServerWithConfiguration(t, "", &authorizedKeysTestEnvironment{}, func(conf *configuration.Configuration) {
+		simple := conf.Flows[0].Authorization.V.(*configuration.AuthorizationSimple)
+		simple.TrustedUserCAsFile = crypto.PublicKeysFile(filename)
+	})
+	require.NoError(t, os.WriteFile(filename, gossh.MarshalAuthorizedKey(replacement.PublicKey()), 0600))
+	certificateSigner := newIncomingCertificateSigner(t, authority, server.signer, server.username, nil)
+
+	client, err := dialAuthorizedKeysTestServer(server, certificateSigner)
+	require.NoError(t, err)
+	require.NoError(t, client.Close())
+}
+
+func TestSimpleAuthorizationAcceptsAuthorizedKeysCertificateAuthority(t *testing.T) {
+	authority := newIncomingCertificateTestSigner(t)
+	server := newAuthorizedKeysTestServerWithConfiguration(t, "", &authorizedKeysTestEnvironment{}, func(conf *configuration.Configuration) {
+		simple := conf.Flows[0].Authorization.V.(*configuration.AuthorizationSimple)
+		simple.Entries[0].AuthorizedKeys = crypto.AuthorizedKeys(fmt.Sprintf(
+			`cert-authority,principals="%s",restrict,pty %s`,
+			serverUsername(conf), strings.TrimSpace(string(gossh.MarshalAuthorizedKey(authority.PublicKey()))),
+		))
+	})
+	certificateSigner := newIncomingCertificateSigner(t, authority, server.signer, server.username, map[string]string{"permit-pty": "", "permit-port-forwarding": ""})
+
+	client, err := dialAuthorizedKeysTestServer(server, certificateSigner)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+	sshSession, err := client.NewSession()
+	require.NoError(t, err)
+	require.NoError(t, sshSession.RequestPty("xterm", 24, 80, gossh.TerminalModes{}))
+
+	directClient, err := dialAuthorizedKeysTestServer(server, authority)
+	if directClient != nil {
+		_ = directClient.Close()
+	}
+	require.Error(t, err)
+}
+
+func TestSimpleAuthorizationRejectsWrongCertificatePrincipal(t *testing.T) {
+	authority := newIncomingCertificateTestSigner(t)
+	server := newAuthorizedKeysTestServerWithConfiguration(t, "", &authorizedKeysTestEnvironment{}, func(conf *configuration.Configuration) {
+		simple := conf.Flows[0].Authorization.V.(*configuration.AuthorizationSimple)
+		simple.TrustedUserCAs = crypto.PublicKeys(strings.TrimSpace(string(gossh.MarshalAuthorizedKey(authority.PublicKey()))))
+	})
+	certificateSigner := newIncomingCertificateSigner(t, authority, server.signer, "another-user", nil)
+
+	client, err := dialAuthorizedKeysTestServer(server, certificateSigner)
+	if client != nil {
+		_ = client.Close()
+	}
+	require.Error(t, err)
+}
+
+func TestUserCertificateCreatesNoSessionBeforeProofAndIsRechecked(t *testing.T) {
+	authority := newIncomingCertificateTestSigner(t)
+	server := newAuthorizedKeysTestServerWithConfiguration(t, "", &authorizedKeysTestEnvironment{}, func(conf *configuration.Configuration) {
+		simple := conf.Flows[0].Authorization.V.(*configuration.AuthorizationSimple)
+		simple.TrustedUserCAs = crypto.PublicKeys(strings.TrimSpace(string(gossh.MarshalAuthorizedKey(authority.PublicKey()))))
+		simple.Entries[0].AuthorizedKeys = ""
+	})
+	expiresAt := time.Unix(time.Now().Unix()+3, 0)
+	certificate := &gossh.Certificate{
+		Key:             server.signer.PublicKey(),
+		CertType:        gossh.UserCert,
+		ValidPrincipals: []string{server.username},
+		ValidAfter:      uint64(time.Now().Add(-time.Minute).Unix()),
+		ValidBefore:     uint64(expiresAt.Unix()),
+	}
+	require.NoError(t, certificate.SignCert(rand.Reader, authority))
+	certificateSigner, err := gossh.NewCertSigner(certificate, server.signer)
+	require.NoError(t, err)
+	blocking := &blockingIncomingCertificateSigner{
+		Signer:      certificateSigner,
+		signStarted: make(chan struct{}),
+		releaseSign: make(chan struct{}),
+	}
+	dialResult := make(chan error, 1)
+	go func() {
+		client, err := dialAuthorizedKeysTestServer(server, blocking)
+		if client != nil {
+			_ = client.Close()
+		}
+		dialResult <- err
+	}()
+
+	select {
+	case <-blocking.signStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("client did not reach the signed public key request")
+	}
+	sessionCount := 0
+	require.NoError(t, server.service.sessions.FindAll(t.Context(), func(_ context.Context, _ session.Session) (bool, error) {
+		sessionCount++
+		return true, nil
+	}, nil))
+	require.Zero(t, sessionCount)
+	time.Sleep(time.Until(expiresAt) + 50*time.Millisecond)
+	close(blocking.releaseSign)
+	require.Error(t, <-dialResult)
+}
+
+func TestBifroestCertificateChain(t *testing.T) {
+	for _, trustPath := range []string{"trusted-user-cas", "authorized-keys-cert-authority"} {
+		t.Run(trustPath, func(t *testing.T) {
+			testBifroestCertificateChain(t, trustPath)
+		})
+	}
+}
+
+func testBifroestCertificateChain(t *testing.T, trustPath string) {
+	_, authorityPrivate, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	authority, err := gossh.NewSignerFromKey(authorityPrivate)
+	require.NoError(t, err)
+	targetEnvironment := &authorizedKeysTestEnvironment{run: func(task environment.Task) (int, error) {
+		_, err := fmt.Fprintf(task.SshSession(), "bifroest-b|%s", task.SshSession().RawCommand())
+		return 0, err
+	}}
+	target := newAuthorizedKeysTestServerWithConfiguration(t, "", targetEnvironment, func(conf *configuration.Configuration) {
+		simple := conf.Flows[0].Authorization.V.(*configuration.AuthorizationSimple)
+		plainAuthority := strings.TrimSpace(string(gossh.MarshalAuthorizedKey(authority.PublicKey())))
+		switch trustPath {
+		case "trusted-user-cas":
+			simple.TrustedUserCAs = crypto.PublicKeys(plainAuthority)
+		case "authorized-keys-cert-authority":
+			simple.Entries[0].AuthorizedKeys = crypto.AuthorizedKeys(`cert-authority,principals="` + simple.Entries[0].Name + `" ` + plainAuthority)
+		default:
+			t.Fatalf("unknown trust path %q", trustPath)
+		}
+	})
+
+	directory := t.TempDir()
+	authorityFile := filepath.Join(directory, "authority")
+	subjectFile := filepath.Join(directory, "subject")
+	privateKey, err := gossh.MarshalPrivateKey(authorityPrivate, "Bifroest chain test CA")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(authorityFile, pem.EncodeToMemory(privateKey), 0600))
+
+	proxy := newAuthorizedKeysTestServerWithConfiguration(t, "", nil, func(conf *configuration.Configuration) {
+		sshEnvironment := &configuration.EnvironmentSsh{}
+		require.NoError(t, sshEnvironment.SetDefaults())
+		sshEnvironment.Address = template.MustNewString(target.address)
+		sshEnvironment.User = template.MustNewString(target.username)
+		sshEnvironment.AcceptAllHostKeys = true
+		certificate := &configuration.EnvironmentSshCertificate{}
+		require.NoError(t, certificate.SetDefaults())
+		certificate.IdentityFile = template.MustNewString(subjectFile)
+		certificate.AuthorityIdentityFile = template.MustNewString(authorityFile)
+		certificate.Validity = template.DurationOf(time.Hour)
+		certificate.Extensions = configuration.EnvironmentSshCertificateExtensions{}
+		sshEnvironment.Certificate = certificate
+		conf.Flows[0].Environment.V = sshEnvironment
+	})
+
+	client := proxy.mustDial(t)
+	sshSession, err := client.NewSession()
+	require.NoError(t, err)
+	output, err := sshSession.Output("through-a")
+	require.NoError(t, err)
+	require.Equal(t, "bifroest-b|through-a", string(output))
+}
+
+func serverUsername(conf *configuration.Configuration) string {
+	return conf.Flows[0].Authorization.V.(*configuration.AuthorizationSimple).Entries[0].Name
+}
+
+func newIncomingCertificateTestSigner(t *testing.T) gossh.Signer {
+	t.Helper()
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := gossh.NewSignerFromKey(privateKey)
+	require.NoError(t, err)
+	return signer
+}
+
+func newIncomingCertificateSigner(t *testing.T, authority, subject gossh.Signer, principal string, extensions map[string]string) gossh.Signer {
+	t.Helper()
+	now := time.Now()
+	certificate := &gossh.Certificate{
+		Key:             subject.PublicKey(),
+		CertType:        gossh.UserCert,
+		ValidPrincipals: []string{principal},
+		ValidAfter:      uint64(now.Add(-time.Minute).Unix()),
+		ValidBefore:     uint64(now.Add(time.Hour).Unix()),
+		Permissions:     gossh.Permissions{Extensions: extensions},
+	}
+	require.NoError(t, certificate.SignCert(rand.Reader, authority))
+	result, err := gossh.NewCertSigner(certificate, subject)
+	require.NoError(t, err)
+	return result
+}
+
+func dialAuthorizedKeysTestServer(server *authorizedKeysTestServer, signer gossh.Signer) (*gossh.Client, error) {
+	return gossh.Dial("tcp", server.address, &gossh.ClientConfig{
+		User:            server.username,
+		Auth:            []gossh.AuthMethod{gossh.PublicKeys(signer)},
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(), //nolint:gosec // The server and key are test-local.
+		Timeout:         5 * time.Second,
+	})
+}
+
+type blockingIncomingCertificateSigner struct {
+	gossh.Signer
+	signStarted chan struct{}
+	releaseSign chan struct{}
+	signOnce    sync.Once
+}
+
+func (this *blockingIncomingCertificateSigner) Sign(random io.Reader, data []byte) (*gossh.Signature, error) {
+	this.signOnce.Do(func() { close(this.signStarted) })
+	<-this.releaseSign
+	return this.Signer.Sign(random, data)
+}

--- a/pkg/service/user-certificate_local_test.go
+++ b/pkg/service/user-certificate_local_test.go
@@ -1,0 +1,76 @@
+//go:build unix
+
+package service
+
+import (
+	"os"
+	osuser "os/user"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/engity-com/bifroest/pkg/configuration"
+	"github.com/engity-com/bifroest/pkg/crypto"
+	"github.com/engity-com/bifroest/pkg/template"
+	buser "github.com/engity-com/bifroest/pkg/user"
+)
+
+func TestLocalAuthorizationAcceptsUserCertificates(t *testing.T) {
+	const username = "certificate-local-user"
+	current, err := osuser.Current()
+	require.NoError(t, err)
+	userDirectory := t.TempDir()
+	passwdFile := filepath.Join(userDirectory, "passwd")
+	groupFile := filepath.Join(userDirectory, "group")
+	shadowFile := filepath.Join(userDirectory, "shadow")
+	require.NoError(t, os.WriteFile(passwdFile, []byte(username+":x:"+current.Uid+":"+current.Gid+"::"+current.HomeDir+":/bin/sh\n"), 0600))
+	require.NoError(t, os.WriteFile(groupFile, []byte(username+":x:"+current.Gid+":"+username+"\n"), 0600))
+	require.NoError(t, os.WriteFile(shadowFile, []byte(username+":!:19722:0:99999:7:::\n"), 0600))
+	previousRepositoryProvider := buser.DefaultRepositoryProvider
+	buser.DefaultRepositoryProvider = &buser.SharedRepositoryProvider[*buser.EtcColonRepository]{V: &buser.EtcColonRepository{
+		PasswdFilename: passwdFile,
+		GroupFilename:  groupFile,
+		ShadowFilename: shadowFile,
+	}}
+	t.Cleanup(func() { buser.DefaultRepositoryProvider = previousRepositoryProvider })
+
+	authority := newIncomingCertificateTestSigner(t)
+	plainAuthority := strings.TrimSpace(string(gossh.MarshalAuthorizedKey(authority.PublicKey())))
+
+	for _, trustPath := range []string{"trusted-user-cas", "trusted-user-cas-file", "authorized-keys-cert-authority"} {
+		t.Run(trustPath, func(t *testing.T) {
+			directory := t.TempDir()
+			caFile := filepath.Join(directory, "ca")
+			authorizedKeysFile := filepath.Join(directory, "authorized_keys")
+			require.NoError(t, os.WriteFile(caFile, []byte(plainAuthority+"\n"), 0600))
+			require.NoError(t, os.WriteFile(authorizedKeysFile, []byte(`cert-authority,principals="`+username+`" `+plainAuthority+"\n"), 0600))
+
+			server := newAuthorizedKeysTestServerWithUsernameAndConfiguration(t, username, "", &authorizedKeysTestEnvironment{}, func(conf *configuration.Configuration) {
+				local := &configuration.AuthorizationLocal{}
+				require.NoError(t, local.SetDefaults())
+				switch trustPath {
+				case "trusted-user-cas":
+					local.AuthorizedKeys = template.Strings{}
+					local.TrustedUserCAs = crypto.PublicKeys(plainAuthority)
+				case "trusted-user-cas-file":
+					local.AuthorizedKeys = template.Strings{}
+					local.TrustedUserCAsFile = crypto.PublicKeysFile(caFile)
+				case "authorized-keys-cert-authority":
+					local.AuthorizedKeys = template.Strings{template.MustNewString(authorizedKeysFile)}
+				}
+				conf.Flows[0].Authorization.V = local
+			})
+			certificateSigner := newIncomingCertificateSigner(t, authority, server.signer, username, nil)
+
+			client, err := dialAuthorizedKeysTestServer(server, certificateSigner)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = client.Close() })
+			sshSession, err := client.NewSession()
+			require.NoError(t, err)
+			require.NoError(t, sshSession.Run("true"))
+		})
+	}
+}

--- a/pkg/session/fs-atomic.go
+++ b/pkg/session/fs-atomic.go
@@ -1,0 +1,48 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func writeFsFileAtomically(path string, data []byte, fileMode, dirMode os.FileMode) (rErr error) {
+	if err := os.MkdirAll(filepath.Dir(path), dirMode); err != nil {
+		return fmt.Errorf("cannot create parent directory for %q: %w", path, err)
+	}
+	temporary, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("cannot create temporary file for %q: %w", path, err)
+	}
+	temporaryPath := temporary.Name()
+	defer func() {
+		if temporary != nil {
+			if err := temporary.Close(); err != nil && rErr == nil {
+				rErr = err
+			}
+		}
+		if rErr != nil {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if err := temporary.Chmod(fileMode); err != nil {
+		return fmt.Errorf("cannot set mode of temporary file for %q: %w", path, err)
+	}
+	if _, err := temporary.Write(data); err != nil {
+		return fmt.Errorf("cannot write temporary file for %q: %w", path, err)
+	}
+	if err := temporary.Sync(); err != nil {
+		return fmt.Errorf("cannot flush temporary file for %q: %w", path, err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("cannot close temporary file for %q: %w", path, err)
+	}
+	temporary = nil
+	if err := replaceFsFile(temporaryPath, path); err != nil {
+		return fmt.Errorf("cannot atomically replace %q: %w", path, err)
+	}
+	if err := syncFsDirectory(filepath.Dir(path)); err != nil {
+		return fmt.Errorf("cannot flush parent directory of %q: %w", path, err)
+	}
+	return nil
+}

--- a/pkg/session/fs-atomic_unix.go
+++ b/pkg/session/fs-atomic_unix.go
@@ -1,0 +1,18 @@
+//go:build unix
+
+package session
+
+import (
+	"os"
+)
+
+func replaceFsFile(from, to string) error { return os.Rename(from, to) }
+
+func syncFsDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	return directory.Sync()
+}

--- a/pkg/session/fs-atomic_windows.go
+++ b/pkg/session/fs-atomic_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package session
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+func replaceFsFile(from, to string) error {
+	fromPath, err := windows.UTF16PtrFromString(from)
+	if err != nil {
+		return err
+	}
+	toPath, err := windows.UTF16PtrFromString(to)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(fromPath, toPath, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH)
+}
+
+func syncFsDirectory(string) error { return nil }

--- a/pkg/session/fs-info.go
+++ b/pkg/session/fs-info.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -18,8 +19,9 @@ type fsInfo struct {
 	VState State `json:"state"`
 
 	createdAt   time.Time
-	VRemoteUser string   `json:"remoteUser"`
-	VRemoteHost net.Host `json:"remoteHost"`
+	VCreatedAt  time.Time `json:"createdAt,omitempty"`
+	VRemoteUser string    `json:"remoteUser"`
+	VRemoteHost net.Host  `json:"remoteHost"`
 
 	created fsCreated
 }
@@ -87,7 +89,7 @@ func (this *fsInfo) ValidUntil(context.Context) (result time.Time, _ error) {
 		result = lat.Add(v)
 	}
 	if v := this.session.repository.conf.MaxTimeout.Native(); v > 0 {
-		byMax := lat.Add(v)
+		byMax := this.createdAt.Add(v)
 		if result.IsZero() || byMax.Before(result) {
 			result = byMax
 		}
@@ -128,20 +130,17 @@ func (this *fsInfo) LastAccessed(context.Context) (InfoLastAccessed, error) {
 }
 
 func (this *fsInfo) save() error {
-	f, _, err := this.session.repository.openWrite(this.session.flow, this.session.id, FsFileSession, false)
+	this.VCreatedAt = this.createdAt
+	var raw bytes.Buffer
+	if err := json.NewEncoder(&raw).Encode(this); err != nil {
+		return fmt.Errorf("cannot encode session %v: %w", this, err)
+	}
+	fn, err := this.session.repository.file(this.session.flow, this.session.id, FsFileSession)
 	if err != nil {
 		return err
 	}
-	defer common.IgnoreCloseError(f)
-
-	if err := json.NewEncoder(f).Encode(this); err != nil {
-		return fmt.Errorf("cannot encode session %v: %w", this, err)
+	if err := writeFsFileAtomically(fn, raw.Bytes(), os.FileMode(this.session.repository.conf.FileMode), os.FileMode(this.session.repository.dirFileMode())); err != nil {
+		return fmt.Errorf("cannot persist session %v: %w", this, err)
 	}
-
-	now := time.Now()
-	if err := os.Chtimes(f.Name(), now, now); err != nil {
-		return fmt.Errorf("cannot change time of session %v: %w", this, err)
-	}
-
 	return nil
 }

--- a/pkg/session/fs-lastaccessed.go
+++ b/pkg/session/fs-lastaccessed.go
@@ -1,13 +1,13 @@
 package session
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
-	"github.com/engity-com/bifroest/pkg/common"
 	"github.com/engity-com/bifroest/pkg/net"
 )
 
@@ -50,18 +50,16 @@ func (this *fsLastAccessed) save() error {
 		return fmt.Errorf("cannot session's %v last access because cannot stat info: %w", this, err)
 	}
 
-	f, _, err := this.info.session.repository.openWrite(this.info.session.flow, this.info.session.id, FsFileLastAccessed, false)
+	var raw bytes.Buffer
+	if err := json.NewEncoder(&raw).Encode(this); err != nil {
+		return fmt.Errorf("cannot encode session %v: %w", this.info.session, err)
+	}
+	fn, err := this.info.session.repository.file(this.info.session.flow, this.info.session.id, FsFileLastAccessed)
 	if err != nil {
 		return err
 	}
-	defer common.IgnoreCloseError(f)
-
-	if err := json.NewEncoder(f).Encode(this); err != nil {
-		return fmt.Errorf("cannot encode session %v: %w", this.info.session, err)
-	}
-	now := time.Now()
-	if err := os.Chtimes(f.Name(), now, now); err != nil {
-		return fmt.Errorf("cannot change time of session's last access %v: %w", this, err)
+	if err := writeFsFileAtomically(fn, raw.Bytes(), os.FileMode(this.info.session.repository.conf.FileMode), os.FileMode(this.info.session.repository.dirFileMode())); err != nil {
+		return fmt.Errorf("cannot persist session's last access %v: %w", this, err)
 	}
 
 	return nil

--- a/pkg/session/fs-lock_unix.go
+++ b/pkg/session/fs-lock_unix.go
@@ -1,0 +1,48 @@
+//go:build unix
+
+package session
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"golang.org/x/sys/unix"
+)
+
+type fsRepositoryProcessLock struct {
+	file *os.File
+	once sync.Once
+	err  error
+}
+
+func acquireFsRepositoryProcessLock(path string, mode os.FileMode) (*fsRepositoryProcessLock, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, mode)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open repository lock file %q: %w", path, err)
+	}
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		_ = file.Close()
+		if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+			return nil, fmt.Errorf("session repository %q is already locked by another process", path)
+		}
+		return nil, fmt.Errorf("cannot determine lock state of session repository %q: %w", path, err)
+	}
+	return &fsRepositoryProcessLock{file: file}, nil
+}
+
+func (this *fsRepositoryProcessLock) Close() error {
+	if this == nil {
+		return nil
+	}
+	this.once.Do(func() {
+		if err := unix.Flock(int(this.file.Fd()), unix.LOCK_UN); err != nil {
+			this.err = err
+		}
+		if err := this.file.Close(); err != nil && this.err == nil {
+			this.err = err
+		}
+	})
+	return this.err
+}

--- a/pkg/session/fs-lock_windows.go
+++ b/pkg/session/fs-lock_windows.go
@@ -1,0 +1,51 @@
+//go:build windows
+
+package session
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"golang.org/x/sys/windows"
+)
+
+type fsRepositoryProcessLock struct {
+	file       *os.File
+	overlapped windows.Overlapped
+	once       sync.Once
+	err        error
+}
+
+func acquireFsRepositoryProcessLock(path string, mode os.FileMode) (*fsRepositoryProcessLock, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, mode)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open repository lock file %q: %w", path, err)
+	}
+	result := &fsRepositoryProcessLock{file: file}
+	err = windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, &result.overlapped)
+	if err != nil {
+		_ = file.Close()
+		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+			return nil, fmt.Errorf("session repository %q is already locked by another process", path)
+		}
+		return nil, fmt.Errorf("cannot determine lock state of session repository %q: %w", path, err)
+	}
+	return result, nil
+}
+
+func (this *fsRepositoryProcessLock) Close() error {
+	if this == nil {
+		return nil
+	}
+	this.once.Do(func() {
+		if err := windows.UnlockFileEx(windows.Handle(this.file.Fd()), 0, 1, 0, &this.overlapped); err != nil {
+			this.err = err
+		}
+		if err := this.file.Close(); err != nil && this.err == nil {
+			this.err = err
+		}
+	})
+	return this.err
+}

--- a/pkg/session/fs-repository.go
+++ b/pkg/session/fs-repository.go
@@ -38,6 +38,41 @@ var (
 )
 
 func NewFsRepository(_ context.Context, conf *configuration.SessionFs) (*FsRepository, error) {
+	if conf == nil {
+		return nil, fmt.Errorf("nil configuration")
+	}
+	storage, err := filepath.Abs(conf.Storage)
+	if err != nil {
+		return nil, fmt.Errorf("cannot resolve session storage %q: %w", conf.Storage, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(storage), 0700); err != nil {
+		return nil, fmt.Errorf("cannot create parent directory of session storage %q: %w", storage, err)
+	}
+	if canonical, err := filepath.EvalSymlinks(storage); err == nil {
+		storage = canonical
+	} else if sys.IsNotExist(err) {
+		if info, lstatErr := os.Lstat(storage); lstatErr == nil && info.Mode()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("cannot canonicalize dangling session storage symlink %q", storage)
+		} else if lstatErr != nil && !sys.IsNotExist(lstatErr) {
+			return nil, fmt.Errorf("cannot inspect session storage %q: %w", storage, lstatErr)
+		}
+		canonicalParent, parentErr := filepath.EvalSymlinks(filepath.Dir(storage))
+		if parentErr != nil {
+			return nil, fmt.Errorf("cannot canonicalize parent directory of session storage %q: %w", storage, parentErr)
+		}
+		storage = filepath.Join(canonicalParent, filepath.Base(storage))
+	} else {
+		return nil, fmt.Errorf("cannot canonicalize session storage %q: %w", storage, err)
+	}
+	lockPath := filepath.Join(filepath.Dir(storage), "."+filepath.Base(storage)+".bifroest.lock")
+	_, statErr := os.Stat(lockPath)
+	lock, err := acquireFsRepositoryProcessLock(lockPath, os.FileMode(conf.FileMode))
+	if err != nil {
+		return nil, err
+	}
+	if statErr == nil {
+		log.GetLogger("sessions").With("path", lockPath).Warn("found existing unlocked session repository lock file; lock was taken over")
+	}
 	touchThreshold := defaultTouchThreshold
 	if v := conf.IdleTimeout.Native(); v > 0 {
 		touchThreshold = v
@@ -53,7 +88,9 @@ func NewFsRepository(_ context.Context, conf *configuration.SessionFs) (*FsRepos
 
 	result := FsRepository{
 		conf:           conf,
+		storage:        storage,
 		touchThreshold: touchThreshold,
+		processLock:    lock,
 	}
 
 	return &result, nil
@@ -62,13 +99,17 @@ func NewFsRepository(_ context.Context, conf *configuration.SessionFs) (*FsRepos
 type FsRepository struct {
 	Logger log.Logger
 
-	conf *configuration.SessionFs
+	conf    *configuration.SessionFs
+	storage string
 
 	touchThreshold time.Duration
 
 	connectionInterceptors fsConnectionInterceptors
 
-	mutex sync.RWMutex
+	mutex       sync.RWMutex
+	closeOnce   sync.Once
+	closeErr    error
+	processLock *fsRepositoryProcessLock
 }
 
 func (this *FsRepository) dir(flow configuration.FlowName, id Id) (string, error) {
@@ -80,7 +121,7 @@ func (this *FsRepository) dir(flow configuration.FlowName, id Id) (string, error
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(this.conf.Storage, string(fs), string(is)), nil
+	return filepath.Join(this.storage, string(fs), string(is)), nil
 }
 
 func (this *FsRepository) file(flow configuration.FlowName, id Id, kind string) (string, error) {
@@ -159,6 +200,16 @@ func (this *FsRepository) Create(ctx context.Context, flow configuration.FlowNam
 		return fail(err)
 	}
 	id := Id(vid)
+	dir, err := this.dir(flow, id)
+	if err != nil {
+		return fail(err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.RemoveAll(dir)
+		}
+	}()
 
 	var sess fs
 	sess.info.VState = StateNew
@@ -178,14 +229,45 @@ func (this *FsRepository) Create(ctx context.Context, flow configuration.FlowNam
 		}
 	}
 
+	committed = true
 	return &sess, nil
 }
 
 func (this *FsRepository) FindBy(ctx context.Context, flow configuration.FlowName, id Id, opts *FindOpts) (Session, error) {
-	this.mutex.RLock()
-	defer this.mutex.RUnlock()
+	return this.loadAndMatch(ctx, flow, id, opts, false)
+}
 
-	return this.findBy(ctx, flow, id, opts, false)
+func (this *FsRepository) loadAndMatch(ctx context.Context, flow configuration.FlowName, id Id, opts *FindOpts, expectedToExist bool) (*fs, error) {
+	this.mutex.RLock()
+	result, err := this.findBy(ctx, flow, id, nil, expectedToExist)
+	this.mutex.RUnlock()
+	if err != nil {
+		if !opts.IsAutoCleanUpAllowed() || errors.Is(err, ErrNoSuchSession) && !expectedToExist {
+			return nil, err
+		}
+		this.mutex.Lock()
+		dir, dirErr := this.dir(flow, id)
+		if dirErr == nil {
+			dirErr = os.RemoveAll(dir)
+		}
+		this.mutex.Unlock()
+		if dirErr != nil {
+			return nil, fmt.Errorf("cannot remove broken session %v/%v: %w", flow, id, dirErr)
+		}
+		opts.GetLogger(this.logger).Withf("session", "%v/%v", flow, id).WithError(err).Warn("found broken session; it was removed entirely")
+		return nil, ErrNoSuchSession
+	}
+	if opts.IsAutoCleanUpAllowed() {
+		this.mutex.Lock()
+		this.doAutoCleanUnexpectedFilesIfAllowed(ctx, result, opts)
+		this.mutex.Unlock()
+	}
+	if ok, err := opts.GetPredicates().Matches(ctx, result); err != nil {
+		return nil, err
+	} else if !ok {
+		return nil, ErrNoSuchSession
+	}
+	return result, nil
 }
 
 func (this *FsRepository) findBy(ctx context.Context, flow configuration.FlowName, id Id, opts *FindOpts, expectedToExist bool) (*fs, error) {
@@ -214,7 +296,11 @@ func (this *FsRepository) findBy(ctx context.Context, flow configuration.FlowNam
 	if err != nil {
 		return cleanUpIfAllowedAndFail(errors.Newf(errors.System, "cannot stat session file of %v/%v: %w", flow, id, err))
 	}
-	buf.info.createdAt = fi.ModTime()
+	if buf.info.VCreatedAt.IsZero() {
+		buf.info.createdAt = fi.ModTime()
+	} else {
+		buf.info.createdAt = buf.info.VCreatedAt
+	}
 	buf.init(this, flow, id)
 
 	this.doAutoCleanUnexpectedFilesIfAllowed(ctx, &buf, opts)
@@ -235,17 +321,15 @@ func (this *FsRepository) FindByPublicKey(ctx context.Context, key ssh.PublicKey
 
 	loadCandidate := func(flow configuration.FlowName, id Id) (*fs, error) {
 		this.mutex.RLock()
-		defer this.mutex.RUnlock()
-
 		ok, err := this.hasPublicKey(ctx, flow, id, key)
+		this.mutex.RUnlock()
 		if err != nil {
 			return nil, err
 		}
 		if !ok {
 			return nil, ErrNoSuchSession
 		}
-
-		return this.findBy(ctx, flow, id, opts, true)
+		return this.loadAndMatch(ctx, flow, id, opts, true)
 	}
 
 	var result Session
@@ -291,17 +375,15 @@ func (this *FsRepository) FindByAccessToken(ctx context.Context, t []byte, opts 
 
 	loadCandidate := func(flow configuration.FlowName, id Id) (*fs, error) {
 		this.mutex.RLock()
-		defer this.mutex.RUnlock()
-
 		ok, err := this.hasAccessToken(ctx, flow, id, t)
+		this.mutex.RUnlock()
 		if err != nil {
 			return nil, err
 		}
 		if !ok {
 			return nil, ErrNoSuchSession
 		}
-
-		return this.findBy(ctx, flow, id, opts, true)
+		return this.loadAndMatch(ctx, flow, id, opts, true)
 	}
 
 	var result Session
@@ -342,10 +424,7 @@ func (this *FsRepository) FindByAccessToken(ctx context.Context, t []byte, opts 
 
 func (this *FsRepository) FindAll(ctx context.Context, consumer Consumer, opts *FindOpts) error {
 	loadCandidate := func(flow configuration.FlowName, id Id) (*fs, error) {
-		this.mutex.RLock()
-		defer this.mutex.RUnlock()
-
-		return this.findBy(ctx, flow, id, opts, true)
+		return this.loadAndMatch(ctx, flow, id, opts, true)
 	}
 
 	canContinue := true
@@ -577,7 +656,12 @@ func (this *FsRepository) Delete(ctx context.Context, s Session) error {
 }
 
 func (this *FsRepository) Close() error {
-	return nil
+	this.closeOnce.Do(func() {
+		this.mutex.Lock()
+		defer this.mutex.Unlock()
+		this.closeErr = this.processLock.Close()
+	})
+	return this.closeErr
 }
 
 func (this *FsRepository) publicKeyKind(pub ssh.PublicKey) string {
@@ -586,7 +670,7 @@ func (this *FsRepository) publicKeyKind(pub ssh.PublicKey) string {
 }
 
 func (this *FsRepository) iterateFlows(ctx context.Context, consumer func(flow configuration.FlowName, path string) (canContinue bool, err error), opts *FindOpts) (rErr error) {
-	dirName := this.conf.Storage
+	dirName := this.storage
 	f, err := os.Open(dirName)
 	if sys.IsNotExist(err) {
 		return nil
@@ -633,7 +717,7 @@ func (this *FsRepository) iterateFlowDirs(ctx context.Context, flow configuratio
 		return err
 	}
 
-	dirName := filepath.Join(this.conf.Storage, string(fs))
+	dirName := filepath.Join(this.storage, string(fs))
 	var entries []os.DirEntry
 	defer func() {
 		if rErr == nil && len(entries) == 0 && opts.IsAutoCleanUpAllowed() {

--- a/pkg/session/fs-repository_test.go
+++ b/pkg/session/fs-repository_test.go
@@ -1,0 +1,139 @@
+package session
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/engity-com/bifroest/pkg/configuration"
+	bnet "github.com/engity-com/bifroest/pkg/net"
+)
+
+func TestFsRepositoryExclusiveProcessLock(t *testing.T) {
+	conf := newFsRepositoryTestConfiguration(t)
+	first, err := NewFsRepository(context.Background(), conf)
+	require.NoError(t, err)
+
+	_, err = NewFsRepository(context.Background(), conf)
+	require.ErrorContains(t, err, "already locked")
+	require.NoError(t, first.Close())
+	require.NoError(t, first.Close())
+
+	second, err := NewFsRepository(context.Background(), conf)
+	require.NoError(t, err)
+	require.NoError(t, second.Close())
+}
+
+func TestFsRepositoryLockCoversStorageSymlinkAliases(t *testing.T) {
+	root := t.TempDir()
+	realStorage := filepath.Join(root, "real", "sessions")
+	require.NoError(t, os.MkdirAll(realStorage, 0700))
+	aliasStorage := filepath.Join(root, "alias")
+	if err := os.Symlink(realStorage, aliasStorage); err != nil {
+		t.Skipf("symbolic links are unavailable: %v", err)
+	}
+	realConfiguration := newFsRepositoryTestConfiguration(t)
+	realConfiguration.Storage = realStorage
+	aliasConfiguration := newFsRepositoryTestConfiguration(t)
+	aliasConfiguration.Storage = aliasStorage
+
+	repository, err := NewFsRepository(context.Background(), realConfiguration)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, repository.Close()) }()
+	_, err = NewFsRepository(context.Background(), aliasConfiguration)
+	require.ErrorContains(t, err, "already locked")
+}
+
+func TestFsRepositoryRejectsDanglingStorageSymlink(t *testing.T) {
+	root := t.TempDir()
+	storage := filepath.Join(root, "alias")
+	if err := os.Symlink(filepath.Join(root, "missing", "sessions"), storage); err != nil {
+		t.Skipf("symbolic links are unavailable: %v", err)
+	}
+	conf := newFsRepositoryTestConfiguration(t)
+	conf.Storage = storage
+	_, err := NewFsRepository(context.Background(), conf)
+	require.ErrorContains(t, err, "dangling")
+}
+
+func TestFsRepositoryPersistsEnvironmentTokenAndCreatedAt(t *testing.T) {
+	conf := newFsRepositoryTestConfiguration(t)
+	conf.IdleTimeout.SetNative(0)
+	conf.MaxTimeout.SetNative(24 * time.Hour)
+	repository, err := NewFsRepository(context.Background(), conf)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	created, err := repository.Create(ctx, "test", fsRepositoryTestRemote{}, []byte("authorization"))
+	require.NoError(t, err)
+	require.NoError(t, created.SetEnvironmentToken(ctx, []byte("credential")))
+	createdInfo, err := created.Info(ctx)
+	require.NoError(t, err)
+	createdDetails, err := createdInfo.Created(ctx)
+	require.NoError(t, err)
+	validUntil, err := createdInfo.ValidUntil(ctx)
+	require.NoError(t, err)
+
+	time.Sleep(5 * time.Millisecond)
+	_, err = created.NotifyLastAccess(ctx, fsRepositoryTestRemote{}, StateAuthorized)
+	require.NoError(t, err)
+	updatedValidUntil, err := createdInfo.ValidUntil(ctx)
+	require.NoError(t, err)
+	require.Equal(t, validUntil, updatedValidUntil)
+	require.NoError(t, repository.Close())
+
+	restoredRepository, err := NewFsRepository(ctx, conf)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, restoredRepository.Close()) }()
+	restored, err := restoredRepository.FindBy(ctx, "test", created.Id(), nil)
+	require.NoError(t, err)
+	token, err := restored.EnvironmentToken(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []byte("credential"), token)
+	restoredInfo, err := restored.Info(ctx)
+	require.NoError(t, err)
+	restoredDetails, err := restoredInfo.Created(ctx)
+	require.NoError(t, err)
+	require.Equal(t, createdDetails.At(), restoredDetails.At())
+}
+
+func TestFsRepositoryRejectsWritesThroughStaleDisposedSession(t *testing.T) {
+	conf := newFsRepositoryTestConfiguration(t)
+	repository, err := NewFsRepository(context.Background(), conf)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, repository.Close()) }()
+	ctx := context.Background()
+	created, err := repository.Create(ctx, "test", fsRepositoryTestRemote{}, nil)
+	require.NoError(t, err)
+	stale, err := repository.FindBy(ctx, "test", created.Id(), nil)
+	require.NoError(t, err)
+	_, err = created.Dispose(ctx)
+	require.NoError(t, err)
+
+	require.ErrorContains(t, stale.SetEnvironmentToken(ctx, []byte("credential")), "disposed")
+	_, err = stale.NotifyLastAccess(ctx, fsRepositoryTestRemote{}, StateAuthorized)
+	require.ErrorContains(t, err, "disposed")
+	restored, err := repository.FindBy(ctx, "test", created.Id(), nil)
+	require.NoError(t, err)
+	info, err := restored.Info(ctx)
+	require.NoError(t, err)
+	require.Equal(t, StateDisposed, info.State())
+}
+
+func newFsRepositoryTestConfiguration(t *testing.T) *configuration.SessionFs {
+	t.Helper()
+	result := &configuration.SessionFs{}
+	require.NoError(t, result.SetDefaults())
+	result.Storage = t.TempDir() + "/sessions"
+	return result
+}
+
+type fsRepositoryTestRemote struct{}
+
+func (fsRepositoryTestRemote) User() string    { return "alice" }
+func (fsRepositoryTestRemote) Host() bnet.Host { return bnet.MustNewHost("127.0.0.1") }
+func (fsRepositoryTestRemote) String() string  { return "alice@127.0.0.1" }

--- a/pkg/session/fs.go
+++ b/pkg/session/fs.go
@@ -121,14 +121,22 @@ func (this *fs) setToken(_ context.Context, data []byte, kind, name string) (rEr
 		}
 		return nil
 	}
+	current, err := this.repository.findBy(context.Background(), this.flow, this.id, nil, false)
+	if err != nil {
+		return fmt.Errorf("cannot write session's %s token because current session state is unavailable: %w", name, err)
+	}
+	if current.info.VState == StateDisposed {
+		return fmt.Errorf("cannot write session's %s token because session %v is disposed", name, this)
+	}
 
-	f, fn, err := this.repository.openWrite(this.flow, this.id, kind, false)
+	if _, err := this.repository.stat(this.flow, this.id, FsFileSession); err != nil {
+		return fmt.Errorf("cannot write session's %s token because session info is unavailable: %w", name, err)
+	}
+	fn, err := this.repository.file(this.flow, this.id, kind)
 	if err != nil {
 		return err
 	}
-	defer common.KeepCloseError(&rErr, f)
-
-	if _, err := f.Write(data); err != nil {
+	if err := writeFsFileAtomically(fn, data, os.FileMode(this.repository.conf.FileMode), os.FileMode(this.repository.dirFileMode())); err != nil {
 		return fmt.Errorf("cannot write session's %s token file (%q) of %v: %w", name, fn, this, err)
 	}
 	return nil
@@ -156,10 +164,22 @@ func (this *fs) DeletePublicKey(ctx context.Context, pub ssh.PublicKey) error {
 }
 
 func (this *fs) NotifyLastAccess(_ context.Context, remote net.Remote, newState State) (State, error) {
+	this.repository.mutex.Lock()
+	defer this.repository.mutex.Unlock()
 	return this.notifyLastAccess(remote, newState)
 }
 
 func (this *fs) notifyLastAccess(remote net.Remote, newState State) (State, error) {
+	current, err := this.repository.findBy(context.Background(), this.flow, this.id, nil, false)
+	if err != nil {
+		return 0, fmt.Errorf("cannot load current state of session %v: %w", this, err)
+	}
+	if current.info.VState == StateDisposed {
+		return current.info.VState, fmt.Errorf("cannot notify last access of disposed session %v", this)
+	}
+	this.info.VState = current.info.VState
+	this.info.createdAt = current.info.createdAt
+	this.info.VCreatedAt = current.info.VCreatedAt
 	var buf fsLastAccessed
 	buf.at = time.Now().Truncate(time.Millisecond)
 	buf.VRemoteUser = remote.User()

--- a/pkg/ssh/address.go
+++ b/pkg/ssh/address.go
@@ -2,8 +2,9 @@ package ssh
 
 import (
 	"fmt"
-	gonet "net"
+	"net/netip"
 	"strings"
+	"unicode"
 
 	bnet "github.com/engity-com/bifroest/pkg/net"
 )
@@ -17,7 +18,7 @@ func ParseAddress(value string) (bnet.HostPort, error) {
 	if explicitErr == nil && !explicit.IsZero() {
 		if err := explicit.Validate(); err == nil {
 			hostValue := explicit.Host.String()
-			if gonet.ParseIP(hostValue) == nil && isUnsafeKnownHostName(hostValue) {
+			if !isSafeIPAddress(hostValue) && isUnsafeKnownHostName(hostValue) {
 				return bnet.HostPort{}, fmt.Errorf("illegal SSH address %q: host contains unsafe characters", value)
 			}
 			return explicit, nil
@@ -32,16 +33,16 @@ func ParseAddress(value string) (bnet.HostPort, error) {
 			return bnet.HostPort{}, fmt.Errorf("illegal SSH address %q: invalid brackets", value)
 		}
 		hostValue = value[1 : len(value)-1]
-		if gonet.ParseIP(hostValue) == nil {
+		if !isSafeIPAddress(hostValue) {
 			return bnet.HostPort{}, fmt.Errorf("illegal SSH address %q: brackets require an IPv6 address", value)
 		}
-	} else if strings.Contains(value, ":") && gonet.ParseIP(value) == nil {
+	} else if strings.Contains(value, ":") && !isSafeIPAddress(value) {
 		return bnet.HostPort{}, fmt.Errorf("illegal SSH address %q: %w", value, explicitErr)
 	}
 	if hostValue == "" {
 		return bnet.HostPort{}, fmt.Errorf("illegal SSH address %q: host is empty", value)
 	}
-	if gonet.ParseIP(hostValue) == nil && isUnsafeKnownHostName(hostValue) {
+	if !isSafeIPAddress(hostValue) && isUnsafeKnownHostName(hostValue) {
 		return bnet.HostPort{}, fmt.Errorf("illegal SSH address %q: host contains unsafe characters", value)
 	}
 	host, err := bnet.NewHost(hostValue)
@@ -56,13 +57,18 @@ func ParseAddress(value string) (bnet.HostPort, error) {
 }
 
 func isUnsafeKnownHostName(value string) bool {
-	if strings.ContainsAny(value, ",*!?[]|#") {
+	if strings.ContainsAny(value, ",*!?[]|#@") {
 		return true
 	}
 	for _, candidate := range value {
-		if candidate <= ' ' || candidate == 0x7f {
+		if unicode.IsSpace(candidate) || unicode.IsControl(candidate) {
 			return true
 		}
 	}
 	return false
+}
+
+func isSafeIPAddress(value string) bool {
+	address, err := netip.ParseAddr(value)
+	return err == nil && (address.Zone() == "" || !isUnsafeKnownHostName(address.Zone()))
 }

--- a/pkg/ssh/address.go
+++ b/pkg/ssh/address.go
@@ -1,0 +1,68 @@
+package ssh
+
+import (
+	"fmt"
+	gonet "net"
+	"strings"
+
+	bnet "github.com/engity-com/bifroest/pkg/net"
+)
+
+const DefaultPort uint16 = 22
+
+func ParseAddress(value string) (bnet.HostPort, error) {
+	value = strings.TrimSpace(value)
+	var explicit bnet.HostPort
+	explicitErr := explicit.Set(value)
+	if explicitErr == nil && !explicit.IsZero() {
+		if err := explicit.Validate(); err == nil {
+			hostValue := explicit.Host.String()
+			if gonet.ParseIP(hostValue) == nil && isUnsafeKnownHostName(hostValue) {
+				return bnet.HostPort{}, fmt.Errorf("illegal SSH address %q: host contains unsafe characters", value)
+			}
+			return explicit, nil
+		} else {
+			explicitErr = err
+		}
+	}
+
+	hostValue := value
+	if strings.HasPrefix(value, "[") || strings.HasSuffix(value, "]") {
+		if len(value) < 3 || value[0] != '[' || value[len(value)-1] != ']' {
+			return bnet.HostPort{}, fmt.Errorf("illegal SSH address %q: invalid brackets", value)
+		}
+		hostValue = value[1 : len(value)-1]
+		if gonet.ParseIP(hostValue) == nil {
+			return bnet.HostPort{}, fmt.Errorf("illegal SSH address %q: brackets require an IPv6 address", value)
+		}
+	} else if strings.Contains(value, ":") && gonet.ParseIP(value) == nil {
+		return bnet.HostPort{}, fmt.Errorf("illegal SSH address %q: %w", value, explicitErr)
+	}
+	if hostValue == "" {
+		return bnet.HostPort{}, fmt.Errorf("illegal SSH address %q: host is empty", value)
+	}
+	if gonet.ParseIP(hostValue) == nil && isUnsafeKnownHostName(hostValue) {
+		return bnet.HostPort{}, fmt.Errorf("illegal SSH address %q: host contains unsafe characters", value)
+	}
+	host, err := bnet.NewHost(hostValue)
+	if err != nil {
+		return bnet.HostPort{}, fmt.Errorf("illegal SSH address %q: %w", value, err)
+	}
+	result, err := host.WithPort(DefaultPort)
+	if err != nil {
+		return bnet.HostPort{}, fmt.Errorf("illegal SSH address %q: %w", value, err)
+	}
+	return result, nil
+}
+
+func isUnsafeKnownHostName(value string) bool {
+	if strings.ContainsAny(value, ",*!?[]|#") {
+		return true
+	}
+	for _, candidate := range value {
+		if candidate <= ' ' || candidate == 0x7f {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/ssh/address_test.go
+++ b/pkg/ssh/address_test.go
@@ -17,6 +17,9 @@ func TestParseAddress(t *testing.T) {
 		{value: "2001:db8::1", expected: "[2001:db8::1]:22"},
 		{value: "[2001:db8::1]", expected: "[2001:db8::1]:22"},
 		{value: "[2001:db8::1]:2222", expected: "[2001:db8::1]:2222"},
+		{value: "fe80::1%eth0", expected: "[fe80::1%eth0]:22"},
+		{value: "[fe80::1%eth0]", expected: "[fe80::1%eth0]:22"},
+		{value: "[fe80::1%eth0]:2222", expected: "[fe80::1%eth0]:2222"},
 	} {
 		t.Run(test.value, func(t *testing.T) {
 			actual, err := ParseAddress(test.value)
@@ -27,7 +30,7 @@ func TestParseAddress(t *testing.T) {
 }
 
 func TestParseAddressRejectsInvalidValues(t *testing.T) {
-	for _, value := range []string{"", ":22", "target.example.org:", "target.example.org:0", "target.example.org:65536", "[2001:db8::1", "[target.example.org]", "host-a,*.example.org", "host-a,*.example.org:22", "*.example.org", "*.example.org:22", "host example.org", "host example.org:22", "#comment", "#comment:22"} {
+	for _, value := range []string{"", ":22", "target.example.org:", "target.example.org:0", "target.example.org:65536", "[2001:db8::1", "[target.example.org]", "host-a,*.example.org", "host-a,*.example.org:22", "*.example.org", "*.example.org:22", "host example.org", "host example.org:22", "host\u00a0ssh-ed25519\u00a0AAAA", "host\u0085ssh-ed25519\u0085AAAA:22", "#comment", "#comment:22", "@revoked", "@revoked:22", "host@example.org", "host@example.org:22", "fe80::1%bad,zone", "[fe80::1%bad,zone]:22"} {
 		t.Run(value, func(t *testing.T) {
 			_, err := ParseAddress(value)
 			require.Error(t, err)

--- a/pkg/ssh/address_test.go
+++ b/pkg/ssh/address_test.go
@@ -1,0 +1,36 @@
+package ssh
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAddress(t *testing.T) {
+	for _, test := range []struct {
+		value    string
+		expected string
+	}{
+		{value: "target.example.org", expected: "target.example.org:22"},
+		{value: "target.example.org:2222", expected: "target.example.org:2222"},
+		{value: "192.0.2.10", expected: "192.0.2.10:22"},
+		{value: "2001:db8::1", expected: "[2001:db8::1]:22"},
+		{value: "[2001:db8::1]", expected: "[2001:db8::1]:22"},
+		{value: "[2001:db8::1]:2222", expected: "[2001:db8::1]:2222"},
+	} {
+		t.Run(test.value, func(t *testing.T) {
+			actual, err := ParseAddress(test.value)
+			require.NoError(t, err)
+			require.Equal(t, test.expected, actual.String())
+		})
+	}
+}
+
+func TestParseAddressRejectsInvalidValues(t *testing.T) {
+	for _, value := range []string{"", ":22", "target.example.org:", "target.example.org:0", "target.example.org:65536", "[2001:db8::1", "[target.example.org]", "host-a,*.example.org", "host-a,*.example.org:22", "*.example.org", "*.example.org:22", "host example.org", "host example.org:22", "#comment", "#comment:22"} {
+		t.Run(value, func(t *testing.T) {
+			_, err := ParseAddress(value)
+			require.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add SSH environments for delegating sessions to remote SSH targets, including lifecycle, forwarding, command, and environment handling
- add persistent SSH user certificates and certificate-based authorization for local and remote environments
- add Bifroest delegation with signed evidence chains and certificate propagation
- add `bifroest key generate`, `key export`, and `key import` bootstrap commands with host-key pinning and protected key/trust file handling
- harden filesystem session persistence with atomic writes and exclusive repository locking
- document the new configuration, CLI, authorization, and environment behavior

## Compatibility

SSH environments, SSH user certificates, Bifroest authorization, and the key-bootstrap CLI are new in v0.8.0 and require no migration from an earlier release.

## Verification

- `mise exec -- go test -p 1 ./... -count=1`
- `mise exec -- go test -race -p 1 ./... -count=1`
- complete native Windows CI test run
- Windows `pkg/crypto` tests, 100 iterations
- Windows concurrency and deterministic retry regression tests, 200 iterations
- `mise exec -- go vet ./...`
- `mise run lint:go`
- `mise run build:docs`